### PR TITLE
Fix: Resolve infinite scan loop caused by problematic files hanging the worker during thumbnail generation.

### DIFF
--- a/backend/indexer.py
+++ b/backend/indexer.py
@@ -17,7 +17,7 @@ from .models import GameSystem, Book, GenericMap, MapFolder, Token, TokenFolder
 
 logger = logging.getLogger("grimoire.indexer")
 
-_FITZ_TIMEOUT = 300  # seconds
+_FITZ_TIMEOUT = 30   # seconds — files that can't be opened in 30s are unreadable
 _DB_TIMEOUT = 30  # seconds — max time to wait for a DB operation before treating it as hung
 
 
@@ -119,7 +119,7 @@ def guess_category(filepath: str) -> str:
     return "core"
 
 
-_THUMBNAIL_TIMEOUT = 60  # seconds
+_THUMBNAIL_TIMEOUT = 30  # seconds
 
 
 def _generate_thumbnail_task(filepath: str, output_path: str, size: tuple, result: list, exc: list):
@@ -176,10 +176,10 @@ def generate_thumbnail(filepath: str, output_path: str, size: tuple = (300, 400)
             logger.warning(f"Thumbnail generation aborted by stop request for {filepath}")
             return False
     if t.is_alive():
-        logger.warning(f"Thumbnail generation timed out after {_THUMBNAIL_TIMEOUT}s for {filepath}")
+        logger.error(f"Thumbnail generation timed out after {_THUMBNAIL_TIMEOUT}s for {filepath}")
         return False
     if exc[0] is not None:
-        logger.warning(f"Thumbnail generation failed for {filepath}: {exc[0]}")
+        logger.error(f"Thumbnail generation failed for {filepath}: {exc[0]}")
         return False
     return bool(result[0])
 
@@ -320,63 +320,115 @@ def scan_library(library_path: str, data_path: str, session: Session, on_progres
                         stats["errors"] += 1
                         continue
                     if existing:
-                        logger.debug(f"Already registered, skipping: {filename}")
-                        continue
+                        if existing.scan_failed:
+                            logger.debug(f"Already registered, skipping: {filename}")
+                            continue
+                        needs_thumbnail = not existing.has_thumbnail
+                        needs_page_count = ext == ".pdf" and existing.page_count == 0 and not existing.index_error
+                        if not needs_thumbnail and not needs_page_count:
+                            logger.debug(f"Already registered, skipping: {filename}")
+                            continue
+                        logger.debug(f"Resuming incomplete scan for: {filename}")
+                        book = existing
+                    else:
+                        category = guess_category(relative_path)
+                        title = Path(filename).stem.replace("_", " ").replace("-", " ").strip()
 
-                    category = guess_category(relative_path)
-                    title = Path(filename).stem.replace("_", " ").replace("-", " ").strip()
+                        try:
+                            file_size = os.path.getsize(filepath)
+                        except OSError:
+                            logger.warning(f"Cannot stat file, skipping: {filepath}")
+                            continue
 
-                    try:
-                        file_size = os.path.getsize(filepath)
-                    except OSError:
-                        logger.warning(f"Cannot stat file, skipping: {filepath}")
-                        continue
+                        book = Book(
+                            game_system_id=system.id,
+                            title=title,
+                            filename=filename,
+                            filepath=filepath,
+                            relative_path=relative_path,
+                            category=category,
+                            file_size=file_size,
+                            mime_type="application/pdf" if ext == ".pdf" else f"image/{ext[1:]}",
+                        )
 
-                    book = Book(
-                        game_system_id=system.id,
-                        title=title,
-                        filename=filename,
-                        filepath=filepath,
-                        relative_path=relative_path,
-                        category=category,
-                        file_size=file_size,
-                        mime_type="application/pdf" if ext == ".pdf" else f"image/{ext[1:]}",
-                    )
+                        # Commit the book record first so that if a subsequent
+                        # hang kills the worker, the file is already in the DB and
+                        # won't be re-processed on the next startup scan.
+                        session.add(book)
+                        logger.debug(f"DB: committing new book '{filename}'")
+                        try:
+                            _run_with_timeout(session.commit, _DB_TIMEOUT, f"commit book '{filepath}'")
+                            stats["new_books"] += 1
+                            logger.info(f"New book saved: {title} ({category}) in {system_name}")
+                        except TimeoutError as e:
+                            logger.error(f"DB hang: {e} — rolling back '{filename}'")
+                            session.rollback()
+                            stats["errors"] += 1
+                            continue
+                        except IntegrityError:
+                            session.rollback()
+                            logger.debug(f"Book already exists, skipping: {filepath}")
+                            continue
+                        needs_thumbnail = True
+                        needs_page_count = ext == ".pdf"
 
                     thumb_path = os.path.join(
                         thumb_dir,
                         "books",
-                        f"{slugify(title)}_{hashlib.md5(filepath.encode()).hexdigest()[:8]}.webp",
+                        f"{slugify(book.title)}_{hashlib.md5(filepath.encode()).hexdigest()[:8]}.webp",
                     )
-                    logger.info(f"Generating thumbnail: {filepath}")
-                    if generate_thumbnail(filepath, thumb_path, should_stop=should_stop):
-                        book.has_thumbnail = True
+                    if needs_thumbnail:
+                        # Set scan_failed before the potentially-hanging operation.
+                        # If the worker is killed mid-hang this flag persists, preventing
+                        # the file from being retried on the next scan. A clean cancel
+                        # clears it below so the file is resumed normally next time.
+                        book.scan_failed = True
+                        try:
+                            _run_with_timeout(session.commit, _DB_TIMEOUT, f"commit scan_failed '{filepath}'")
+                        except (TimeoutError, IntegrityError) as e:
+                            logger.error(f"DB hang writing scan_failed for '{filename}': {e}")
+                            session.rollback()
+                        logger.info(f"Generating thumbnail: {filepath}")
+                        if generate_thumbnail(filepath, thumb_path, should_stop=should_stop):
+                            book.has_thumbnail = True
+                        if should_stop and should_stop():
+                            # Cancelled — clear the flag so the file is resumed next scan.
+                            book.scan_failed = False
+                        try:
+                            _run_with_timeout(session.commit, _DB_TIMEOUT, f"commit thumbnail '{filepath}'")
+                        except (TimeoutError, IntegrityError) as e:
+                            logger.error(f"DB hang saving thumbnail for '{filename}': {e}")
+                            session.rollback()
 
-                    if ext == ".pdf":
+                    if needs_page_count:
+                        if not book.scan_failed:
+                            book.scan_failed = True
+                            try:
+                                _run_with_timeout(session.commit, _DB_TIMEOUT, f"commit scan_failed '{filepath}'")
+                            except (TimeoutError, IntegrityError) as e:
+                                logger.error(f"DB hang writing scan_failed for '{filename}': {e}")
+                                session.rollback()
                         logger.info(f"Opening PDF for page count: {filepath}")
                         try:
                             doc = _fitz_open_with_timeout(filepath, should_stop=should_stop)
                             book.page_count = len(doc)
                             doc.close()
                             logger.debug(f"Page count: {book.page_count} pages in '{filename}'")
+                            book.scan_failed = False
+                            _run_with_timeout(session.commit, _DB_TIMEOUT, f"commit page_count '{filepath}'")
                         except Exception as e:
-                            logger.warning(f"Could not read page count for '{filename}': {e}")
-                            book.index_error = str(e)[:500]
-                            stats["errors"] += 1
-
-                    session.add(book)
-                    logger.debug(f"DB: committing new book '{filename}'")
-                    try:
-                        _run_with_timeout(session.commit, _DB_TIMEOUT, f"commit book '{filepath}'")
-                        stats["new_books"] += 1
-                        logger.info(f"New book saved: {title} ({category}) in {system_name}")
-                    except TimeoutError as e:
-                        logger.error(f"DB hang: {e} — rolling back '{filename}'")
-                        session.rollback()
-                        stats["errors"] += 1
-                    except IntegrityError:
-                        session.rollback()
-                        logger.debug(f"Book already exists, skipping: {filepath}")
+                            if should_stop and should_stop():
+                                # Cancelled — clear the flag so the file is resumed next scan.
+                                book.scan_failed = False
+                            else:
+                                logger.error(f"Could not read page count for '{filename}': {e}")
+                                book.index_error = str(e)[:500]
+                                stats["errors"] += 1
+                            try:
+                                _run_with_timeout(session.commit, _DB_TIMEOUT, f"commit scan_failed '{filepath}'")
+                            except (TimeoutError, IntegrityError) as e2:
+                                logger.error(f"DB hang saving index_error for '{filename}': {e2}")
+                                session.rollback()
 
     if maps_dir.exists():
         for root, dirs, files in os.walk(maps_dir):

--- a/backend/models.py
+++ b/backend/models.py
@@ -77,6 +77,7 @@ class Book(Base):
     indexed = Column(Boolean, default=False)
     index_failed = Column(Boolean, default=False)
     index_error = Column(String(500), default="")
+    scan_failed = Column(Boolean, default=False)
 
     created_at = Column(DateTime, default=_utcnow)
     updated_at = Column(DateTime, default=_utcnow, onupdate=_utcnow)
@@ -372,11 +373,15 @@ def init_db(db_path: str):
 
     with engine.connect() as conn:
         # Runtime migrations for columns added after initial release
-        try:
-            conn.execute(text("ALTER TABLE books ADD COLUMN index_failed BOOLEAN DEFAULT 0"))
-            conn.commit()
-        except Exception:
-            pass  # Column already exists
+        for migration in [
+            "ALTER TABLE books ADD COLUMN index_failed BOOLEAN DEFAULT 0",
+            "ALTER TABLE books ADD COLUMN scan_failed BOOLEAN DEFAULT 0",
+        ]:
+            try:
+                conn.execute(text(migration))
+                conn.commit()
+            except Exception:
+                pass  # Column already exists
 
         conn.execute(
             text(

--- a/tests/test_indexer_resilience.py
+++ b/tests/test_indexer_resilience.py
@@ -1,4 +1,4 @@
-"""Tests for indexer resilience: fitz timeout, getsize guard, and index_failed logic."""
+"""Tests for indexer resilience: fitz timeout, getsize guard, index_failed, and scan_failed logic."""
 from __future__ import annotations
 
 import os
@@ -400,3 +400,250 @@ class TestShouldStop:
             db.close()
 
         assert isinstance(stats, dict)
+
+
+# ---------------------------------------------------------------------------
+# scan_library — scan_failed / early-commit / resume behaviour
+# ---------------------------------------------------------------------------
+
+
+class TestScanFailed:
+    """Tests for the scan_failed flag and the early-commit ordering that prevents
+    the infinite-hang loop when a worker is killed mid-operation."""
+
+    def _books_dir(self, lib: Path, system_folder: str = "ScanFailSystem") -> Path:
+        d = lib / "books" / system_folder
+        d.mkdir(parents=True, exist_ok=True)
+        return d
+
+    def test_book_committed_before_thumbnail(self):
+        """The book record exists in the DB before generate_thumbnail is called,
+        so a worker kill during the thumbnail hang doesn't lose the file."""
+        tmp, lib = _mk_lib()
+        folder = self._books_dir(lib, "EarlyCommitSystem")
+        (folder / "book.pdf").write_bytes(b"%PDF-1.4")
+
+        committed_before_thumb = []
+
+        db = SessionLocal()
+        try:
+            def check_committed(filepath, *args, **kwargs):
+                # At this point the book should already be in the DB
+                exists = db.query(Book).filter_by(filepath=filepath).first()
+                committed_before_thumb.append(exists is not None)
+                return False
+
+            with patch("backend.indexer.generate_thumbnail", side_effect=check_committed):
+                with patch("backend.indexer._fitz_open_with_timeout") as mock_fitz:
+                    mock_doc = MagicMock()
+                    mock_doc.__len__ = lambda _: 1
+                    mock_fitz.return_value = mock_doc
+                    scan_library(str(lib), tmp, db)
+        finally:
+            db.close()
+
+        assert committed_before_thumb, "generate_thumbnail was never called"
+        assert all(committed_before_thumb), "book was not in DB before thumbnail was attempted"
+
+    def test_scan_failed_set_before_thumbnail_hang(self):
+        """scan_failed=True is committed before generate_thumbnail runs, so a
+        worker kill mid-hang leaves the flag set and prevents infinite retries."""
+        tmp, lib = _mk_lib()
+        folder = self._books_dir(lib, "ScanFailBefore")
+        pdf_path = str(folder / "hang.pdf")
+        (folder / "hang.pdf").write_bytes(b"%PDF-1.4")
+
+        scan_failed_before_thumb = []
+
+        db = SessionLocal()
+        try:
+            def check_scan_failed(filepath, *args, **kwargs):
+                book = db.query(Book).filter_by(filepath=filepath).first()
+                if book:
+                    db.refresh(book)
+                    scan_failed_before_thumb.append(book.scan_failed)
+                return False
+
+            with patch("backend.indexer.generate_thumbnail", side_effect=check_scan_failed):
+                with patch("backend.indexer._fitz_open_with_timeout") as mock_fitz:
+                    mock_doc = MagicMock()
+                    mock_doc.__len__ = lambda _: 1
+                    mock_fitz.return_value = mock_doc
+                    scan_library(str(lib), tmp, db)
+        finally:
+            db.close()
+
+        assert scan_failed_before_thumb, "generate_thumbnail was never called"
+        assert all(scan_failed_before_thumb), "scan_failed was not True before thumbnail attempt"
+
+    def test_scan_failed_cleared_after_successful_scan(self):
+        """After a clean scan completes, scan_failed is False on the saved book."""
+        tmp, lib = _mk_lib()
+        folder = self._books_dir(lib, "ScanFailClear")
+        (folder / "good.pdf").write_bytes(b"%PDF-1.4")
+
+        db = SessionLocal()
+        try:
+            with patch("backend.indexer.generate_thumbnail", return_value=True):
+                with patch("backend.indexer._fitz_open_with_timeout") as mock_fitz:
+                    mock_doc = MagicMock()
+                    mock_doc.__len__ = lambda _: 5
+                    mock_fitz.return_value = mock_doc
+                    scan_library(str(lib), tmp, db)
+
+            book = db.query(Book).filter_by(filename="good.pdf").first()
+            assert book is not None
+            assert book.scan_failed is False
+            assert book.page_count == 5
+        finally:
+            db.close()
+
+    def test_book_with_scan_failed_skipped_on_rescan(self):
+        """A book with scan_failed=True is skipped entirely on subsequent scans
+        — it does not cause a hang retry."""
+        tmp, lib = _mk_lib()
+        folder = self._books_dir(lib, "ScanFailSkip")
+        pdf = folder / "problematic.pdf"
+        pdf.write_bytes(b"%PDF-1.4")
+
+        # Pre-seed the DB with scan_failed=True (simulates a prior killed worker)
+        db = SessionLocal()
+        try:
+            book = Book(
+                title="Problematic",
+                filename="problematic.pdf",
+                filepath=str(pdf),
+                relative_path=os.path.relpath(str(pdf), str(lib)),
+                mime_type="application/pdf",
+                scan_failed=True,
+            )
+            db.add(book)
+            db.commit()
+
+            thumb_calls = []
+            fitz_calls = []
+
+            with patch("backend.indexer.generate_thumbnail", side_effect=lambda *a, **kw: thumb_calls.append(1) or False):
+                with patch("backend.indexer._fitz_open_with_timeout", side_effect=lambda *a, **kw: fitz_calls.append(1)):
+                    scan_library(str(lib), tmp, db)
+
+            assert len(thumb_calls) == 0, "generate_thumbnail should not be called for scan_failed book"
+            assert len(fitz_calls) == 0, "fitz should not be called for scan_failed book"
+        finally:
+            db.close()
+
+    def test_cancelled_scan_clears_scan_failed_for_resume(self):
+        """When a scan is cancelled via should_stop, scan_failed is cleared so the
+        file will be retried on the next scan rather than treated as broken."""
+        tmp, lib = _mk_lib()
+        folder = self._books_dir(lib, "CancelResume")
+        pdf = folder / "resumable.pdf"
+        pdf.write_bytes(b"%PDF-1.4")
+
+        db = SessionLocal()
+        try:
+            # Stop immediately after thumbnail starts (simulates cancel mid-hang)
+            stop_now = [False]
+
+            def cancelling_thumbnail(filepath, output_path, should_stop=None, **kwargs):
+                stop_now[0] = True  # signal stop
+                return False
+
+            def should_stop():
+                return stop_now[0]
+
+            with patch("backend.indexer.generate_thumbnail", side_effect=cancelling_thumbnail):
+                with patch("backend.indexer._fitz_open_with_timeout") as mock_fitz:
+                    mock_doc = MagicMock()
+                    mock_doc.__len__ = lambda _: 1
+                    mock_fitz.return_value = mock_doc
+                    scan_library(str(lib), tmp, db, should_stop=should_stop)
+
+            book = db.query(Book).filter_by(filename="resumable.pdf").first()
+            assert book is not None, "book should be in DB after cancelled scan"
+            assert book.scan_failed is False, "scan_failed must be cleared on cancel so file is resumed next scan"
+        finally:
+            db.close()
+
+    def test_resume_completes_missing_thumbnail_after_cancel(self):
+        """A book saved without a thumbnail (due to cancel) gets its thumbnail
+        generated on the next scan."""
+        tmp, lib = _mk_lib()
+        folder = self._books_dir(lib, "ResumeThumb")
+        pdf = folder / "needs_thumb.pdf"
+        pdf.write_bytes(b"%PDF-1.4")
+
+        db = SessionLocal()
+        try:
+            # First scan: commit book but simulate cancel before thumbnail completes
+            book = Book(
+                title="NeedsThumb",
+                filename="needs_thumb.pdf",
+                filepath=str(pdf),
+                relative_path=os.path.relpath(str(pdf), str(lib)),
+                mime_type="application/pdf",
+                has_thumbnail=False,
+                page_count=0,
+                scan_failed=False,
+            )
+            db.add(book)
+            db.commit()
+
+            # Second scan: should pick up the incomplete book and generate thumbnail
+            thumb_calls = []
+
+            def record_thumb(filepath, output_path, should_stop=None, **kwargs):
+                thumb_calls.append(filepath)
+                return True
+
+            with patch("backend.indexer.generate_thumbnail", side_effect=record_thumb):
+                with patch("backend.indexer._fitz_open_with_timeout") as mock_fitz:
+                    mock_doc = MagicMock()
+                    mock_doc.__len__ = lambda _: 3
+                    mock_fitz.return_value = mock_doc
+                    scan_library(str(lib), tmp, db)
+
+            assert any("needs_thumb.pdf" in c for c in thumb_calls), \
+                "thumbnail should be generated for incomplete book on rescan"
+
+            db.refresh(book)
+            assert book.has_thumbnail is True
+            assert book.page_count == 3
+            assert book.scan_failed is False
+        finally:
+            db.close()
+
+    def test_resume_skips_book_with_index_error_already_set(self):
+        """A book that failed page-count extraction (index_error set) is not
+        retried for page count on rescan — only thumbnail is retried if missing."""
+        tmp, lib = _mk_lib()
+        folder = self._books_dir(lib, "ResumeIndexError")
+        pdf = folder / "broken.pdf"
+        pdf.write_bytes(b"%PDF-1.4")
+
+        db = SessionLocal()
+        try:
+            book = Book(
+                title="Broken",
+                filename="broken.pdf",
+                filepath=str(pdf),
+                relative_path=os.path.relpath(str(pdf), str(lib)),
+                mime_type="application/pdf",
+                has_thumbnail=True,
+                page_count=0,
+                index_error="fitz.open() timed out",
+                scan_failed=False,
+            )
+            db.add(book)
+            db.commit()
+
+            fitz_calls = []
+
+            with patch("backend.indexer.generate_thumbnail", return_value=False):
+                with patch("backend.indexer._fitz_open_with_timeout",
+                           side_effect=lambda *a, **kw: fitz_calls.append(1)):
+                    scan_library(str(lib), tmp, db)
+
+            assert len(fitz_calls) == 0, "page count should not be retried when index_error is already set"
+        finally:
+            db.close()


### PR DESCRIPTION
When a scan encountered a corrupt or unreadable file, the worker could hang for up to 6 minutes (60s thumbnail + 300s fitz timeout) before moving on. If the worker was killed during that window — by the OS, container, or uvicorn — the book record was never committed to the database. On the next startup scan, the same file would be encountered again with no record of the prior failure, causing the same hang, the same worker kill, and the same restart — indefinitely