### PR TITLE
Add reading progress and recently opened books

### DIFF
--- a/frontend/src/components/system/BookRow.jsx
+++ b/frontend/src/components/system/BookRow.jsx
@@ -3,11 +3,17 @@ import { LuChevronRight, LuFileText, LuHeart, LuPencil } from 'react-icons/lu'
 import { mediaUrl } from '../../api'
 import { CATEGORY_ICONS } from '../../constants'
 import { useFavorites } from '../../context/FavoritesContext'
+import { getBookPrefs } from '../../hooks/useBookPrefs'
 
 export default function BookRow({ book, onOpen, onEdit, editing }) {
   const [hovered, setHovered] = useState(false)
   const { isFavorite, toggleFavorite } = useFavorites()
   const CatIcon = CATEGORY_ICONS[book.category] || LuFileText
+
+  const lastPage = getBookPrefs(book.id).page || 0
+  const progress = book.page_count > 0 && lastPage > 1
+    ? Math.min(lastPage / book.page_count, 1)
+    : 0
 
   return (
     <div
@@ -22,9 +28,16 @@ export default function BookRow({ book, onOpen, onEdit, editing }) {
         display: 'flex', alignItems: 'center', gap: 16, padding: '12px 16px',
         background: hovered ? 'var(--bg-card-hover)' : 'var(--bg-card)',
         border: '1px solid var(--border)', borderRadius: 8, cursor: 'pointer',
-        transition: 'background 0.15s',
+        transition: 'background 0.15s', position: 'relative', overflow: 'hidden',
       }}
     >
+      {/* Reading progress bar at bottom of card */}
+      {progress > 0 && (
+        <div style={{ position: 'absolute', bottom: 0, left: 0, right: 0, height: 2, background: 'var(--bg-deep)' }}>
+          <div style={{ width: `${progress * 100}%`, height: '100%', background: 'var(--gold-dim)', transition: 'width 0.3s' }} />
+        </div>
+      )}
+
       <div style={{
         width: 36, height: 48, borderRadius: 4, overflow: 'hidden', flexShrink: 0,
         background: 'var(--bg-deep)', display: 'flex', alignItems: 'center', justifyContent: 'center',
@@ -41,6 +54,11 @@ export default function BookRow({ book, onOpen, onEdit, editing }) {
         </div>
         <div style={{ fontSize: 13, color: 'var(--text-muted)', display: 'flex', flexWrap: 'wrap', gap: 6, marginTop: 4, alignItems: 'center' }}>
           {book.page_count > 0 && <span>{book.page_count} pages</span>}
+          {progress > 0 && (
+            <span style={{ color: 'var(--gold-dim)' }}>
+              p. {lastPage}
+            </span>
+          )}
           {book.year && <span>{book.year}</span>}
           {book.publisher && <span>{book.publisher}</span>}
           {book.is_explicit && (
@@ -58,6 +76,11 @@ export default function BookRow({ book, onOpen, onEdit, editing }) {
               index failed
             </span>
           )}
+          {(book.tags || []).map(tag => (
+            <span key={tag} style={{ fontSize: 11, padding: '1px 7px', borderRadius: 8, background: 'rgba(201,168,76,0.12)', border: '1px solid var(--gold-dim)', color: 'var(--gold)' }}>
+              {tag.charAt(0).toUpperCase() + tag.slice(1)}
+            </span>
+          ))}
         </div>
       </div>
 

--- a/frontend/src/hooks/useBookPrefs.js
+++ b/frontend/src/hooks/useBookPrefs.js
@@ -22,3 +22,23 @@ export function getBookPrefs(bookId) {
 export function saveBookPrefs(bookId, updates) {
   write(bookId, updates)
 }
+
+const RECENT_KEY = 'grimoire:recently-opened'
+const RECENT_MAX = 10
+
+export function saveRecentBook(book) {
+  try {
+    const list = getRecentBooks().filter(b => b.id !== book.id)
+    list.unshift({ id: book.id, title: book.title, has_thumbnail: book.has_thumbnail, page_count: book.page_count, openedAt: Date.now() })
+    localStorage.setItem(RECENT_KEY, JSON.stringify(list.slice(0, RECENT_MAX)))
+  } catch {}
+}
+
+export function getRecentBooks() {
+  try {
+    const raw = localStorage.getItem(RECENT_KEY)
+    return raw ? JSON.parse(raw) : []
+  } catch {
+    return []
+  }
+}

--- a/frontend/src/views/LibraryView.jsx
+++ b/frontend/src/views/LibraryView.jsx
@@ -5,6 +5,7 @@ import Spinner from '../components/Spinner'
 import Tag from '../components/Tag'
 import FavoriteButton from '../components/FavoriteButton'
 import { getUserPrefs } from '../hooks/useUserPrefs'
+import { getRecentBooks, getBookPrefs } from '../hooks/useBookPrefs'
 
 function SystemCard({ system, onClick, compact }) {
   const [hovered, setHovered] = useState(false)
@@ -145,9 +146,62 @@ export default function LibraryView() {
 
   const compact = cardSize === 'compact'
   const minCard = compact ? '130px' : '220px'
+  const recentBooks = getRecentBooks()
 
   return (
     <div className="fade-in" style={{ padding: '32px 40px', maxWidth: 1400, width: '100%', margin: '0 auto', boxSizing: 'border-box' }}>
+
+      {/* Recently Opened */}
+      {recentBooks.length > 0 && (
+        <div style={{ marginBottom: 40 }}>
+          <h3 style={{ fontSize: 16, color: 'var(--text-dim)', fontWeight: 500, marginBottom: 12, letterSpacing: '0.05em', textTransform: 'uppercase' }}>
+            Recently Opened
+          </h3>
+          <div style={{ display: 'flex', gap: 10, flexWrap: 'wrap' }}>
+            {recentBooks.map(book => {
+              const lastPage = getBookPrefs(book.id).page || 1
+              const progress = book.page_count > 0 ? Math.min(lastPage / book.page_count, 1) : 0
+              return (
+                <div
+                  key={book.id}
+                  onClick={() => navigate(`/library/book/${book.id}?page=${lastPage}`)}
+                  style={{
+                    display: 'flex', alignItems: 'center', gap: 10,
+                    background: 'var(--bg-card)', border: '1px solid var(--border)',
+                    borderRadius: 8, padding: '8px 12px', cursor: 'pointer',
+                    maxWidth: 260, position: 'relative', overflow: 'hidden',
+                  }}
+                  onMouseEnter={e => e.currentTarget.style.background = 'var(--bg-card-hover)'}
+                  onMouseLeave={e => e.currentTarget.style.background = 'var(--bg-card)'}
+                >
+                  {progress > 0 && (
+                    <div style={{ position: 'absolute', bottom: 0, left: 0, right: 0, height: 2, background: 'var(--bg-deep)' }}>
+                      <div style={{ width: `${progress * 100}%`, height: '100%', background: 'var(--gold-dim)' }} />
+                    </div>
+                  )}
+                  <div style={{ width: 28, height: 36, borderRadius: 3, overflow: 'hidden', flexShrink: 0, background: 'var(--bg-deep)', display: 'flex', alignItems: 'center', justifyContent: 'center' }}>
+                    {book.has_thumbnail
+                      ? <img src={mediaUrl(`/books/${book.id}/thumbnail`)} alt="" style={{ width: '100%', height: '100%', objectFit: 'cover' }} />
+                      : <span style={{ fontSize: 14, color: 'var(--text-muted)' }}>📄</span>
+                    }
+                  </div>
+                  <div style={{ minWidth: 0 }}>
+                    <div style={{ fontSize: 13, fontWeight: 500, overflow: 'hidden', textOverflow: 'ellipsis', whiteSpace: 'nowrap', maxWidth: 180 }}>
+                      {book.title}
+                    </div>
+                    {progress > 0 && (
+                      <div style={{ fontSize: 11, color: 'var(--gold-dim)', marginTop: 2 }}>
+                        p. {lastPage}{book.page_count > 0 ? ` / ${book.page_count}` : ''}
+                      </div>
+                    )}
+                  </div>
+                </div>
+              )
+            })}
+          </div>
+        </div>
+      )}
+
       <div style={{ marginBottom: 32 }}>
         <h2 style={{ fontSize: 28, marginBottom: 8 }}>Your Collection</h2>
         <p style={{ color: 'var(--text-dim)', fontSize: 17, fontFamily: 'Alegreya, serif', fontStyle: 'italic' }}>

--- a/frontend/src/views/ReaderView.jsx
+++ b/frontend/src/views/ReaderView.jsx
@@ -6,7 +6,7 @@ import {
 } from 'react-icons/lu'
 import api, { mediaUrl } from '../api'
 import Spinner from '../components/Spinner'
-import { getBookPrefs, saveBookPrefs } from '../hooks/useBookPrefs'
+import { getBookPrefs, saveBookPrefs, saveRecentBook } from '../hooks/useBookPrefs'
 import { getUserPrefs } from '../hooks/useUserPrefs'
 import useReaderGestures from '../hooks/useReaderGestures'
 import TocSidebar from '../components/reader/TocSidebar'
@@ -87,6 +87,7 @@ export default function ReaderView() {
     api.get(`/books/${bookId}`).then(b => {
       setBook(b)
       setTotalPages(b.page_count || 0)
+      saveRecentBook(b)
     })
   }, [bookId])
 


### PR DESCRIPTION
### Summary
- Reading progress bar appears at the bottom of each book row in the system view, filling up as you read further into the book
- Last read page number is shown next to the page count (e.g. p. 42)
- "Recently Opened" section appears at the top of the library page showing the last 10 opened books as compact cards
- clicking one jumps straight back to the last read page


### Notes
Progress and recently opened data is stored in localStorage per book (grimoire:book:{id}). The reader was already saving the last read page — this PR just surfaces that data in the UI. No backend changes required.
<img width="895" height="366" alt="image" src="https://github.com/user-attachments/assets/11344f29-dd9b-47c5-8d23-287ce4373e59" />

<img width="2294" height="527" alt="image" src="https://github.com/user-attachments/assets/0f0bf0f7-0539-44bd-840a-0911e7a3eec7" />
