### PR TITLE
Add scan cancellation and add application log viewer

### DIFF
--- a/README.md
+++ b/README.md
@@ -264,6 +264,7 @@ Tags are applied (or updated) every time the library is rescanned. Tags set via 
 | `DATA_PATH` | `/data` | Path for the database, thumbnails, and search cache |
 | `WORKERS` | `2` | Number of uvicorn worker processes |
 | `VALKEY_URL` | — | Optional Redis-compatible cache URL for rendered page images (e.g. `redis://valkey:6379/0`) |
+| `LOG_LEVEL` | `info` | Optional Console/Docker log verbosity: `debug`, `info`, `warning`, `error`, or `critical`. The in-app Logs tab (Settings → Logs) always captures `debug`-level entries regardless of this setting. |
 
 ### Volumes
 

--- a/backend/config.py
+++ b/backend/config.py
@@ -1,6 +1,9 @@
 """Shared configuration, database, and cache setup for Grimoire."""
 import os
 import logging
+import collections
+import threading
+import datetime
 from typing import Optional
 from .models import init_db
 
@@ -14,8 +17,121 @@ PAGE_CACHE_DIR = os.path.join(DATA_PATH, "page_cache")
 VALKEY_URL = os.environ.get("VALKEY_URL", "")
 _PAGE_CACHE_HEADERS = {"Cache-Control": "max-age=31536000, immutable"}
 
-logging.basicConfig(level=logging.INFO, format="%(asctime)s [%(name)s] %(levelname)s: %(message)s")
+# Console log level is controlled by the LOG_LEVEL env var (default: info).
+# In-memory ring buffer always captures DEBUG+ so the /api/logs endpoint can
+# serve debug logs regardless of the console level.
+_LOG_LEVEL_NAME = os.environ.get("LOG_LEVEL", "info").upper()
+_CONSOLE_LEVEL = getattr(logging, _LOG_LEVEL_NAME, logging.INFO)
+
+_LOG_FORMAT = "%(asctime)s [%(name)s] %(levelname)s: %(message)s"
+logging.basicConfig(level=logging.DEBUG, format=_LOG_FORMAT)
+
+for _noisy in ("uvicorn", "uvicorn.access", "uvicorn.error", "fastapi", "sqlalchemy.engine"):
+    logging.getLogger(_noisy).setLevel(logging.WARNING)
+
+for _h in logging.root.handlers:
+    _h.setLevel(_CONSOLE_LEVEL)
+
 logger = logging.getLogger("grimoire")
+logger.setLevel(logging.DEBUG)
+
+_LOG_BUFFER_MAX = 20000
+
+_seq_counter = 0
+
+
+class _LogEntry:
+    """Lightweight log record stored in the ring buffer."""
+    __slots__ = ("seq", "timestamp", "level", "logger", "message")
+
+    def __init__(self, seq: int, timestamp: str, level: str, logger_name: str, message: str):
+        self.seq       = seq
+        self.timestamp = timestamp
+        self.level     = level
+        self.logger    = logger_name
+        self.message   = message
+
+    def to_dict(self) -> dict:
+        return {
+            "seq":       self.seq,
+            "timestamp": self.timestamp,
+            "level":     self.level,
+            "logger":    self.logger,
+            "message":   self.message,
+        }
+
+
+class _MemoryLogHandler(logging.Handler):
+    """Thread-safe ring-buffer log handler for in-app log viewing."""
+
+    def __init__(self, maxlen: int = _LOG_BUFFER_MAX):
+        super().__init__(level=logging.DEBUG)
+        self._buf: collections.deque[_LogEntry] = collections.deque(maxlen=maxlen)
+        self._lock = threading.Lock()
+
+    def emit(self, record: logging.LogRecord) -> None:
+        global _seq_counter
+        try:
+            ts = datetime.datetime.fromtimestamp(
+                record.created, tz=datetime.timezone.utc
+            ).strftime("%Y-%m-%dT%H:%M:%S.%f")[:-3] + "Z"
+            with self._lock:
+                _seq_counter += 1
+                entry = _LogEntry(
+                    seq=_seq_counter,
+                    timestamp=ts,
+                    level=record.levelname,
+                    logger_name=record.name,
+                    message=self.format(record),
+                )
+                self._buf.append(entry)
+        except Exception:
+            self.handleError(record)
+
+    def get_entries(
+        self,
+        min_level: int = logging.DEBUG,
+        limit: int = 500,
+        offset: int = 0,
+        after_seq: int = 0,
+    ) -> tuple[list[dict], int]:
+        """Return entries in oldest-to-newest order and the current max seq.
+
+        When `after_seq` > 0, returns only entries with seq > after_seq (up to
+        `limit`), ignoring `offset`.  This is the fast path for live polling.
+
+        When `after_seq` == 0 (initial / historical load), `offset` is counted
+        from the newest end: offset=0 → most-recent `limit` entries,
+        offset=limit → next-older page, etc.
+
+        Returns (entries_list, max_seq_in_buffer).
+        """
+        with self._lock:
+            all_entries = [e for e in self._buf if logging.getLevelName(e.level) >= min_level]  # type: ignore[arg-type]
+            max_seq = self._buf[-1].seq if self._buf else 0
+
+        if after_seq > 0:
+            new = [e for e in all_entries if e.seq > after_seq]
+            return [e.to_dict() for e in new[-limit:]], max_seq
+
+        total = len(all_entries)
+        end   = total - offset
+        start = max(0, end - limit)
+        return [e.to_dict() for e in all_entries[start:end]], max_seq
+
+    def get_total(self, min_level: int = logging.DEBUG) -> int:
+        with self._lock:
+            return sum(1 for e in self._buf if logging.getLevelName(e.level) >= min_level)  # type: ignore[arg-type]
+
+    def clear(self) -> None:
+        with self._lock:
+            self._buf.clear()
+
+
+_memory_handler = _MemoryLogHandler()
+_memory_handler.setFormatter(logging.Formatter("%(message)s"))
+
+logging.root.addHandler(_memory_handler)
 
 os.makedirs(DATA_PATH, exist_ok=True)
 os.makedirs(THUMB_DIR, exist_ok=True)
@@ -34,7 +150,6 @@ def get_db():
         db.close()
 
 
-# Optional Valkey page cache
 _valkey: Optional[object] = None
 if VALKEY_URL:
     try:

--- a/backend/indexer.py
+++ b/backend/indexer.py
@@ -140,11 +140,13 @@ def _count_eligible_files(directory: Path, extensions: set) -> int:
     return count
 
 
-def scan_library(library_path: str, data_path: str, session: Session, on_progress=None):
+def scan_library(library_path: str, data_path: str, session: Session, on_progress=None, should_stop=None):
     """Scan the library directory and register all files in the database.
 
     on_progress(scanned_books, total_books, scanned_maps, total_maps, scanned_tokens, total_tokens)
     is called after each file is processed if provided.
+
+    should_stop() is an optional callable that returns True when the scan should abort early.
     """
     library = Path(library_path)
     books_dir = library / "books"
@@ -214,6 +216,9 @@ def scan_library(library_path: str, data_path: str, session: Session, on_progres
                             scanned_tokens,
                             total_tokens,
                         )
+                    if should_stop and should_stop():
+                        logger.info("scan_library: stop requested during books scan.")
+                        return stats
 
                     relative_path = os.path.relpath(filepath, library_path)
 
@@ -291,6 +296,9 @@ def scan_library(library_path: str, data_path: str, session: Session, on_progres
                         scanned_tokens,
                         total_tokens,
                     )
+                if should_stop and should_stop():
+                    logger.info("scan_library: stop requested during maps scan.")
+                    return stats
 
                 relative_path = os.path.relpath(filepath, library_path)
 
@@ -353,6 +361,9 @@ def scan_library(library_path: str, data_path: str, session: Session, on_progres
                         scanned_tokens,
                         total_tokens,
                     )
+                if should_stop and should_stop():
+                    logger.info("scan_library: stop requested during tokens scan.")
+                    return stats
 
                 relative_path = os.path.relpath(filepath, library_path)
 

--- a/backend/indexer.py
+++ b/backend/indexer.py
@@ -20,8 +20,12 @@ logger = logging.getLogger("grimoire.indexer")
 _FITZ_TIMEOUT = 300  # seconds
 
 
-def _fitz_open_with_timeout(filepath: str, timeout: int = _FITZ_TIMEOUT):
-    """Open a PDF with fitz, raising TimeoutError if it hangs beyond `timeout` seconds."""
+def _fitz_open_with_timeout(filepath: str, timeout: int = _FITZ_TIMEOUT, should_stop=None):
+    """Open a PDF with fitz, raising TimeoutError if it hangs beyond `timeout` seconds.
+
+    If `should_stop` callable is provided, the wait is interrupted early when it
+    returns True, raising TimeoutError so the caller can exit cleanly.
+    """
     result = [None]
     exc = [None]
 
@@ -33,7 +37,14 @@ def _fitz_open_with_timeout(filepath: str, timeout: int = _FITZ_TIMEOUT):
 
     t = threading.Thread(target=_open, daemon=True)
     t.start()
