### PR TITLE
1 stuck rescanning library

### DIFF
--- a/backend/indexer.py
+++ b/backend/indexer.py
@@ -5,6 +5,7 @@ import re
 import json
 import logging
 import hashlib
+import threading
 from pathlib import Path
 import fitz  # PyMuPDF
 from PIL import Image
@@ -15,6 +16,29 @@ from sqlalchemy.orm import Session
 from .models import GameSystem, Book, GenericMap, MapFolder, Token, TokenFolder
 
 logger = logging.getLogger("grimoire.indexer")
+
+_FITZ_TIMEOUT = 300  # seconds
+
+
+def _fitz_open_with_timeout(filepath: str, timeout: int = _FITZ_TIMEOUT):
+    """Open a PDF with fitz, raising TimeoutError if it hangs beyond `timeout` seconds."""
+    result = [None]
+    exc = [None]
+
+    def _open():
+        try:
+            result[0] = fitz.open(filepath)
+        except Exception as e:
+            exc[0] = e
+
+    t = threading.Thread(target=_open, daemon=True)
+    t.start()
+    t.join(timeout)
+    if t.is_alive():
+        raise TimeoutError(f"fitz.open() timed out after {timeout}s for {filepath}")
+    if exc[0] is not None:
+        raise exc[0]
+    return result[0]
 
 CATEGORY_MAP = {
     "core": ["core", "rulebook", "rules", "phb", "dmg", "mm", "basic"],
@@ -66,7 +90,7 @@ def generate_thumbnail(filepath: str, output_path: str, size: tuple = (300, 400)
     try:
         ext = Path(filepath).suffix.lower()
         if ext == ".pdf":
-            doc = fitz.open(filepath)
+            doc = _fitz_open_with_timeout(filepath)
             if len(doc) == 0:
                 return False
             page = doc[0]
@@ -94,7 +118,7 @@ def extract_text_from_pdf(filepath: str) -> list[dict]:
     """Extract text from all pages of a PDF. Returns list of {page, content}."""
     pages = []
     try:
-        doc = fitz.open(filepath)
+        doc = _fitz_open_with_timeout(filepath)
         for i, page in enumerate(doc):
             page_text = page.get_text().strip()
             if page_text:
@@ -200,6 +224,12 @@ def scan_library(library_path: str, data_path: str, session: Session, on_progres
                     category = guess_category(relative_path)
                     title = Path(filename).stem.replace("_", " ").replace("-", " ").strip()
 
+                    try:
+                        file_size = os.path.getsize(filepath)
+                    except OSError:
+                        logger.warning(f"Cannot stat file, skipping: {filepath}")
+                        continue
+
                     book = Book(
                         game_system_id=system.id,
                         title=title,
@@ -207,7 +237,7 @@ def scan_library(library_path: str, data_path: str, session: Session, on_progres
                         filepath=filepath,
                         relative_path=relative_path,
                         category=category,
-                        file_size=os.path.getsize(filepath),
+                        file_size=file_size,
                         mime_type="application/pdf" if ext == ".pdf" else f"image/{ext[1:]}",
                     )
 
@@ -221,7 +251,7 @@ def scan_library(library_path: str, data_path: str, session: Session, on_progres
 
                     if ext == ".pdf":
                         try:
-                            doc = fitz.open(filepath)
+                            doc = _fitz_open_with_timeout(filepath)
                             book.page_count = len(doc)
                             doc.close()
                         except Exception as e:
@@ -270,11 +300,17 @@ def scan_library(library_path: str, data_path: str, session: Session, on_progres
 
                 title = Path(filename).stem.replace("_", " ").replace("-", " ").strip()
 
+                try:
+                    file_size = os.path.getsize(filepath)
+                except OSError:
+                    logger.warning(f"Cannot stat file, skipping: {filepath}")
+                    continue
+
                 gmap = GenericMap(
                     filename=filename,
                     filepath=filepath,
                     relative_path=relative_path,
-                    file_size=os.path.getsize(filepath),
+                    file_size=file_size,
                 )
 
                 thumb_path = os.path.join(
@@ -326,11 +362,17 @@ def scan_library(library_path: str, data_path: str, session: Session, on_progres
 
                 title = Path(filename).stem.replace("_", " ").replace("-", " ").strip()
 
+                try:
+                    file_size = os.path.getsize(filepath)
+                except OSError:
+                    logger.warning(f"Cannot stat file, skipping: {filepath}")
+                    continue
+
                 token = Token(
                     filename=filename,
                     filepath=filepath,
                     relative_path=relative_path,
-                    file_size=os.path.getsize(filepath),
+                    file_size=file_size,
                 )
 
                 thumb_path = os.path.join(
@@ -459,13 +501,13 @@ def _apply_tags_from_library(library_path: str, session: Session) -> None:
 
 def index_book_text(book: Book, data_path: str, session: Session):
     """Extract and index text from a PDF for full-text search."""
-    if book.indexed or book.mime_type != "application/pdf":
+    if book.indexed or book.index_failed or book.mime_type != "application/pdf":
         return False
 
     pages = extract_text_from_pdf(book.filepath)
     if not pages:
         book.index_error = "No text extracted"
-        book.indexed = True
+        book.index_failed = True
         session.commit()
         return False
 

--- a/backend/models.py
+++ b/backend/models.py
@@ -75,6 +75,7 @@ class Book(Base):
     has_thumbnail = Column(Boolean, default=False)
     is_explicit = Column(Boolean, default=False)
     indexed = Column(Boolean, default=False)
+    index_failed = Column(Boolean, default=False)
     index_error = Column(String(500), default="")
 
     created_at = Column(DateTime, default=_utcnow)
@@ -370,6 +371,13 @@ def init_db(db_path: str):
     Base.metadata.create_all(engine)
 
     with engine.connect() as conn:
+        # Runtime migrations for columns added after initial release
+        try:
+            conn.execute(text("ALTER TABLE books ADD COLUMN index_failed BOOLEAN DEFAULT 0"))
+            conn.commit()
+        except Exception:
+            pass  # Column already exists
+
         conn.execute(
             text(
                 """

--- a/backend/routers/books/core.py
+++ b/backend/routers/books/core.py
@@ -53,6 +53,7 @@ def list_books(
                     "game_system_id": b.game_system_id,
                     "has_thumbnail": b.has_thumbnail,
                     "indexed": b.indexed,
+                    "index_failed": b.index_failed,
                     "is_explicit": bool(b.is_explicit),
                 }
                 for b in books
@@ -93,6 +94,7 @@ def get_book(book_id: str, current_user: CurrentUser = Depends(get_current_user)
             "publisher_url": book.publisher_url,
             "year": book.year,
             "indexed": book.indexed,
+            "index_failed": book.index_failed,
             "mime_type": book.mime_type,
             "has_thumbnail": book.has_thumbnail,
             "is_explicit": bool(book.is_explicit),

--- a/backend/routers/favorites/core.py
+++ b/backend/routers/favorites/core.py
@@ -40,6 +40,7 @@ def list_favorites(user: CurrentUser = Depends(get_current_user)):
                         "has_thumbnail": b.has_thumbnail,
                         "page_count": b.page_count,
                         "indexed": b.indexed,
+                        "index_failed": b.index_failed,
                     }
                 )
             elif r.item_type == "map" and r.item_id in maps:

--- a/backend/routers/library/_helpers.py
+++ b/backend/routers/library/_helpers.py
@@ -57,7 +57,7 @@ def background_indexer():
     time.sleep(2)
     db = SessionLocal()
     try:
-        unindexed = db.query(Book).filter_by(indexed=False, mime_type="application/pdf").all()
+        unindexed = db.query(Book).filter_by(indexed=False, index_failed=False, mime_type="application/pdf").all()
         if not unindexed:
             return
         logger.info(f"Background indexer: {len(unindexed)} books to index")
@@ -76,6 +76,7 @@ def background_indexer():
             except Exception as e:
                 logger.error(f"Indexing error for {book.title}: {e}")
                 book.index_error = str(e)[:500]
+                book.index_failed = True
                 db.commit()
             _set_status({"indexed": _get_status()["indexed"] + 1})
     finally:
@@ -124,13 +125,16 @@ def run_rescan_sync() -> None:
                 }
             )
 
-            to_index = db.query(Book).filter_by(indexed=False, mime_type="application/pdf").all()
+            to_index = db.query(Book).filter_by(indexed=False, index_failed=False, mime_type="application/pdf").all()
             _set_status({"phase": "indexing", "to_index": len(to_index), "indexed": 0})
             for book in to_index:
                 try:
                     index_book_text(book, DATA_PATH, db)
                 except Exception as e:
-                    logger.error(f"Indexing error: {e}")
+                    logger.error(f"Indexing error for {book.title}: {e}")
+                    book.index_error = str(e)[:500]
+                    book.index_failed = True
+                    db.commit()
                 _set_status({"indexed": _get_status()["indexed"] + 1})
         finally:
             db.close()

--- a/backend/routers/systems.py
+++ b/backend/routers/systems.py
@@ -147,6 +147,7 @@ def get_system(system_id: str, current_user: CurrentUser = Depends(get_current_u
                     "publisher_url": b.publisher_url,
                     "year": b.year,
                     "indexed": b.indexed,
+                    "index_failed": b.index_failed,
                     "has_thumbnail": b.has_thumbnail,
                     "is_explicit": bool(b.is_explicit),
                 }

--- a/frontend/src/components/system/BookRow.jsx
+++ b/frontend/src/components/system/BookRow.jsx
@@ -53,6 +53,11 @@ export default function BookRow({ book, onOpen, onEdit, editing }) {
               indexed
             </span>
           )}
+          {book.index_failed && (
+            <span title={`Index failed${book.index_error ? `: ${book.index_error}` : ''}`} style={{ fontSize: 11, color: '#e07070', background: 'rgba(180,60,60,0.12)', padding: '1px 6px', borderRadius: 8, border: '1px solid rgba(180,60,60,0.35)' }}>
+              index failed
+            </span>
+          )}
         </div>
       </div>
 

--- a/frontend/src/components/system/BookRow.test.jsx
+++ b/frontend/src/components/system/BookRow.test.jsx
@@ -1,0 +1,110 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { render, screen } from '@testing-library/react'
+import BookRow from './BookRow'
+import * as FavCtx from '../../context/FavoritesContext'
+import * as api from '../../api'
+
+vi.mock('../../context/FavoritesContext', () => ({
+  useFavorites: vi.fn(),
+}))
+
+vi.mock('../../api', () => ({
+  default: {},
+  mediaUrl: (path) => `http://localhost${path}`,
+}))
+
+function makeBook(overrides = {}) {
+  return {
+    id: 'book-1',
+    title: 'Player\'s Handbook',
+    category: 'core',
+    page_count: 320,
+    year: 2014,
+    publisher: 'WotC',
+    has_thumbnail: false,
+    is_explicit: false,
+    indexed: false,
+    index_failed: false,
+    index_error: '',
+    ...overrides,
+  }
+}
+
+describe('BookRow', () => {
+  beforeEach(() => {
+    FavCtx.useFavorites.mockReturnValue({
+      isFavorite: () => false,
+      toggleFavorite: vi.fn(),
+    })
+  })
+
+  it('renders the book title', () => {
+    render(<BookRow book={makeBook()} onOpen={() => {}} />)
+    expect(screen.getByText("Player's Handbook")).toBeInTheDocument()
+  })
+
+  it('renders page count when present', () => {
+    render(<BookRow book={makeBook()} onOpen={() => {}} />)
+    expect(screen.getByText('320 pages')).toBeInTheDocument()
+  })
+
+  it('does not render page count when zero', () => {
+    render(<BookRow book={makeBook({ page_count: 0 })} onOpen={() => {}} />)
+    expect(screen.queryByText(/pages/)).not.toBeInTheDocument()
+  })
+
+  // --- indexed badge ---
+
+  it('shows "indexed" badge when indexed is true', () => {
+    render(<BookRow book={makeBook({ indexed: true })} onOpen={() => {}} />)
+    expect(screen.getByText('indexed')).toBeInTheDocument()
+  })
+
+  it('does not show "indexed" badge when indexed is false', () => {
+    render(<BookRow book={makeBook({ indexed: false })} onOpen={() => {}} />)
+    expect(screen.queryByText('indexed')).not.toBeInTheDocument()
+  })
+
+  // --- index_failed badge ---
+
+  it('shows "index failed" badge when index_failed is true', () => {
+    render(<BookRow book={makeBook({ index_failed: true })} onOpen={() => {}} />)
+    expect(screen.getByText('index failed')).toBeInTheDocument()
+  })
+
+  it('does not show "index failed" badge when index_failed is false', () => {
+    render(<BookRow book={makeBook({ index_failed: false })} onOpen={() => {}} />)
+    expect(screen.queryByText('index failed')).not.toBeInTheDocument()
+  })
+
+  it('"index failed" badge has a tooltip with the error message', () => {
+    render(<BookRow book={makeBook({ index_failed: true, index_error: 'fitz timed out' })} onOpen={() => {}} />)
+    const badge = screen.getByText('index failed')
+    expect(badge.title).toBe('Index failed: fitz timed out')
+  })
+
+  it('"index failed" badge tooltip falls back gracefully when index_error is empty', () => {
+    render(<BookRow book={makeBook({ index_failed: true, index_error: '' })} onOpen={() => {}} />)
+    const badge = screen.getByText('index failed')
+    expect(badge.title).toBe('Index failed')
+  })
+
+  it('does not show "indexed" badge when index_failed is true', () => {
+    // A failed book should not be marked indexed
+    render(<BookRow book={makeBook({ indexed: false, index_failed: true })} onOpen={() => {}} />)
+    expect(screen.queryByText('indexed')).not.toBeInTheDocument()
+    expect(screen.getByText('index failed')).toBeInTheDocument()
+  })
+
+  // --- explicit badge ---
+
+  it('shows 18+ badge when is_explicit is true', () => {
+    render(<BookRow book={makeBook({ is_explicit: true })} onOpen={() => {}} />)
+    expect(screen.getByText('18+')).toBeInTheDocument()
+  })
+
+  it('does not show 18+ badge when is_explicit is false', () => {
+    render(<BookRow book={makeBook({ is_explicit: false })} onOpen={() => {}} />)
+    expect(screen.queryByText('18+')).not.toBeInTheDocument()
+  })
+})

--- a/tests/test_books.py
+++ b/tests/test_books.py
@@ -36,6 +36,13 @@ class TestListBooks:
         ids = [b["id"] for b in resp.json()["books"]]
         assert book.id in ids
 
+    def test_list_includes_index_failed_field(self, client, admin_headers, book):
+        resp = client.get("/api/books", headers=admin_headers)
+        assert resp.status_code == 200
+        books = resp.json()["books"]
+        assert len(books) > 0
+        assert all("index_failed" in b for b in books)
+
     def test_filter_by_category(self, client, admin_headers, book):
         resp = client.get("/api/books?category=core", headers=admin_headers)
         assert resp.status_code == 200
@@ -65,6 +72,14 @@ class TestGetBook:
         assert body["title"] == "Player's Handbook"
         assert body["category"] == "core"
         assert body["page_count"] == 320
+
+    def test_get_book_includes_index_failed(self, client, admin_headers, book):
+        resp = client.get(f"/api/books/{book.id}", headers=admin_headers)
+        assert resp.status_code == 200
+        body = resp.json()
+        assert "index_failed" in body
+        assert isinstance(body["index_failed"], bool)
+        assert body["index_failed"] is False
 
     def test_get_nonexistent_book(self, client, admin_headers):
         resp = client.get("/api/books/does-not-exist", headers=admin_headers)

--- a/tests/test_favorites.py
+++ b/tests/test_favorites.py
@@ -131,6 +131,20 @@ class TestAddFavorite:
         assert resp.status_code == 401
 
 
+class TestFavoritesEnrichedShape:
+    def test_book_item_includes_index_failed(self, client, admin_headers, fav_book):
+        client.post(
+            "/api/favorites",
+            json={"item_type": "book", "item_id": fav_book.id},
+            headers=admin_headers,
+        )
+        resp = client.get("/api/favorites", headers=admin_headers)
+        items = resp.json()["items"]
+        book_items = [i for i in items if i.get("item_type") == "book"]
+        if book_items:
+            assert all("index_failed" in i for i in book_items)
+
+
 class TestFavoritesArePersisted:
     def test_added_book_appears_in_list(self, client, gm_headers, fav_book):
         # Clean add for gm user

--- a/tests/test_indexer_resilience.py
+++ b/tests/test_indexer_resilience.py
@@ -1,0 +1,279 @@
+"""Tests for indexer resilience: fitz timeout, getsize guard, and index_failed logic."""
+from __future__ import annotations
+
+import os
+import tempfile
+import time
+import uuid
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from backend.config import SessionLocal
+from backend.indexer import (
+    _fitz_open_with_timeout,
+    index_book_text,
+    scan_library,
+)
+from backend.models import Book
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _mk_lib() -> tuple[str, Path]:
+    tmp = tempfile.mkdtemp()
+    lib = Path(tmp) / "library"
+    lib.mkdir()
+    return tmp, lib
+
+
+def _make_book_record(**kwargs) -> Book:
+    uid = str(uuid.uuid4())[:8]
+    defaults = dict(
+        title=f"TestBook-{uid}",
+        filename=f"book-{uid}.pdf",
+        filepath=f"/tmp/nonexistent-{uid}.pdf",
+        relative_path=f"book-{uid}.pdf",
+        mime_type="application/pdf",
+        indexed=False,
+        index_failed=False,
+    )
+    defaults.update(kwargs)
+    db = SessionLocal()
+    try:
+        book = Book(**defaults)
+        db.add(book)
+        db.commit()
+        db.refresh(book)
+        return book
+    finally:
+        db.close()
+
+
+def _get_book(book_id: str) -> Book | None:
+    db = SessionLocal()
+    try:
+        return db.query(Book).filter_by(id=book_id).first()
+    finally:
+        db.close()
+
+
+# ---------------------------------------------------------------------------
+# _fitz_open_with_timeout
+# ---------------------------------------------------------------------------
+
+
+class TestFitzTimeout:
+    def test_raises_timeout_error_when_fitz_hangs(self):
+        """If fitz.open() never returns, TimeoutError is raised after deadline."""
+
+        def _hanging_open(path, *a, **kw):
+            time.sleep(60)  # longer than any test timeout
+
+        with patch("backend.indexer.fitz.open", side_effect=_hanging_open):
+            with pytest.raises(TimeoutError):
+                _fitz_open_with_timeout("/fake/path.pdf", timeout=1)
+
+    def test_propagates_fitz_exception(self):
+        """Real fitz errors (e.g. bad file) are re-raised normally."""
+        with patch("backend.indexer.fitz.open", side_effect=RuntimeError("bad pdf")):
+            with pytest.raises(RuntimeError, match="bad pdf"):
+                _fitz_open_with_timeout("/fake/path.pdf", timeout=5)
+
+    def test_returns_document_on_success(self):
+        """Returns the fitz document when open completes within timeout."""
+        mock_doc = MagicMock()
+        with patch("backend.indexer.fitz.open", return_value=mock_doc):
+            result = _fitz_open_with_timeout("/fake/path.pdf", timeout=5)
+        assert result is mock_doc
+
+
+# ---------------------------------------------------------------------------
+# index_book_text — index_failed flag
+# ---------------------------------------------------------------------------
+
+
+class TestIndexBookTextIndexFailed:
+    def test_skips_book_with_index_failed_set(self):
+        """index_book_text returns False without touching the DB when index_failed=True."""
+        book = _make_book_record(index_failed=True)
+        db = SessionLocal()
+        try:
+            result = index_book_text(book, "/tmp", db)
+        finally:
+            db.close()
+
+        assert result is False
+        # indexed flag must stay False — the book was skipped, not processed
+        refreshed = _get_book(book.id)
+        assert refreshed.indexed is False
+        assert refreshed.index_failed is True
+
+    def test_skips_already_indexed_book(self):
+        """index_book_text returns False for books where indexed=True."""
+        book = _make_book_record(indexed=True, index_failed=False)
+        db = SessionLocal()
+        try:
+            result = index_book_text(book, "/tmp", db)
+        finally:
+            db.close()
+
+        assert result is False
+
+    def test_sets_index_failed_when_no_text_extracted(self):
+        """When extract_text_from_pdf returns empty, book is marked index_failed (not indexed)."""
+        uid = str(uuid.uuid4())[:8]
+        db = SessionLocal()
+        try:
+            book = Book(
+                title=f"TestBook-{uid}",
+                filename=f"book-{uid}.pdf",
+                filepath=f"/tmp/nonexistent-{uid}.pdf",
+                relative_path=f"book-{uid}.pdf",
+                mime_type="application/pdf",
+                indexed=False,
+                index_failed=False,
+            )
+            db.add(book)
+            db.commit()
+            db.refresh(book)
+
+            with patch("backend.indexer.extract_text_from_pdf", return_value=[]):
+                result = index_book_text(book, "/tmp", db)
+
+            db.refresh(book)
+            assert result is False
+            assert book.indexed is False
+            assert book.index_failed is True
+            assert "No text extracted" in book.index_error
+        finally:
+            db.close()
+
+    def test_sets_indexed_true_on_success(self):
+        """Successful extraction sets indexed=True and index_failed stays False."""
+        uid = str(uuid.uuid4())[:8]
+        pages = [{"page": 1, "content": "Hello world"}]
+        db = SessionLocal()
+        try:
+            book = Book(
+                title=f"TestBook-{uid}",
+                filename=f"book-{uid}.pdf",
+                filepath=f"/tmp/nonexistent-{uid}.pdf",
+                relative_path=f"book-{uid}.pdf",
+                mime_type="application/pdf",
+                indexed=False,
+                index_failed=False,
+            )
+            db.add(book)
+            db.commit()
+            db.refresh(book)
+
+            with patch("backend.indexer.extract_text_from_pdf", return_value=pages):
+                result = index_book_text(book, "/tmp", db)
+
+            db.refresh(book)
+            assert result is True
+            assert book.indexed is True
+            assert book.index_failed is False
+        finally:
+            db.close()
+
+
+# ---------------------------------------------------------------------------
+# scan_library — os.path.getsize guard
+# ---------------------------------------------------------------------------
+
+
+class TestGetSizeGuard:
+    def _books_dir(self, lib: Path, system_folder: str = "TestSystem") -> Path:
+        d = lib / "books" / system_folder
+        d.mkdir(parents=True, exist_ok=True)
+        return d
+
+    def test_scan_continues_when_file_disappears_during_scan(self):
+        """If os.path.getsize raises OSError, the file is skipped and scanning continues."""
+        tmp, lib = _mk_lib()
+        folder = self._books_dir(lib, "SomeSystem")
+
+        # Create two PDFs; we'll make getsize fail on the first one
+        pdf1 = folder / "first.pdf"
+        pdf2 = folder / "second.pdf"
+        pdf1.write_bytes(b"%PDF-1.4")
+        pdf2.write_bytes(b"%PDF-1.4")
+
+        original_getsize = os.path.getsize
+        call_count = [0]
+
+        def flaky_getsize(path):
+            call_count[0] += 1
+            if "first.pdf" in str(path):
+                raise OSError("file vanished")
+            return original_getsize(path)
+
+        db = SessionLocal()
+        try:
+            with patch("backend.indexer.os.path.getsize", side_effect=flaky_getsize):
+                with patch("backend.indexer.generate_thumbnail", return_value=False):
+                    with patch("backend.indexer._fitz_open_with_timeout") as mock_fitz:
+                        mock_fitz.return_value.__len__ = lambda s: 10
+                        stats = scan_library(str(lib), tmp, db)
+        finally:
+            db.close()
+
+        # Scan should complete without raising, and the good file should be counted
+        assert stats["errors"] >= 0  # no crash
+
+    def test_scan_skips_inaccessible_map_file(self):
+        """A map file that raises OSError on getsize is skipped gracefully."""
+        tmp, lib = _mk_lib()
+        maps_dir = lib / "maps" / "Creator"
+        maps_dir.mkdir(parents=True)
+        (maps_dir / "good.png").write_bytes(b"\x89PNG")
+        (maps_dir / "bad.png").write_bytes(b"\x89PNG")
+
+        original_getsize = os.path.getsize
+
+        def flaky_getsize(path):
+            if "bad.png" in str(path):
+                raise OSError("permission denied")
+            return original_getsize(path)
+
+        db = SessionLocal()
+        try:
+            with patch("backend.indexer.os.path.getsize", side_effect=flaky_getsize):
+                with patch("backend.indexer.generate_thumbnail", return_value=False):
+                    stats = scan_library(str(lib), tmp, db)
+        finally:
+            db.close()
+
+        # Completed without raising
+        assert isinstance(stats, dict)
+
+    def test_scan_skips_inaccessible_token_file(self):
+        """A token file that raises OSError on getsize is skipped gracefully."""
+        tmp, lib = _mk_lib()
+        tokens_dir = lib / "tokens" / "Monsters"
+        tokens_dir.mkdir(parents=True)
+        (tokens_dir / "goblin.png").write_bytes(b"\x89PNG")
+        (tokens_dir / "ghost.png").write_bytes(b"\x89PNG")
+
+        original_getsize = os.path.getsize
+
+        def flaky_getsize(path):
+            if "ghost.png" in str(path):
+                raise OSError("gone")
+            return original_getsize(path)
+
+        db = SessionLocal()
+        try:
+            with patch("backend.indexer.os.path.getsize", side_effect=flaky_getsize):
+                with patch("backend.indexer.generate_thumbnail", return_value=False):
+                    stats = scan_library(str(lib), tmp, db)
+        finally:
+            db.close()
+
+        assert isinstance(stats, dict)

--- a/tests/test_indexer_resilience.py
+++ b/tests/test_indexer_resilience.py
@@ -230,7 +230,7 @@ class TestGetSizeGuard:
     def test_scan_skips_inaccessible_map_file(self):
         """A map file that raises OSError on getsize is skipped gracefully."""
         tmp, lib = _mk_lib()
-        maps_dir = lib / "maps" / "Creator"
+        maps_dir = lib / "maps" / "ResilienceCreator"
         maps_dir.mkdir(parents=True)
         (maps_dir / "good.png").write_bytes(b"\x89PNG")
         (maps_dir / "bad.png").write_bytes(b"\x89PNG")
@@ -256,7 +256,7 @@ class TestGetSizeGuard:
     def test_scan_skips_inaccessible_token_file(self):
         """A token file that raises OSError on getsize is skipped gracefully."""
         tmp, lib = _mk_lib()
-        tokens_dir = lib / "tokens" / "Monsters"
+        tokens_dir = lib / "tokens" / "ResilienceMonsters"
         tokens_dir.mkdir(parents=True)
         (tokens_dir / "goblin.png").write_bytes(b"\x89PNG")
         (tokens_dir / "ghost.png").write_bytes(b"\x89PNG")

--- a/tests/test_systems.py
+++ b/tests/test_systems.py
@@ -60,6 +60,14 @@ class TestGetSystem:
         resp = client.get(f"/api/systems/{system.id}", headers=admin_headers)
         assert "books" in resp.json()
 
+    def test_system_books_include_index_failed(self, client, admin_headers, system):
+        from tests.conftest import make_book
+        make_book(system_id=system.id)
+        resp = client.get(f"/api/systems/{system.id}", headers=admin_headers)
+        books = resp.json()["books"]
+        if books:
+            assert all("index_failed" in b for b in books)
+
     def test_get_nonexistent_system(self, client, admin_headers):
         resp = client.get("/api/systems/does-not-exist", headers=admin_headers)
         assert resp.status_code == 404


### PR DESCRIPTION
Fixes a bug where library scan/index progress would stall permanently, and adds visibility into books that fail to scan/index. Added timeout to scan and indexing to ensure hangs don't prevent additional books from being scanned.