-    t.join(timeout)
+    deadline = timeout
+    poll_interval = 0.5  # check stop flag every 500ms
+    elapsed = 0.0
+    while t.is_alive() and elapsed < deadline:
+        t.join(poll_interval)
+        elapsed += poll_interval
+        if should_stop and should_stop():
+            raise TimeoutError(f"fitz.open() aborted by stop request for {filepath}")
     if t.is_alive():
         raise TimeoutError(f"fitz.open() timed out after {timeout}s for {filepath}")
     if exc[0] is not None:
@@ -85,12 +96,12 @@ def guess_category(filepath: str) -> str:
     return "core"
 
 
-def generate_thumbnail(filepath: str, output_path: str, size: tuple = (300, 400)) -> bool:
+def generate_thumbnail(filepath: str, output_path: str, size: tuple = (300, 400), should_stop=None) -> bool:
     """Generate a thumbnail from the first page of a PDF or from an image."""
     try:
         ext = Path(filepath).suffix.lower()
         if ext == ".pdf":
-            doc = _fitz_open_with_timeout(filepath)
+            doc = _fitz_open_with_timeout(filepath, should_stop=should_stop)
             if len(doc) == 0:
                 return False
             page = doc[0]
@@ -114,11 +125,11 @@ def generate_thumbnail(filepath: str, output_path: str, size: tuple = (300, 400)
         return False
 
 
-def extract_text_from_pdf(filepath: str) -> list[dict]:
+def extract_text_from_pdf(filepath: str, should_stop=None) -> list[dict]:
     """Extract text from all pages of a PDF. Returns list of {page, content}."""
     pages = []
     try:
-        doc = _fitz_open_with_timeout(filepath)
+        doc = _fitz_open_with_timeout(filepath, should_stop=should_stop)
         for i, page in enumerate(doc):
             page_text = page.get_text().strip()
             if page_text:
@@ -224,8 +235,10 @@ def scan_library(library_path: str, data_path: str, session: Session, on_progres
 
                     existing = session.query(Book).filter_by(filepath=filepath).first()
                     if existing:
+                        logger.debug(f"File scan: already registered, skipping: {filename}")
                         continue
 
+                    logger.debug(f"File scan: new book found: {filename}")
                     category = guess_category(relative_path)
                     title = Path(filename).stem.replace("_", " ").replace("-", " ").strip()
 
@@ -251,12 +264,12 @@ def scan_library(library_path: str, data_path: str, session: Session, on_progres
                         "books",
                         f"{slugify(title)}_{hashlib.md5(filepath.encode()).hexdigest()[:8]}.webp",
                     )
-                    if generate_thumbnail(filepath, thumb_path):
+                    if generate_thumbnail(filepath, thumb_path, should_stop=should_stop):
                         book.has_thumbnail = True
 
                     if ext == ".pdf":
                         try:
-                            doc = _fitz_open_with_timeout(filepath)
+                            doc = _fitz_open_with_timeout(filepath, should_stop=should_stop)
                             book.page_count = len(doc)
                             doc.close()
                         except Exception as e:
@@ -304,8 +317,10 @@ def scan_library(library_path: str, data_path: str, session: Session, on_progres
 
                 existing = session.query(GenericMap).filter_by(filepath=filepath).first()
                 if existing:
+                    logger.debug(f"File scan: already registered, skipping: {filename}")
                     continue
 
+                logger.debug(f"File scan: new map found: {filename}")
                 title = Path(filename).stem.replace("_", " ").replace("-", " ").strip()
 
                 try:
@@ -326,7 +341,7 @@ def scan_library(library_path: str, data_path: str, session: Session, on_progres
                     "maps",
                     f"{slugify(title)}_{hashlib.md5(filepath.encode()).hexdigest()[:8]}.webp",
                 )
-                if generate_thumbnail(filepath, thumb_path):
+                if generate_thumbnail(filepath, thumb_path, should_stop=should_stop):
                     gmap.has_thumbnail = True
 
                 session.add(gmap)
@@ -369,8 +384,10 @@ def scan_library(library_path: str, data_path: str, session: Session, on_progres
 
                 existing = session.query(Token).filter_by(filepath=filepath).first()
                 if existing:
+                    logger.debug(f"File scan: already registered, skipping: {filename}")
                     continue
 
+                logger.debug(f"File scan: new token found: {filename}")
                 title = Path(filename).stem.replace("_", " ").replace("-", " ").strip()
 
                 try:
@@ -391,7 +408,7 @@ def scan_library(library_path: str, data_path: str, session: Session, on_progres
                     "tokens",
                     f"{slugify(title)}_{hashlib.md5(filepath.encode()).hexdigest()[:8]}.webp",
                 )
-                if generate_thumbnail(filepath, thumb_path, size=(200, 200)):
+                if generate_thumbnail(filepath, thumb_path, size=(200, 200), should_stop=should_stop):
                     token.has_thumbnail = True
 
                 session.add(token)
@@ -510,12 +527,12 @@ def _apply_tags_from_library(library_path: str, session: Session) -> None:
     session.commit()
 
 
-def index_book_text(book: Book, data_path: str, session: Session):
+def index_book_text(book: Book, data_path: str, session: Session, should_stop=None):
     """Extract and index text from a PDF for full-text search."""
     if book.indexed or book.index_failed or book.mime_type != "application/pdf":
         return False
 
-    pages = extract_text_from_pdf(book.filepath)
+    pages = extract_text_from_pdf(book.filepath, should_stop=should_stop)
     if not pages:
         book.index_error = "No text extracted"
         book.index_failed = True
@@ -534,5 +551,5 @@ def index_book_text(book: Book, data_path: str, session: Session):
     book.indexed = True
     book.index_error = ""
     session.commit()
-    logger.info(f"Indexed {len(pages)} pages for: {book.title}")
+    logger.info(f"Indexed {len(pages)} pages for: {book.filename} ('{book.title}')")
     return True

--- a/backend/main.py
+++ b/backend/main.py
@@ -24,6 +24,7 @@ from .routers import bookmarks as bookmarks_router
 from .routers import maintenance as maintenance_router
 from .routers import settings as settings_router
 from .routers import campaigns as campaigns_router
+from .routers import logs as logs_router
 from .routers.library import run_rescan_sync
 from . import scheduler
 from . import session_creator
@@ -63,6 +64,7 @@ _TAGS = [
     },
     {"name": "settings", "description": "Application settings. **Admin only.**"},
     {"name": "maintenance", "description": "Admin housekeeping tasks."},
+    {"name": "logs", "description": "Application log retrieval. **Admin only.**"},
 ]
 
 
@@ -139,6 +141,7 @@ api.include_router(bookmarks_router.router)
 api.include_router(maintenance_router.router)
 api.include_router(settings_router.router)
 api.include_router(campaigns_router.router)
+api.include_router(logs_router.router)
 app.include_router(api)
 
 

--- a/backend/routers/library/_helpers.py
+++ b/backend/routers/library/_helpers.py
@@ -28,6 +28,22 @@ _DEFAULT_STATUS: dict = {
 # In-process fallback when Valkey is unavailable (single-worker or no cache)
 _scan_status: dict = dict(_DEFAULT_STATUS)
 
+_stop_requested: bool = False
+
+
+def request_stop() -> None:
+    global _stop_requested
+    _stop_requested = True
+
+
+def clear_stop() -> None:
+    global _stop_requested
+    _stop_requested = False
+
+
+def is_stop_requested() -> bool:
+    return _stop_requested
+
 
 def _get_status() -> dict:
     if _valkey:
@@ -71,6 +87,9 @@ def background_indexer():
                 }
             )
         for book in unindexed:
+            if is_stop_requested():
+                logger.info("Background indexer: stop requested, halting.")
+                break
             try:
                 index_book_text(book, DATA_PATH, db)
             except Exception as e:
@@ -97,6 +116,7 @@ def run_rescan_sync() -> None:
         logger.info("Rescan already running, skipping.")
         return
 
+    clear_stop()
     _set_status({**_DEFAULT_STATUS, "running": True, "phase": "scanning"})
     try:
         _invalidate_book_cache()
@@ -115,7 +135,7 @@ def run_rescan_sync() -> None:
                     }
                 )
 
-            stats = scan_library(LIBRARY_PATH, DATA_PATH, db, on_progress=on_progress)
+            stats = scan_library(LIBRARY_PATH, DATA_PATH, db, on_progress=on_progress, should_stop=is_stop_requested)
             logger.info(f"Rescan complete: {stats}")
             _set_status(
                 {
@@ -125,9 +145,15 @@ def run_rescan_sync() -> None:
                 }
             )
 
+            if is_stop_requested():
+                return
+
             to_index = db.query(Book).filter_by(indexed=False, index_failed=False, mime_type="application/pdf").all()
             _set_status({"phase": "indexing", "to_index": len(to_index), "indexed": 0})
             for book in to_index:
+                if is_stop_requested():
+                    logger.info("Rescan: stop requested during indexing.")
+                    break
                 try:
                     index_book_text(book, DATA_PATH, db)
                 except Exception as e:

--- a/backend/routers/library/_helpers.py
+++ b/backend/routers/library/_helpers.py
@@ -8,6 +8,7 @@ from ...indexer import scan_library, index_book_text
 from ..books import _invalidate_book_cache
 
 _SCAN_KEY = "grimoire:scan_status"
+_STOP_KEY = "grimoire:scan_stop"
 
 _DEFAULT_STATUS: dict = {
     "running": False,
@@ -27,21 +28,35 @@ _DEFAULT_STATUS: dict = {
 
 # In-process fallback when Valkey is unavailable (single-worker or no cache)
 _scan_status: dict = dict(_DEFAULT_STATUS)
-
 _stop_requested: bool = False
 
 
 def request_stop() -> None:
     global _stop_requested
     _stop_requested = True
+    if _valkey:
+        try:
+            _valkey.set(_STOP_KEY, "1", ex=3600)
+        except Exception:
+            pass
 
 
 def clear_stop() -> None:
     global _stop_requested
     _stop_requested = False
+    if _valkey:
+        try:
+            _valkey.delete(_STOP_KEY)
+        except Exception:
+            pass
 
 
 def is_stop_requested() -> bool:
+    if _valkey:
+        try:
+            return bool(_valkey.exists(_STOP_KEY))
+        except Exception:
+            pass
     return _stop_requested
 
 
@@ -75,8 +90,9 @@ def background_indexer():
     try:
         unindexed = db.query(Book).filter_by(indexed=False, index_failed=False, mime_type="application/pdf").all()
         if not unindexed:
+            logger.debug("Background indexer: no unindexed books found, exiting.")
             return
-        logger.info(f"Background indexer: {len(unindexed)} books to index")
+        logger.info(f"Background indexer: starting — {len(unindexed)} book(s) to index")
         if not _get_status()["running"]:
             _set_status(
                 {
@@ -86,18 +102,26 @@ def background_indexer():
                     "indexed": 0,
                 }
             )
+        indexed_count = 0
         for book in unindexed:
             if is_stop_requested():
                 logger.info("Background indexer: stop requested, halting.")
                 break
+            logger.debug(f"Index start: '{book.filename}' ('{book.title}', id={book.id})")
             try:
-                index_book_text(book, DATA_PATH, db)
+                result = index_book_text(book, DATA_PATH, db, should_stop=is_stop_requested)
+                if result:
+                    indexed_count += 1
+                    logger.debug(f"Index end: '{book.filename}' — success")
+                else:
+                    logger.debug(f"Index end: '{book.filename}' — skipped or no text extracted")
             except Exception as e:
-                logger.error(f"Indexing error for {book.title}: {e}")
+                logger.error(f"Indexing error for '{book.filename}': {e}")
                 book.index_error = str(e)[:500]
                 book.index_failed = True
                 db.commit()
             _set_status({"indexed": _get_status()["indexed"] + 1})
+        logger.info(f"Background indexer: complete — {indexed_count}/{len(unindexed)} book(s) indexed")
     finally:
         db.close()
         if _get_status()["phase"] == "indexing":
@@ -122,6 +146,8 @@ def run_rescan_sync() -> None:
         _invalidate_book_cache()
         db = SessionLocal()
         try:
+            # --- Phase 1: file scan ---
+            logger.info("File scan start")
 
             def on_progress(sb, tb, sm, tm, st, tt):
                 _set_status(
@@ -134,9 +160,16 @@ def run_rescan_sync() -> None:
                         "total_tokens": tt,
                     }
                 )
+                logger.debug(
+                    f"File scan progress: books={sb}/{tb}, maps={sm}/{tm}, tokens={st}/{tt}"
+                )
 
             stats = scan_library(LIBRARY_PATH, DATA_PATH, db, on_progress=on_progress, should_stop=is_stop_requested)
-            logger.info(f"Rescan complete: {stats}")
+            logger.info(
+                f"File scan end: new_books={stats.get('new_books', 0)}, "
+                f"new_maps={stats.get('new_maps', 0)}, new_tokens={stats.get('new_tokens', 0)}, "
+                f"errors={stats.get('errors', 0)}"
+            )
             _set_status(
                 {
                     "new_books": stats.get("new_books", 0),
@@ -146,22 +179,33 @@ def run_rescan_sync() -> None:
             )
 
             if is_stop_requested():
+                logger.info("Rescan: stop requested after file scan, skipping indexing.")
                 return
 
+            # --- Phase 2: PDF indexing ---
             to_index = db.query(Book).filter_by(indexed=False, index_failed=False, mime_type="application/pdf").all()
             _set_status({"phase": "indexing", "to_index": len(to_index), "indexed": 0})
+            logger.info(f"Index scan start: {len(to_index)} PDF(s) to index")
+            indexed_count = 0
             for book in to_index:
                 if is_stop_requested():
                     logger.info("Rescan: stop requested during indexing.")
                     break
+                logger.debug(f"Index start: '{book.filename}' ('{book.title}', id={book.id})")
                 try:
-                    index_book_text(book, DATA_PATH, db)
+                    result = index_book_text(book, DATA_PATH, db, should_stop=is_stop_requested)
+                    if result:
+                        indexed_count += 1
+                        logger.debug(f"Index end: '{book.filename}' — success")
+                    else:
+                        logger.debug(f"Index end: '{book.filename}' — skipped or no text extracted")
                 except Exception as e:
-                    logger.error(f"Indexing error for {book.title}: {e}")
+                    logger.error(f"Indexing error for '{book.filename}': {e}")
                     book.index_error = str(e)[:500]
                     book.index_failed = True
                     db.commit()
                 _set_status({"indexed": _get_status()["indexed"] + 1})
+            logger.info(f"Index scan end: {indexed_count}/{len(to_index)} PDF(s) indexed")
         finally:
             db.close()
     finally:

--- a/backend/routers/library/core.py
+++ b/backend/routers/library/core.py
@@ -37,6 +37,18 @@ def rescan_library(
     return {"status": "scan_started"}
 
 
+@router.post(
+    "/cancel-scan",
+    summary="Cancel running scan",
+    description="Requests a graceful stop of the currently running library scan or indexing job. GM or admin role required.",
+)
+def cancel_scan(_: CurrentUser = Depends(require_gm_or_admin)):
+    if not _helpers._get_status()["running"]:
+        return {"status": "not_running"}
+    _helpers.request_stop()
+    return {"status": "stop_requested"}
+
+
 @public_router.get(
     "/stats",
     summary="Library statistics",

--- a/backend/routers/library/core.py
+++ b/backend/routers/library/core.py
@@ -6,7 +6,7 @@ from sqlalchemy import func
 
 from ...config import SessionLocal, VERSION
 from ...models import GameSystem, Book, GenericMap, Token
-from ...auth import require_gm_or_admin, optional_get_current_user, CurrentUser
+from ...auth import require_admin, optional_get_current_user, CurrentUser
 from ..settings import get_stats_api_key
 from . import _helpers
 
@@ -19,17 +19,17 @@ public_router = APIRouter(prefix="/api", tags=["library"])
     summary="Scan status",
     description="Returns current scan state: running, phase (scanning|indexing), progress counters, and new-item counts from the last scan.",
 )
-def get_scan_status():
+def get_scan_status(_: CurrentUser = Depends(require_admin)):
     return _helpers._get_status()
 
 
 @router.post(
     "/rescan",
     summary="Rescan and reindex library",
-    description="Triggers a background rescan of the library directory, adding new files and indexing unindexed PDFs. GM or admin role required.",
+    description="Triggers a background rescan of the library directory, adding new files and indexing unindexed PDFs. Admin role required.",
 )
 def rescan_library(
-    background_tasks: BackgroundTasks, _: CurrentUser = Depends(require_gm_or_admin)
+    background_tasks: BackgroundTasks, _: CurrentUser = Depends(require_admin)
 ):
     if _helpers._scan_status["running"]:
         return {"status": "already_running"}
@@ -40,9 +40,9 @@ def rescan_library(
 @router.post(
     "/cancel-scan",
     summary="Cancel running scan",
-    description="Requests a graceful stop of the currently running library scan or indexing job. GM or admin role required.",
+    description="Requests a graceful stop of the currently running library scan or indexing job. Admin role required.",
 )
-def cancel_scan(_: CurrentUser = Depends(require_gm_or_admin)):
+def cancel_scan(_: CurrentUser = Depends(require_admin)):
     if not _helpers._get_status()["running"]:
         return {"status": "not_running"}
     _helpers.request_stop()

--- a/backend/routers/logs.py
+++ b/backend/routers/logs.py
@@ -1,0 +1,60 @@
+"""Log retrieval endpoint for admin users."""
+import logging
+from typing import Literal, Optional
+
+from fastapi import APIRouter, Depends, Query
+
+from ..config import _memory_handler
+from ..auth import require_admin, CurrentUser
+
+router = APIRouter(tags=["logs"])
+
+_LEVEL_MAP: dict[str, int] = {
+    "debug":    logging.DEBUG,
+    "info":     logging.INFO,
+    "warning":  logging.WARNING,
+    "error":    logging.ERROR,
+    "critical": logging.CRITICAL,
+}
+
+
+@router.get(
+    "/logs",
+    summary="Application logs",
+    description=(
+        "Returns recent application log entries from the in-memory ring buffer (up to 20 000 entries). "
+        "The `level` filter follows standard log hierarchy: `debug` returns all levels, "
+        "`info` returns info/warning/error/critical, etc. "
+        "Console output is controlled by the `LOG_LEVEL` environment variable, but this endpoint "
+        "always has access to DEBUG-level logs regardless of that setting. "
+        "For live polling, pass `after_seq` set to the `max_seq` value from the previous response — "
+        "only entries with a higher sequence number are returned, making polling exact regardless of "
+        "how fast entries arrive. "
+        "**Admin only.**"
+    ),
+)
+def get_logs(
+    level: Literal["debug", "info", "warning", "error", "critical"] = Query(
+        default="info", description="Minimum log level to return"
+    ),
+    limit: int = Query(default=200, ge=1, le=20000, description="Maximum number of entries to return"),
+    offset: int = Query(default=0, ge=0, description="Entries to skip from the newest end (historical pagination, ignored when after_seq is set)"),
+    after_seq: Optional[int] = Query(default=None, ge=0, description="Return only entries with seq > this value (live-poll cursor)"),
+    _: CurrentUser = Depends(require_admin),
+):
+    min_level = _LEVEL_MAP.get(level.lower(), logging.INFO)
+    entries, max_seq = _memory_handler.get_entries(
+        min_level=min_level,
+        limit=limit,
+        offset=offset,
+        after_seq=after_seq if after_seq is not None else 0,
+    )
+    total = _memory_handler.get_total(min_level=min_level)
+    return {
+        "entries":  entries,
+        "total":    total,
+        "max_seq":  max_seq,
+        "level":    level,
+        "limit":    limit,
+        "offset":   offset,
+    }

--- a/docs/api.md
+++ b/docs/api.md
@@ -67,8 +67,9 @@ Tokens are returned by `/api/auth/login` and expire after **30 days**.
 | Endpoint | Method | Auth | Description |
 |----------|--------|------|-------------|
 | `/api/stats` | GET | JWT **or** `X-API-Key` header | Counts, page totals, library size, version |
-| `/api/scan-status` | GET | any | Current scan state |
-| `/api/rescan` | POST | gm/admin | Trigger a background rescan and reindex |
+| `/api/scan-status` | GET | admin | Current scan state |
+| `/api/rescan` | POST | admin | Trigger a background rescan and reindex |
+| `/api/cancel-scan` | POST | admin | Request a graceful stop of the running scan or indexing job |
 
 **Stats response:**
 ```json
@@ -104,6 +105,12 @@ Tokens are returned by `/api/auth/login` and expire after **30 days**.
 ```
 
 `phase` is `"scanning"`, `"indexing"`, or `null` when idle.
+
+**Cancel-scan response:**
+```json
+{"status": "stop_requested"}
+```
+Returns `{"status": "not_running"}` if no scan is in progress. Cancellation is cooperative — the running scan checks for the stop signal after each file and exits at the next safe checkpoint. Poll `/api/scan-status` until `running` is `false` to confirm it has stopped.
 
 ### Game Systems
 
@@ -322,6 +329,43 @@ Availability statuses: `available`, `tentative`, `unavailable`
 | Endpoint | Method | Description |
 |----------|--------|-------------|
 | `/api/maintenance/cleanup-missing` | POST | Remove DB records for files no longer present on disk |
+
+### Logs *(admin only)*
+
+| Endpoint | Method | Auth | Description |
+|----------|--------|------|-------------|
+| `/api/logs` | GET | admin | Retrieve recent log entries from the in-memory ring buffer |
+
+**Query parameters:**
+
+| Parameter | Default | Description |
+|-----------|---------|-------------|
+| `level` | `info` | Minimum log level: `debug`, `info`, `warning`, `error`, `critical`. Follows standard hierarchy — `debug` returns all levels, `info` returns info and above, etc. |
+| `limit` | `200` | Max entries to return (1–20000) |
+| `offset` | `0` | Skip this many of the most-recent matching entries (historical pagination, ignored when `after_seq` is set) |
+| `after_seq` | — | Return only entries with `seq` greater than this value. Use the `max_seq` from the previous response as a cursor for live polling. Exact even when hundreds of entries arrive between polls. |
+
+**Response:**
+```json
+{
+  "entries": [
+    {
+      "seq": 142,
+      "timestamp": "2026-04-10T12:34:56.789Z",
+      "level": "INFO",
+      "logger": "grimoire",
+      "message": "File scan start"
+    }
+  ],
+  "total": 42,
+  "max_seq": 142,
+  "level": "info",
+  "limit": 200,
+  "offset": 0
+}
+```
+
+> **Note:** Console/Docker log verbosity is controlled by the `LOG_LEVEL` environment variable (default `info`). The `/api/logs` endpoint always has access to `DEBUG`-level entries regardless of `LOG_LEVEL`, because the in-memory buffer captures all levels. The buffer holds up to 20 000 entries.
 
 **Cleanup response:**
 ```json

--- a/frontend/src/components/settings/LogsTab.jsx
+++ b/frontend/src/components/settings/LogsTab.jsx
@@ -1,0 +1,316 @@
+import { useState, useEffect, useRef, useCallback } from 'react'
+import { LuPause, LuPlay, LuSearch, LuArrowDown } from 'react-icons/lu'
+import api from '../../api'
+
+const LEVELS = ['debug', 'info', 'warning', 'error', 'critical']
+
+const LEVEL_COLORS = {
+  DEBUG:    '#9ca3af',
+  INFO:     '#e5e7eb',
+  WARNING:  '#fbbf24',
+  ERROR:    '#f87171',
+  CRITICAL: '#ff6b6b',
+}
+
+const LEVEL_BG = {
+  DEBUG:    'transparent',
+  INFO:     'transparent',
+  WARNING:  'rgba(251,191,36,0.07)',
+  ERROR:    'rgba(248,113,113,0.09)',
+  CRITICAL: 'rgba(255,107,107,0.14)',
+}
+
+const LEVEL_LABELS = {
+  DEBUG: 'DEBUG', INFO: 'INFO', WARNING: 'WARNING', ERROR: 'ERROR', CRITICAL: 'CRITICAL',
+}
+
+const INITIAL_LIMIT = 1000
+
+function LevelBadge({ level }) {
+  const color = LEVEL_COLORS[level] ?? LEVEL_COLORS.INFO
+  return (
+    <span
+      aria-label={`Log level: ${LEVEL_LABELS[level] ?? level}`}
+      style={{ color, fontWeight: level === 'DEBUG' ? 400 : 600, letterSpacing: '0.02em', minWidth: 56, display: 'inline-block' }}
+    >
+      {LEVEL_LABELS[level] ?? level}
+    </span>
+  )
+}
+
+function LogRow({ entry, searchQuery }) {
+  const bg   = LEVEL_BG[entry.level] ?? 'transparent'
+  const time = entry.timestamp.slice(11, 23)
+
+  let messageContent = entry.message
+  if (searchQuery) {
+    const idx = entry.message.toLowerCase().indexOf(searchQuery.toLowerCase())
+    if (idx !== -1) {
+      messageContent = (
+        <>
+          {entry.message.slice(0, idx)}
+          <mark style={{ background: 'rgba(251,191,36,0.35)', color: 'inherit', borderRadius: 2 }}>
+            {entry.message.slice(idx, idx + searchQuery.length)}
+          </mark>
+          {entry.message.slice(idx + searchQuery.length)}
+        </>
+      )
+    }
+  }
+
+  return (
+    <div role="row" style={{ display: 'grid', gridTemplateColumns: '90px 72px 1fr', gap: '0 10px', padding: '3px 12px', fontSize: 12, fontFamily: 'monospace', lineHeight: 1.55, background: bg, borderBottom: '1px solid rgba(255,255,255,0.03)', wordBreak: 'break-word' }}>
+      <span role="cell" aria-label={`Time: ${time}`} style={{ color: '#6b7280', flexShrink: 0, userSelect: 'none' }}>{time}</span>
+      <span role="cell"><LevelBadge level={entry.level} /></span>
+      <span role="cell" aria-label={`Message: ${entry.message}`} style={{ color: LEVEL_COLORS[entry.level] ?? LEVEL_COLORS.INFO }}>{messageContent}</span>
+    </div>
+  )
+}
+
+function isAtBottom(el, threshold = 40) {
+  return el.scrollHeight - el.scrollTop - el.clientHeight <= threshold
+}
+
+export default function LogsTab() {
+  const [level,       setLevel]       = useState('info')
+  const [search,      setSearch]      = useState('')
+  const [entries,     setEntries]     = useState([])
+  const [total,       setTotal]       = useState(0)
+  const [live,        setLive]        = useState(true)
+  const [loadingMore, setLoadingMore] = useState(false)
+  const [pinned,      setPinned]      = useState(true)
+  const [error,       setError]       = useState(null)
+
+  const containerRef    = useRef(null)
+  const sentinelRef     = useRef(null)
+  const scrollAnchorRef = useRef(null)
+  const levelRef      = useRef(level)
+  const lastSeqRef    = useRef(0)   // max_seq from last successful fetch; poll cursor
+  const liveRef       = useRef(live)
+
+  useEffect(() => { levelRef.current = level }, [level])
+  useEffect(() => { liveRef.current  = live  }, [live])
+
+  const scrollToBottom = useCallback(() => {
+    const el = containerRef.current
+    if (el) el.scrollTop = el.scrollHeight
+  }, [])
+
+  useEffect(() => {
+    const anchor = scrollAnchorRef.current
+    if (!anchor) return
+    const el = containerRef.current
+    if (el) el.scrollTop = el.scrollTop + (el.scrollHeight - anchor)
+    scrollAnchorRef.current = null
+  })
+
+  useEffect(() => {
+    if (pinned) scrollToBottom()
+  }, [entries, pinned, scrollToBottom])
+
+  useEffect(() => {
+    let cancelled = false
+    setEntries([])
+    setTotal(0)
+    lastSeqRef.current = 0
+    setPinned(true)
+    setError(null)
+
+    api.get(`/logs?level=${level}&limit=${INITIAL_LIMIT}&offset=0`)
+      .then(data => {
+        if (cancelled) return
+        setEntries(data.entries)
+        setTotal(data.total)
+        lastSeqRef.current = data.max_seq ?? 0
+      })
+      .catch(e => {
+        if (!cancelled) setError(e.message ?? 'Failed to load logs')
+      })
+
+    return () => { cancelled = true }
+  }, [level])
+
+  useEffect(() => {
+    const id = setInterval(async () => {
+      if (!liveRef.current) return
+      const seq = lastSeqRef.current
+      if (seq === 0) return
+      try {
+        const data = await api.get(
+          `/logs?level=${levelRef.current}&limit=${INITIAL_LIMIT}&after_seq=${seq}`
+        )
+        if (!data.entries.length) return
+        setEntries(prev => [...prev, ...data.entries])
+        setTotal(data.total)
+        lastSeqRef.current = data.max_seq
+      } catch (_) {}
+    }, 1000)
+
+    return () => clearInterval(id)
+  }, []) 
+
+  const totalRef        = useRef(0)
+  const entriesLenRef   = useRef(0)
+  useEffect(() => { totalRef.current      = total          }, [total])
+  useEffect(() => { entriesLenRef.current = entries.length }, [entries.length])
+
+  const loadOlder = useCallback(async () => {
+    if (loadingMore) return
+    const currentTotal  = totalRef.current
+    const currentLen    = entriesLenRef.current
+    const olderCount    = currentTotal - currentLen
+    if (olderCount <= 0) return
+
+    setLoadingMore(true)
+    const el = containerRef.current
+    if (el) scrollAnchorRef.current = el.scrollHeight
+
+    try {
+      const pageSize = Math.min(500, olderCount)
+      const data = await api.get(
+        `/logs?level=${levelRef.current}&limit=${pageSize}&offset=${currentLen}`
+      )
+      setEntries(prev => [...data.entries, ...prev])
+      setTotal(data.total)
+    } catch (_) {}
+    setLoadingMore(false)
+  }, [loadingMore])
+
+  useEffect(() => {
+    const sentinel  = sentinelRef.current
+    const container = containerRef.current
+    if (!sentinel || !container) return
+    const observer = new IntersectionObserver(
+      ([e]) => { if (e.isIntersecting) loadOlder() },
+      { root: container, threshold: 0 }
+    )
+    observer.observe(sentinel)
+    return () => observer.disconnect()
+  }, [loadOlder])
+
+  const handleScroll = useCallback(() => {
+    const el = containerRef.current
+    if (!el) return
+    setPinned(isAtBottom(el))
+  }, [])
+
+  const filtered = search
+    ? entries.filter(e => e.message.toLowerCase().includes(search.toLowerCase()))
+    : entries
+
+  const hasOlder = total > entries.length
+
+  return (
+    <div>
+      <div role="toolbar" aria-label="Log viewer controls" style={{ display: 'flex', alignItems: 'center', gap: 10, marginBottom: 14, flexWrap: 'wrap' }}>
+
+        <div role="group" aria-label="Minimum log level" style={{ display: 'flex', border: '1px solid var(--border)', borderRadius: 6, overflow: 'hidden' }}>
+          {LEVELS.map((l, idx) => (
+            <button
+              key={l}
+              onClick={() => setLevel(l)}
+              aria-pressed={level === l}
+              aria-label={`Show ${l} and above`}
+              style={{
+                padding: '6px 14px', fontSize: 12, cursor: 'pointer', border: 'none',
+                borderRight: idx < LEVELS.length - 1 ? '1px solid var(--border)' : 'none',
+                background: level === l ? 'var(--bg-card-hover)' : 'var(--bg-card)',
+                color: level === l ? 'var(--gold)' : 'var(--text-dim)',
+                textTransform: 'uppercase', fontFamily: 'monospace',
+                transition: 'background 0.15s, color 0.15s',
+              }}
+            >
+              {l}
+            </button>
+          ))}
+        </div>
+
+        <button
+          onClick={() => setLive(v => !v)}
+          aria-pressed={live}
+          aria-label={live ? 'Pause live log updates' : 'Resume live log updates'}
+          style={{
+            display: 'inline-flex', alignItems: 'center', gap: 6,
+            padding: '6px 14px', borderRadius: 6, fontSize: 13, cursor: 'pointer',
+            background: live ? 'rgba(80,180,80,0.12)' : 'var(--bg-card)',
+            border: `1px solid ${live ? 'rgba(80,180,80,0.4)' : 'var(--border)'}`,
+            color: live ? '#6fcf6f' : 'var(--text-dim)', transition: 'all 0.15s',
+          }}
+        >
+          {live ? <LuPause size={13} aria-hidden="true" /> : <LuPlay size={13} aria-hidden="true" />}
+          <span>{live ? 'Live' : 'Paused'}</span>
+        </button>
+
+        <div style={{ position: 'relative', flex: 1, minWidth: 180 }}>
+          <LuSearch size={13} aria-hidden="true" style={{ position: 'absolute', left: 10, top: '50%', transform: 'translateY(-50%)', color: 'var(--text-muted)', pointerEvents: 'none' }} />
+          <input
+            type="search"
+            value={search}
+            onChange={e => setSearch(e.target.value)}
+            placeholder="Search log messages…"
+            aria-label="Search log messages"
+            style={{ width: '100%', boxSizing: 'border-box', paddingLeft: 30, paddingRight: 10, paddingTop: 6, paddingBottom: 6, fontSize: 13, borderRadius: 6, background: 'var(--bg-card)', border: '1px solid var(--border)', color: 'var(--text)', outline: 'none' }}
+          />
+        </div>
+      </div>
+
+      {error && <div role="alert" style={{ marginBottom: 12, fontSize: 13, color: '#f87171' }}>{error}</div>}
+
+      <div style={{ position: 'relative' }}>
+        <div
+          ref={containerRef}
+          role="log"
+          aria-label="Application log output"
+          aria-live="polite"
+          aria-atomic="false"
+          aria-relevant="additions"
+          tabIndex={0}
+          onScroll={handleScroll}
+          style={{ background: 'var(--bg-deep)', border: '1px solid var(--border)', borderRadius: 8, height: 480, overflowY: 'auto', overflowX: 'hidden', outline: 'none' }}
+          onFocus={e => { e.currentTarget.style.boxShadow = '0 0 0 2px var(--gold)' }}
+          onBlur={e => { e.currentTarget.style.boxShadow = 'none' }}
+        >
+          <div ref={sentinelRef} style={{ height: 1 }} aria-hidden="true" />
+
+          {loadingMore && (
+            <div role="status" aria-label="Loading older log entries" style={{ padding: '6px 12px', fontSize: 11, color: 'var(--text-muted)', fontFamily: 'monospace' }}>
+              Loading older entries…
+            </div>
+          )}
+
+          {hasOlder && !loadingMore && (
+            <div aria-label={`${total - entries.length} older entries not yet loaded`} style={{ padding: '4px 12px', fontSize: 11, color: 'var(--text-muted)', fontFamily: 'monospace', borderBottom: '1px solid rgba(255,255,255,0.05)' }}>
+              ↑ {total - entries.length} older entries — scroll up to load more
+            </div>
+          )}
+
+          {filtered.length === 0 ? (
+            <div role="status" style={{ padding: 24, fontSize: 13, color: 'var(--text-muted)', textAlign: 'center' }}>
+              {search
+                ? `No entries matching "${search}"`
+                : <span>No log entries at <span style={{ fontFamily: 'monospace', textTransform: 'uppercase' }}>{level}</span> level or above.</span>
+              }
+            </div>
+          ) : (
+            <div role="rowgroup">
+              {filtered.map((e, i) => <LogRow key={`${e.timestamp}-${i}`} entry={e} searchQuery={search} />)}
+            </div>
+          )}
+        </div>
+
+        {!pinned && (
+          <button
+            onClick={() => { setPinned(true); scrollToBottom() }}
+            aria-label="Scroll to bottom and resume auto-scroll"
+            style={{ position: 'absolute', bottom: 12, right: 12, display: 'inline-flex', alignItems: 'center', gap: 5, padding: '5px 12px', borderRadius: 20, fontSize: 12, cursor: 'pointer', background: 'var(--bg-card)', border: '1px solid var(--border)', color: 'var(--text-dim)', boxShadow: '0 2px 8px rgba(0,0,0,0.4)', transition: 'background 0.15s' }}
+            onMouseEnter={e => { e.currentTarget.style.background = 'var(--bg-card-hover)' }}
+            onMouseLeave={e => { e.currentTarget.style.background = 'var(--bg-card)' }}
+          >
+            <LuArrowDown size={12} aria-hidden="true" />
+            Jump to latest
+          </button>
+        )}
+      </div>
+    </div>
+  )
+}

--- a/frontend/src/components/settings/MaintenanceTab.jsx
+++ b/frontend/src/components/settings/MaintenanceTab.jsx
@@ -1,5 +1,5 @@
 import { useState, useEffect } from 'react'
-import { LuTrash2, LuCircleCheck, LuRefreshCw } from 'react-icons/lu'
+import { LuTrash2, LuCircleCheck, LuRefreshCw, LuSquare } from 'react-icons/lu'
 import api, { settings as settingsApi } from '../../api'
 import Spinner from '../Spinner'
 
@@ -17,6 +17,7 @@ function RescanSection() {
     new_books: 0, new_maps: 0, new_tokens: 0,
   })
   const [lastResult, setLastResult] = useState(null)
+  const [stopping, setStopping] = useState(false)
 
   useEffect(() => {
     const poll = () => {
@@ -37,8 +38,14 @@ function RescanSection() {
   const handleRescan = async () => {
     if (status.running) return
     setLastResult(null)
+    setStopping(false)
     setStatus(s => ({ ...s, running: true, phase: 'scanning' }))
     try { await api.post('/rescan') } catch (_) { setStatus(s => ({ ...s, running: false, phase: null })) }
+  }
+
+  const handleStop = async () => {
+    setStopping(true)
+    try { await api.post('/cancel-scan') } catch (_) {}
   }
 
   const { running, phase, indexed, to_index,
@@ -61,20 +68,39 @@ function RescanSection() {
       <p style={{ fontSize: 14, color: 'var(--text-dim)', marginBottom: 20, lineHeight: 1.6 }}>
         Scan the library directory for new or changed files and update the search index.
       </p>
-      <button
-        onClick={handleRescan}
-        disabled={running}
-        style={{
-          display: 'inline-flex', alignItems: 'center', gap: 8,
-          padding: '8px 18px', borderRadius: 6, fontSize: 14, fontWeight: 500,
-          background: 'var(--bg-card)', border: '1px solid var(--border)',
-          color: running ? 'var(--gold)' : 'var(--text-dim)',
-          cursor: running ? 'default' : 'pointer',
-        }}
-      >
-        {running ? <Spinner size={13} /> : <LuRefreshCw size={13} />}
-        {running ? phaseLabel : 'Rescan Library'}
-      </button>
+      <div style={{ display: 'flex', alignItems: 'center', gap: 8 }}>
+        <button
+          onClick={handleRescan}
+          disabled={running}
+          style={{
+            display: 'inline-flex', alignItems: 'center', gap: 8,
+            padding: '8px 18px', borderRadius: 6, fontSize: 14, fontWeight: 500,
+            background: 'var(--bg-card)', border: '1px solid var(--border)',
+            color: running ? 'var(--gold)' : 'var(--text-dim)',
+            cursor: running ? 'default' : 'pointer',
+          }}
+        >
+          {running ? <Spinner size={13} /> : <LuRefreshCw size={13} />}
+          {running ? phaseLabel : 'Rescan Library'}
+        </button>
+        {running && (
+          <button
+            onClick={handleStop}
+            disabled={stopping}
+            title="Stop scan"
+            style={{
+              display: 'inline-flex', alignItems: 'center', gap: 6,
+              padding: '8px 14px', borderRadius: 6, fontSize: 14, fontWeight: 500,
+              background: 'rgba(180,60,60,0.12)', border: '1px solid rgba(180,60,60,0.35)',
+              color: stopping ? 'var(--text-muted)' : '#e07070',
+              cursor: stopping ? 'default' : 'pointer',
+            }}
+          >
+            <LuSquare size={13} />
+            {stopping ? 'Stopping…' : 'Stop'}
+          </button>
+        )}
+      </div>
 
       {/* Progress bar — scanning phase */}
       {running && phase === 'scanning' && (

--- a/frontend/src/components/settings/MaintenanceTab.test.jsx
+++ b/frontend/src/components/settings/MaintenanceTab.test.jsx
@@ -1,0 +1,115 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { render, screen, fireEvent, waitFor } from '@testing-library/react'
+import MaintenanceTab from './MaintenanceTab'
+
+vi.mock('../../api', () => ({
+  default: {
+    get: vi.fn(),
+    post: vi.fn(),
+  },
+  settings: {
+    get: vi.fn(),
+    patch: vi.fn(),
+  },
+}))
+
+import api, { settings as settingsApi } from '../../api'
+
+const idleStatus = {
+  running: false, phase: null,
+  total_books: 0, scanned_books: 0,
+  total_maps: 0, scanned_maps: 0,
+  total_tokens: 0, scanned_tokens: 0,
+  indexed: 0, to_index: 0,
+  new_books: 0, new_maps: 0, new_tokens: 0,
+}
+
+const scanningStatus = {
+  ...idleStatus,
+  running: true, phase: 'scanning',
+  total_books: 10, scanned_books: 3,
+}
+
+const indexingStatus = {
+  ...idleStatus,
+  running: true, phase: 'indexing',
+  to_index: 20, indexed: 5,
+}
+
+beforeEach(() => {
+  vi.resetAllMocks()
+  api.get.mockResolvedValue(idleStatus)
+  api.post.mockResolvedValue({})
+  settingsApi.get.mockResolvedValue({
+    rescan_schedule_enabled: false,
+    rescan_schedule_interval: 'daily',
+    rescan_schedule_hour: 2,
+    rescan_schedule_minute: 0,
+    rescan_schedule_weekday: 0,
+  })
+})
+
+describe('MaintenanceTab — RescanSection', () => {
+  it('renders the Rescan Library button when idle', () => {
+    render(<MaintenanceTab />)
+    expect(screen.getByRole('button', { name: /rescan library/i })).toBeInTheDocument()
+  })
+
+  it('does not show Stop button when scan is not running', () => {
+    render(<MaintenanceTab />)
+    expect(screen.queryByRole('button', { name: /stop/i })).not.toBeInTheDocument()
+  })
+
+  it('shows Stop button while a scan is running', async () => {
+    api.get.mockResolvedValue(scanningStatus)
+    render(<MaintenanceTab />)
+    await waitFor(() => {
+      expect(screen.getByRole('button', { name: /stop/i })).toBeInTheDocument()
+    })
+  })
+
+  it('calls /cancel-scan when Stop is clicked', async () => {
+    api.get.mockResolvedValue(scanningStatus)
+    render(<MaintenanceTab />)
+    const stopBtn = await screen.findByRole('button', { name: /stop/i })
+    fireEvent.click(stopBtn)
+    await waitFor(() => {
+      expect(api.post).toHaveBeenCalledWith('/cancel-scan')
+    })
+  })
+
+  it('shows "Stopping…" after Stop is clicked', async () => {
+    api.get.mockResolvedValue(scanningStatus)
+    api.post.mockImplementation(() => new Promise(() => {})) // never resolves
+    render(<MaintenanceTab />)
+    const stopBtn = await screen.findByRole('button', { name: /stop/i })
+    fireEvent.click(stopBtn)
+    await waitFor(() => {
+      expect(screen.getByText('Stopping…')).toBeInTheDocument()
+    })
+  })
+
+  it('shows scanning phase label while scanning', async () => {
+    api.get.mockResolvedValue(scanningStatus)
+    render(<MaintenanceTab />)
+    await waitFor(() => {
+      expect(screen.getByText(/scanning/i)).toBeInTheDocument()
+    })
+  })
+
+  it('shows indexing phase label while indexing', async () => {
+    api.get.mockResolvedValue(indexingStatus)
+    render(<MaintenanceTab />)
+    await waitFor(() => {
+      expect(screen.getByText(/indexing pdfs/i)).toBeInTheDocument()
+    })
+  })
+
+  it('calls /rescan when Rescan Library is clicked', async () => {
+    render(<MaintenanceTab />)
+    fireEvent.click(screen.getByRole('button', { name: /rescan library/i }))
+    await waitFor(() => {
+      expect(api.post).toHaveBeenCalledWith('/rescan')
+    })
+  })
+})

--- a/frontend/src/views/SettingsView.jsx
+++ b/frontend/src/views/SettingsView.jsx
@@ -4,12 +4,14 @@ import UsersTab from '../components/settings/UsersTab'
 import MaintenanceTab from '../components/settings/MaintenanceTab'
 import UserSettingsTab from '../components/settings/UserSettingsTab'
 import AppSettingsTab from '../components/settings/AppSettingsTab'
+import LogsTab from '../components/settings/LogsTab'
 
 const ADMIN_TABS = [
   { key: 'account',     label: 'Account'     },
   { key: 'users',       label: 'Users'       },
   { key: 'application', label: 'Application' },
   { key: 'maintenance', label: 'Maintenance' },
+  { key: 'logs',        label: 'Logs'        },
 ]
 
 const USER_TABS = [
@@ -48,6 +50,7 @@ export default function SettingsView({ user, onLogout }) {
       {tab === 'users'       && isAdmin && <UsersTab />}
       {tab === 'application' && isAdmin && <AppSettingsTab />}
       {tab === 'maintenance' && isAdmin && <MaintenanceTab />}
+      {tab === 'logs'        && isAdmin && <LogsTab />}
     </div>
   )
 }

--- a/tests/test_indexer_resilience.py
+++ b/tests/test_indexer_resilience.py
@@ -277,3 +277,126 @@ class TestGetSizeGuard:
             db.close()
 
         assert isinstance(stats, dict)
+
+
+# ---------------------------------------------------------------------------
+# scan_library — should_stop callback
+# ---------------------------------------------------------------------------
+
+
+class TestShouldStop:
+    def _books_dir(self, lib: Path, system_folder: str) -> Path:
+        d = lib / "books" / system_folder
+        d.mkdir(parents=True, exist_ok=True)
+        return d
+
+    def test_scan_aborts_books_when_stop_requested(self):
+        """should_stop returning True after the first book causes an early return."""
+        tmp, lib = _mk_lib()
+        folder = self._books_dir(lib, "StopSystem")
+        for i in range(5):
+            (folder / f"book{i}.pdf").write_bytes(b"%PDF-1.4")
+
+        calls = [0]
+
+        def stop_after_one():
+            calls[0] += 1
+            return calls[0] > 1
+
+        db = SessionLocal()
+        try:
+            with patch("backend.indexer.generate_thumbnail", return_value=False):
+                with patch("backend.indexer._fitz_open_with_timeout") as mock_fitz:
+                    mock_doc = MagicMock()
+                    mock_doc.__len__ = lambda _: 1
+                    mock_fitz.return_value = mock_doc
+                    stats = scan_library(str(lib), tmp, db, should_stop=stop_after_one)
+        finally:
+            db.close()
+
+        assert stats["new_books"] < 5
+
+    def test_scan_processes_all_files_when_stop_never_requested(self):
+        """should_stop always returning False lets the full scan complete."""
+        tmp, lib = _mk_lib()
+        folder = self._books_dir(lib, "NoStopSystem")
+        for i in range(3):
+            (folder / f"book{i}.pdf").write_bytes(b"%PDF-1.4")
+
+        db = SessionLocal()
+        try:
+            with patch("backend.indexer.generate_thumbnail", return_value=False):
+                with patch("backend.indexer._fitz_open_with_timeout") as mock_fitz:
+                    mock_doc = MagicMock()
+                    mock_doc.__len__ = lambda _: 1
+                    mock_fitz.return_value = mock_doc
+                    stats = scan_library(str(lib), tmp, db, should_stop=lambda: False)
+        finally:
+            db.close()
+
+        assert stats["new_books"] == 3
+
+    def test_scan_aborts_maps_when_stop_requested(self):
+        """Stop during maps phase returns early from that loop."""
+        tmp, lib = _mk_lib()
+        maps_dir = lib / "maps" / "StopMaps"
+        maps_dir.mkdir(parents=True)
+        for i in range(4):
+            (maps_dir / f"map{i}.png").write_bytes(b"\x89PNG")
+
+        calls = [0]
+
+        def stop_after_one():
+            calls[0] += 1
+            return calls[0] > 1
+
+        db = SessionLocal()
+        try:
+            with patch("backend.indexer.generate_thumbnail", return_value=False):
+                stats = scan_library(str(lib), tmp, db, should_stop=stop_after_one)
+        finally:
+            db.close()
+
+        assert stats["new_maps"] < 4
+
+    def test_scan_aborts_tokens_when_stop_requested(self):
+        """Stop during tokens phase returns early from that loop."""
+        tmp, lib = _mk_lib()
+        tokens_dir = lib / "tokens" / "StopTokens"
+        tokens_dir.mkdir(parents=True)
+        for i in range(4):
+            (tokens_dir / f"token{i}.png").write_bytes(b"\x89PNG")
+
+        calls = [0]
+
+        def stop_after_one():
+            calls[0] += 1
+            return calls[0] > 1
+
+        db = SessionLocal()
+        try:
+            with patch("backend.indexer.generate_thumbnail", return_value=False):
+                stats = scan_library(str(lib), tmp, db, should_stop=stop_after_one)
+        finally:
+            db.close()
+
+        assert stats["new_tokens"] < 4
+
+    def test_scan_without_should_stop_completes_normally(self):
+        """Omitting should_stop entirely runs the full scan with no errors."""
+        tmp, lib = _mk_lib()
+        folder = self._books_dir(lib, "NormalSystem")
+        (folder / "book.pdf").write_bytes(b"%PDF-1.4")
+
+        db = SessionLocal()
+        try:
+            with patch("backend.indexer.generate_thumbnail", return_value=False):
+                with patch("backend.indexer._fitz_open_with_timeout") as mock_fitz:
+                    mock_doc = MagicMock()
+                    mock_doc.__len__ = lambda _: 1
+                    mock_fitz.return_value = mock_doc
+                    stats = scan_library(str(lib), tmp, db)
+        finally:
+            db.close()
+
+        assert isinstance(stats, dict)

--- a/tests/test_library.py
+++ b/tests/test_library.py
@@ -121,3 +121,43 @@ class TestRescan:
     def test_unauthenticated_cannot_rescan(self, client):
         resp = client.post("/api/rescan")
         assert resp.status_code == 401
+
+
+class TestCancelScan:
+    def test_cancel_when_not_running_returns_not_running(self, client, admin_headers):
+        # Ensure no scan is running
+        from backend.routers.library import _helpers
+        _helpers._scan_status["running"] = False
+        resp = client.post("/api/cancel-scan", headers=admin_headers)
+        assert resp.status_code == 200
+        assert resp.json()["status"] == "not_running"
+
+    def test_cancel_while_running_returns_stop_requested(self, client, admin_headers):
+        from backend.routers.library import _helpers
+        _helpers._scan_status["running"] = True
+        try:
+            resp = client.post("/api/cancel-scan", headers=admin_headers)
+            assert resp.status_code == 200
+            assert resp.json()["status"] == "stop_requested"
+            assert _helpers.is_stop_requested() is True
+        finally:
+            _helpers._scan_status["running"] = False
+            _helpers.clear_stop()
+
+    def test_gm_can_cancel_scan(self, client, gm_headers):
+        from backend.routers.library import _helpers
+        _helpers._scan_status["running"] = True
+        try:
+            resp = client.post("/api/cancel-scan", headers=gm_headers)
+            assert resp.status_code == 200
+        finally:
+            _helpers._scan_status["running"] = False
+            _helpers.clear_stop()
+
+    def test_player_cannot_cancel_scan(self, client, player_headers):
+        resp = client.post("/api/cancel-scan", headers=player_headers)
+        assert resp.status_code == 403
+
+    def test_unauthenticated_cannot_cancel_scan(self, client):
+        resp = client.post("/api/cancel-scan")
+        assert resp.status_code == 401

--- a/tests/test_library.py
+++ b/tests/test_library.py
@@ -100,19 +100,27 @@ class TestScanStatus:
         ):
             assert isinstance(body[field], int), f"{field} should be int"
 
-    def test_player_can_view_scan_status(self, client, player_headers):
+    def test_player_cannot_view_scan_status(self, client, player_headers):
         resp = client.get("/api/scan-status", headers=player_headers)
-        assert resp.status_code == 200
+        assert resp.status_code == 403
+
+    def test_gm_cannot_view_scan_status(self, client, gm_headers):
+        resp = client.get("/api/scan-status", headers=gm_headers)
+        assert resp.status_code == 403
+
+    def test_unauthenticated_cannot_view_scan_status(self, client):
+        resp = client.get("/api/scan-status")
+        assert resp.status_code == 401
 
 
 class TestRescan:
-    def test_gm_can_trigger_rescan(self, client, gm_headers):
-        resp = client.post("/api/rescan", headers=gm_headers)
-        assert resp.status_code == 200
-
     def test_admin_can_trigger_rescan(self, client, admin_headers):
         resp = client.post("/api/rescan", headers=admin_headers)
         assert resp.status_code == 200
+
+    def test_gm_cannot_trigger_rescan(self, client, gm_headers):
+        resp = client.post("/api/rescan", headers=gm_headers)
+        assert resp.status_code == 403
 
     def test_player_cannot_trigger_rescan(self, client, player_headers):
         resp = client.post("/api/rescan", headers=player_headers)
@@ -144,15 +152,9 @@ class TestCancelScan:
             _helpers._scan_status["running"] = False
             _helpers.clear_stop()
 
-    def test_gm_can_cancel_scan(self, client, gm_headers):
-        from backend.routers.library import _helpers
-        _helpers._scan_status["running"] = True
-        try:
-            resp = client.post("/api/cancel-scan", headers=gm_headers)
-            assert resp.status_code == 200
-        finally:
-            _helpers._scan_status["running"] = False
-            _helpers.clear_stop()
+    def test_gm_cannot_cancel_scan(self, client, gm_headers):
+        resp = client.post("/api/cancel-scan", headers=gm_headers)
+        assert resp.status_code == 403
 
     def test_player_cannot_cancel_scan(self, client, player_headers):
         resp = client.post("/api/cancel-scan", headers=player_headers)

--- a/tests/test_logs.py
+++ b/tests/test_logs.py
@@ -1,0 +1,223 @@
+"""Tests for the /api/logs endpoint."""
+import logging
+import pytest
+
+
+class TestLogsAccess:
+    def test_admin_can_access_logs(self, client, admin_headers):
+        resp = client.get("/api/logs", headers=admin_headers)
+        assert resp.status_code == 200
+
+    def test_gm_cannot_access_logs(self, client, gm_headers):
+        resp = client.get("/api/logs", headers=gm_headers)
+        assert resp.status_code == 403
+
+    def test_player_cannot_access_logs(self, client, player_headers):
+        resp = client.get("/api/logs", headers=player_headers)
+        assert resp.status_code == 403
+
+    def test_unauthenticated_cannot_access_logs(self, client):
+        resp = client.get("/api/logs")
+        assert resp.status_code == 401
+
+
+class TestLogsResponseShape:
+    def test_response_has_required_fields(self, client, admin_headers):
+        resp = client.get("/api/logs", headers=admin_headers)
+        body = resp.json()
+        assert "entries" in body
+        assert "total" in body
+        assert "max_seq" in body
+        assert "level" in body
+        assert "limit" in body
+        assert "offset" in body
+
+    def test_max_seq_is_non_negative_int(self, client, admin_headers):
+        resp = client.get("/api/logs", headers=admin_headers)
+        body = resp.json()
+        assert isinstance(body["max_seq"], int)
+        assert body["max_seq"] >= 0
+
+    def test_after_seq_returns_only_newer_entries(self, client, admin_headers):
+        # Get current max_seq
+        resp1 = client.get("/api/logs?level=info&limit=500", headers=admin_headers)
+        seq = resp1.json()["max_seq"]
+        # Emit a known new entry
+        logging.getLogger("grimoire").info("after_seq test marker")
+        # Poll with after_seq
+        resp2 = client.get(f"/api/logs?level=info&after_seq={seq}", headers=admin_headers)
+        body = resp2.json()
+        assert resp2.status_code == 200
+        assert len(body["entries"]) >= 1
+        assert any("after_seq test marker" in e["message"] for e in body["entries"])
+        # All returned entries must have seq > the cursor
+        for e in body["entries"]:
+            assert e["seq"] > seq
+
+    def test_after_seq_only_returns_entries_after_cursor(self, client, admin_headers):
+        # Any entries returned must have seq strictly greater than the cursor
+        resp1 = client.get("/api/logs?level=info&limit=500", headers=admin_headers)
+        seq = resp1.json()["max_seq"]
+        resp2 = client.get(f"/api/logs?level=info&after_seq={seq}", headers=admin_headers)
+        assert resp2.status_code == 200
+        for entry in resp2.json()["entries"]:
+            assert entry["seq"] > seq
+
+    def test_entries_is_list(self, client, admin_headers):
+        resp = client.get("/api/logs", headers=admin_headers)
+        assert isinstance(resp.json()["entries"], list)
+
+    def test_total_is_non_negative_int(self, client, admin_headers):
+        resp = client.get("/api/logs", headers=admin_headers)
+        body = resp.json()
+        assert isinstance(body["total"], int)
+        assert body["total"] >= 0
+
+    def test_entry_fields(self, client, admin_headers):
+        # Emit a known log entry so at least one exists
+        logging.getLogger("grimoire").info("test_entry_fields probe")
+        resp = client.get("/api/logs?level=info&limit=500", headers=admin_headers)
+        entries = resp.json()["entries"]
+        assert len(entries) > 0
+        entry = entries[-1]
+        assert "seq" in entry
+        assert "timestamp" in entry
+        assert "level" in entry
+        assert "logger" in entry
+        assert "message" in entry
+        assert isinstance(entry["seq"], int)
+        assert entry["seq"] > 0
+
+    def test_timestamp_format(self, client, admin_headers):
+        logging.getLogger("grimoire").info("timestamp format probe")
+        resp = client.get("/api/logs?level=info&limit=500", headers=admin_headers)
+        entries = resp.json()["entries"]
+        assert len(entries) > 0
+        ts = entries[-1]["timestamp"]
+        # Should end with Z and contain T separator
+        assert ts.endswith("Z")
+        assert "T" in ts
+
+
+class TestLogsLevelFilter:
+    def test_default_level_is_info(self, client, admin_headers):
+        resp = client.get("/api/logs", headers=admin_headers)
+        assert resp.json()["level"] == "info"
+
+    def test_debug_level_accepted(self, client, admin_headers):
+        resp = client.get("/api/logs?level=debug", headers=admin_headers)
+        assert resp.status_code == 200
+        assert resp.json()["level"] == "debug"
+
+    def test_warning_level_accepted(self, client, admin_headers):
+        resp = client.get("/api/logs?level=warning", headers=admin_headers)
+        assert resp.status_code == 200
+
+    def test_error_level_accepted(self, client, admin_headers):
+        resp = client.get("/api/logs?level=error", headers=admin_headers)
+        assert resp.status_code == 200
+
+    def test_critical_level_accepted(self, client, admin_headers):
+        resp = client.get("/api/logs?level=critical", headers=admin_headers)
+        assert resp.status_code == 200
+
+    def test_invalid_level_rejected(self, client, admin_headers):
+        resp = client.get("/api/logs?level=verbose", headers=admin_headers)
+        assert resp.status_code == 422
+
+    def test_debug_returns_more_than_info(self, client, admin_headers):
+        """DEBUG level should return >= entries compared to INFO level."""
+        logging.getLogger("grimoire").debug("debug-only probe for filter test")
+        logging.getLogger("grimoire").info("info probe for filter test")
+
+        debug_resp = client.get("/api/logs?level=debug&limit=2000", headers=admin_headers)
+        info_resp  = client.get("/api/logs?level=info&limit=2000",  headers=admin_headers)
+
+        debug_total = debug_resp.json()["total"]
+        info_total  = info_resp.json()["total"]
+        assert debug_total >= info_total
+
+    def test_info_entries_contain_no_debug(self, client, admin_headers):
+        """Entries returned at INFO level must not include DEBUG-level entries."""
+        resp = client.get("/api/logs?level=info&limit=2000", headers=admin_headers)
+        for entry in resp.json()["entries"]:
+            assert entry["level"] != "DEBUG"
+
+    def test_error_entries_only_contain_error_or_above(self, client, admin_headers):
+        resp = client.get("/api/logs?level=error&limit=2000", headers=admin_headers)
+        allowed = {"ERROR", "CRITICAL"}
+        for entry in resp.json()["entries"]:
+            assert entry["level"] in allowed
+
+
+class TestLogsPagination:
+    def test_limit_param(self, client, admin_headers):
+        # Ensure enough log entries exist
+        log = logging.getLogger("grimoire")
+        for i in range(10):
+            log.info(f"pagination test probe {i}")
+
+        resp = client.get("/api/logs?level=debug&limit=5", headers=admin_headers)
+        body = resp.json()
+        assert body["limit"] == 5
+        assert len(body["entries"]) <= 5
+
+    def test_offset_param(self, client, admin_headers):
+        resp_no_offset = client.get("/api/logs?level=debug&limit=10&offset=0", headers=admin_headers)
+        resp_offset    = client.get("/api/logs?level=debug&limit=10&offset=5", headers=admin_headers)
+
+        entries_no = resp_no_offset.json()["entries"]
+        entries_of = resp_offset.json()["entries"]
+        # They should differ (assuming enough entries exist)
+        if entries_no and entries_of:
+            assert entries_no != entries_of
+
+    def test_limit_too_large_rejected(self, client, admin_headers):
+        resp = client.get("/api/logs?limit=99999", headers=admin_headers)
+        assert resp.status_code == 422
+
+    def test_limit_zero_rejected(self, client, admin_headers):
+        resp = client.get("/api/logs?limit=0", headers=admin_headers)
+        assert resp.status_code == 422
+
+    def test_negative_offset_rejected(self, client, admin_headers):
+        resp = client.get("/api/logs?offset=-1", headers=admin_headers)
+        assert resp.status_code == 422
+
+
+class TestMemoryHandler:
+    def test_buffer_captures_info(self):
+        from backend.config import _memory_handler
+        initial = _memory_handler.get_total(min_level=logging.INFO)
+        logging.getLogger("grimoire").info("memory handler capture test")
+        after = _memory_handler.get_total(min_level=logging.INFO)
+        assert after > initial
+
+    def test_buffer_captures_debug(self):
+        from backend.config import _memory_handler
+        initial = _memory_handler.get_total(min_level=logging.DEBUG)
+        logging.getLogger("grimoire").debug("memory handler debug capture test")
+        after = _memory_handler.get_total(min_level=logging.DEBUG)
+        assert after > initial
+
+    def test_get_entries_respects_min_level(self):
+        from backend.config import _memory_handler
+        logging.getLogger("grimoire").debug("level-filter debug entry")
+        logging.getLogger("grimoire").info("level-filter info entry")
+
+        debug_entries, _ = _memory_handler.get_entries(min_level=logging.DEBUG, limit=2000)
+        info_entries,  _ = _memory_handler.get_entries(min_level=logging.INFO,  limit=2000)
+
+        assert len(debug_entries) >= len(info_entries)
+
+    def test_entries_have_correct_structure(self):
+        from backend.config import _memory_handler
+        logging.getLogger("grimoire").info("structure check probe")
+        entries, max_seq = _memory_handler.get_entries(min_level=logging.INFO, limit=10)
+        assert len(entries) > 0
+        e = entries[-1]
+        assert set(e.keys()) == {"seq", "timestamp", "level", "logger", "message"}
+        assert isinstance(e["seq"], int)
+        assert e["seq"] > 0
+        assert isinstance(max_seq, int)
+        assert max_seq > 0


### PR DESCRIPTION
Add scan cancellation that is able to interrupt long-running PDF operations (thumbnail generation, text extraction) within 500ms of a stop request rather than waiting for the current file to finish.

Adds a Logs tab to Settings (admin only) with a real-time log viewer supporting level filtering (debug/info/warning/error/critical), message search, live polling via a sequence-number cursor, and bottom-pinned auto-scroll with infinite scroll upward for history. Console/Docker log verbosity is controlled by the LOG_LEVEL environment variable while the in-app viewer always captures debug-level entries regardless of that setting.