### PR TITLE
Fix: Add is_missing flag to track library items whose files no longer exist on disk

### DIFF
--- a/backend/indexer.py
+++ b/backend/indexer.py
@@ -598,6 +598,46 @@ def scan_library(library_path: str, data_path: str, session: Session, on_progres
 
     _apply_tags_from_library(library_path, session)
 
+    # --- Mark / unmark missing files ---
+    # After walking the filesystem, any DB record whose file is gone gets
+    # is_missing=True; records that exist on disk have is_missing cleared.
+    if should_stop and should_stop():
+        return stats
+
+    missing_books = missing_maps = missing_tokens = 0
+    for book in session.query(Book).all():
+        gone = not os.path.exists(book.filepath)
+        if gone != bool(book.is_missing):
+            book.is_missing = gone
+            if gone:
+                missing_books += 1
+                logger.warning(f"Missing book: '{book.title}' ({book.filepath})")
+    for m in session.query(GenericMap).all():
+        gone = not os.path.exists(m.filepath)
+        if gone != bool(m.is_missing):
+            m.is_missing = gone
+            if gone:
+                missing_maps += 1
+                logger.warning(f"Missing map: '{m.filename}' ({m.filepath})")
+    for t in session.query(Token).all():
+        gone = not os.path.exists(t.filepath)
+        if gone != bool(t.is_missing):
+            t.is_missing = gone
+            if gone:
+                missing_tokens += 1
+                logger.warning(f"Missing token: '{t.filename}' ({t.filepath})")
+    if missing_books or missing_maps or missing_tokens:
+        logger.info(f"Missing files: {missing_books} book(s), {missing_maps} map(s), {missing_tokens} token(s)")
+    try:
+        _run_with_timeout(session.commit, _DB_TIMEOUT, "commit missing flags")
+    except (TimeoutError, Exception) as e:
+        logger.error(f"DB hang saving missing flags: {e}")
+        session.rollback()
+
+    stats["missing_books"] = missing_books
+    stats["missing_maps"] = missing_maps
+    stats["missing_tokens"] = missing_tokens
+
     return stats
 
 

--- a/backend/models.py
+++ b/backend/models.py
@@ -79,6 +79,7 @@ class Book(Base):
     index_failed = Column(Boolean, default=False)
     index_error = Column(String(500), default="")
     scan_failed = Column(Boolean, default=False)
+    is_missing = Column(Boolean, default=False)
 
     created_at = Column(DateTime, default=_utcnow)
     updated_at = Column(DateTime, default=_utcnow, onupdate=_utcnow)
@@ -103,6 +104,7 @@ class GenericMap(Base):
     grid_size = Column(String(50), default="")
     file_size = Column(Integer, default=0)
     has_thumbnail = Column(Boolean, default=False)
+    is_missing = Column(Boolean, default=False)
     created_at = Column(DateTime, default=_utcnow)
 
 
@@ -130,6 +132,7 @@ class Token(Base):
     is_explicit = Column(Boolean, default=False)
     file_size = Column(Integer, default=0)
     has_thumbnail = Column(Boolean, default=False)
+    is_missing = Column(Boolean, default=False)
     created_at = Column(DateTime, default=_utcnow)
 
 
@@ -377,6 +380,9 @@ def init_db(db_path: str):
         for migration in [
             "ALTER TABLE books ADD COLUMN index_failed BOOLEAN DEFAULT 0",
             "ALTER TABLE books ADD COLUMN scan_failed BOOLEAN DEFAULT 0",
+            "ALTER TABLE books ADD COLUMN is_missing BOOLEAN DEFAULT 0",
+            "ALTER TABLE generic_maps ADD COLUMN is_missing BOOLEAN DEFAULT 0",
+            "ALTER TABLE tokens ADD COLUMN is_missing BOOLEAN DEFAULT 0",
         ]:
             try:
                 conn.execute(text(migration))

--- a/backend/routers/books/core.py
+++ b/backend/routers/books/core.py
@@ -55,6 +55,7 @@ def list_books(
                     "indexed": b.indexed,
                     "index_failed": b.index_failed,
                     "is_explicit": bool(b.is_explicit),
+                    "is_missing": bool(b.is_missing),
                 }
                 for b in books
             ],
@@ -95,6 +96,7 @@ def get_book(book_id: str, current_user: CurrentUser = Depends(get_current_user)
             "year": book.year,
             "indexed": book.indexed,
             "index_failed": book.index_failed,
+            "is_missing": bool(book.is_missing),
             "mime_type": book.mime_type,
             "has_thumbnail": book.has_thumbnail,
             "is_explicit": bool(book.is_explicit),
@@ -137,6 +139,9 @@ def serve_book_file(book_id: str):
         if not book:
             raise HTTPException(404, "Book not found")
         if not os.path.exists(book.filepath):
+            if not book.is_missing:
+                book.is_missing = True
+                db.commit()
             raise HTTPException(404, "File not found on disk")
         return FileResponse(
             book.filepath,

--- a/backend/routers/books/pages.py
+++ b/backend/routers/books/pages.py
@@ -95,6 +95,15 @@ def serve_book_page(book_id: str, page_num: int, width: int = Query(1200, le=300
         return FileResponse(cache_path, media_type="image/webp", headers=_PAGE_CACHE_HEADERS)
 
     if not os.path.exists(filepath):
+        db = SessionLocal()
+        try:
+            from ...models import Book
+            book = db.query(Book).filter_by(id=book_id).first()
+            if book and not book.is_missing:
+                book.is_missing = True
+                db.commit()
+        finally:
+            db.close()
         raise HTTPException(404, "File not found on disk")
     doc = _get_pdf_doc(filepath)
     if page_num < 1 or page_num > len(doc):

--- a/backend/routers/maps/core.py
+++ b/backend/routers/maps/core.py
@@ -41,6 +41,7 @@ def list_maps(
                     "map_type": m.map_type,
                     "file_size": m.file_size,
                     "has_thumbnail": m.has_thumbnail,
+                    "is_missing": bool(m.is_missing),
                 }
                 for m in maps
             ],
@@ -93,6 +94,7 @@ def get_map(map_id: str):
             "grid_size": m.grid_size,
             "file_size": m.file_size,
             "has_thumbnail": m.has_thumbnail,
+            "is_missing": bool(m.is_missing),
             **img_info,
         }
     finally:
@@ -105,6 +107,11 @@ def serve_map_file(map_id: str):
         m = db.query(GenericMap).filter_by(id=map_id).first()
         if not m:
             raise HTTPException(404)
+        if not os.path.exists(m.filepath):
+            if not m.is_missing:
+                m.is_missing = True
+                db.commit()
+            raise HTTPException(404, "File not found on disk")
         ext = Path(m.filepath).suffix.lower()
         media = "application/pdf" if ext == ".pdf" else f"image/{ext[1:]}"
         return FileResponse(m.filepath, media_type=media, filename=m.filename)

--- a/backend/routers/systems.py
+++ b/backend/routers/systems.py
@@ -151,6 +151,7 @@ def get_system(system_id: str, current_user: CurrentUser = Depends(get_current_u
                     "has_thumbnail": b.has_thumbnail,
                     "tags": b.tags or [],
                     "is_explicit": bool(b.is_explicit),
+                    "is_missing": bool(b.is_missing),
                 }
                 for b in books
             ],

--- a/backend/routers/tokens/core.py
+++ b/backend/routers/tokens/core.py
@@ -43,6 +43,7 @@ def list_tokens(
                     "file_size": t.file_size,
                     "has_thumbnail": t.has_thumbnail,
                     "is_explicit": bool(t.is_explicit),
+                    "is_missing": bool(t.is_missing),
                 }
                 for t in tokens
             ],
@@ -103,6 +104,7 @@ def get_token(token_id: str, current_user: CurrentUser = Depends(get_current_use
             "file_size": t.file_size,
             "has_thumbnail": t.has_thumbnail,
             "is_explicit": bool(t.is_explicit),
+            "is_missing": bool(t.is_missing),
             "pixel_width": pixel_width,
             "pixel_height": pixel_height,
         }
@@ -116,6 +118,11 @@ def serve_token_file(token_id: str):
         t = db.query(Token).filter_by(id=token_id).first()
         if not t:
             raise HTTPException(404)
+        if not os.path.exists(t.filepath):
+            if not t.is_missing:
+                t.is_missing = True
+                db.commit()
+            raise HTTPException(404, "File not found on disk")
         ext = Path(t.filepath).suffix.lower()
         media = f"image/{ext[1:]}"
         return FileResponse(t.filepath, media_type=media, filename=t.filename)

--- a/frontend/src/components/maps/MapCard.jsx
+++ b/frontend/src/components/maps/MapCard.jsx
@@ -41,11 +41,16 @@ export default function MapCard({ map, onClick, bulkMode, selected, onToggle }) 
           {selected && <LuCheck size={12} color="var(--bg-deep)" strokeWidth={3} />}
         </div>
       )}
-      <div style={{ width: '100%', height: 140, background: 'var(--bg-deep)', display: 'flex', alignItems: 'center', justifyContent: 'center' }}>
+      <div style={{ width: '100%', height: 140, background: 'var(--bg-deep)', display: 'flex', alignItems: 'center', justifyContent: 'center', position: 'relative' }}>
         {map.has_thumbnail
           ? <img src={mediaUrl(`/maps/${map.id}/thumbnail`)} alt="" loading="lazy" style={{ width: '100%', height: '100%', objectFit: 'cover' }} />
           : <LuMap size={32} color="var(--text-muted)" aria-hidden="true" style={{ opacity: 0.4 }} />
         }
+        {map.is_missing && (
+          <div style={{ position: 'absolute', bottom: 6, left: 6, fontSize: 11, padding: '1px 6px', borderRadius: 6, background: 'rgba(200,134,10,0.9)', color: '#fff', fontWeight: 600 }}>
+            Missing
+          </div>
+        )}
       </div>
       <div style={{ padding: '10px 12px' }}>
         <div style={{ fontSize: 15, color: 'var(--text)', overflow: 'hidden', textOverflow: 'ellipsis', whiteSpace: 'nowrap' }}>

--- a/frontend/src/components/system/BookRow.jsx
+++ b/frontend/src/components/system/BookRow.jsx
@@ -66,15 +66,23 @@ export default function BookRow({ book, onOpen, onEdit, editing }) {
               18+
             </span>
           )}
-          {book.indexed && (
-            <span title="Full-text indexed" style={{ fontSize: 11, color: 'var(--green)', background: 'rgba(90,154,90,0.1)', padding: '1px 6px', borderRadius: 8 }}>
-              indexed
+          {book.is_missing ? (
+            <span title="File not found on disk" style={{ fontSize: 11, color: '#c8860a', background: 'rgba(200,134,10,0.12)', padding: '1px 6px', borderRadius: 8, border: '1px solid rgba(200,134,10,0.4)' }}>
+              Missing
             </span>
-          )}
-          {book.index_failed && (
-            <span title={`Index failed${book.index_error ? `: ${book.index_error}` : ''}`} style={{ fontSize: 11, color: '#e07070', background: 'rgba(180,60,60,0.12)', padding: '1px 6px', borderRadius: 8, border: '1px solid rgba(180,60,60,0.35)' }}>
-              index failed
-            </span>
+          ) : (
+            <>
+              {book.indexed && (
+                <span title="Full-text indexed" style={{ fontSize: 11, color: 'var(--green)', background: 'rgba(90,154,90,0.1)', padding: '1px 6px', borderRadius: 8 }}>
+                  Indexed
+                </span>
+              )}
+              {book.index_failed && (
+                <span title={`Index failed${book.index_error ? `: ${book.index_error}` : ''}`} style={{ fontSize: 11, color: '#e07070', background: 'rgba(180,60,60,0.12)', padding: '1px 6px', borderRadius: 8, border: '1px solid rgba(180,60,60,0.35)' }}>
+                  Index Failed
+                </span>
+              )}
+            </>
           )}
           {(book.tags || []).map(tag => (
             <span key={tag} style={{ fontSize: 11, padding: '1px 7px', borderRadius: 8, background: 'rgba(201,168,76,0.12)', border: '1px solid var(--gold-dim)', color: 'var(--gold)' }}>

--- a/frontend/src/components/system/BookRow.test.jsx
+++ b/frontend/src/components/system/BookRow.test.jsx
@@ -55,45 +55,69 @@ describe('BookRow', () => {
 
   // --- indexed badge ---
 
-  it('shows "indexed" badge when indexed is true', () => {
+  it('shows "Indexed" badge when indexed is true', () => {
     render(<BookRow book={makeBook({ indexed: true })} onOpen={() => {}} />)
-    expect(screen.getByText('indexed')).toBeInTheDocument()
+    expect(screen.getByText('Indexed')).toBeInTheDocument()
   })
 
-  it('does not show "indexed" badge when indexed is false', () => {
+  it('does not show "Indexed" badge when indexed is false', () => {
     render(<BookRow book={makeBook({ indexed: false })} onOpen={() => {}} />)
-    expect(screen.queryByText('indexed')).not.toBeInTheDocument()
+    expect(screen.queryByText('Indexed')).not.toBeInTheDocument()
   })
 
   // --- index_failed badge ---
 
-  it('shows "index failed" badge when index_failed is true', () => {
+  it('shows "Index Failed" badge when index_failed is true', () => {
     render(<BookRow book={makeBook({ index_failed: true })} onOpen={() => {}} />)
-    expect(screen.getByText('index failed')).toBeInTheDocument()
+    expect(screen.getByText('Index Failed')).toBeInTheDocument()
   })
 
-  it('does not show "index failed" badge when index_failed is false', () => {
+  it('does not show "Index Failed" badge when index_failed is false', () => {
     render(<BookRow book={makeBook({ index_failed: false })} onOpen={() => {}} />)
-    expect(screen.queryByText('index failed')).not.toBeInTheDocument()
+    expect(screen.queryByText('Index Failed')).not.toBeInTheDocument()
   })
 
-  it('"index failed" badge has a tooltip with the error message', () => {
+  it('"Index Failed" badge has a tooltip with the error message', () => {
     render(<BookRow book={makeBook({ index_failed: true, index_error: 'fitz timed out' })} onOpen={() => {}} />)
-    const badge = screen.getByText('index failed')
+    const badge = screen.getByText('Index Failed')
     expect(badge.title).toBe('Index failed: fitz timed out')
   })
 
-  it('"index failed" badge tooltip falls back gracefully when index_error is empty', () => {
+  it('"Index Failed" badge tooltip falls back gracefully when index_error is empty', () => {
     render(<BookRow book={makeBook({ index_failed: true, index_error: '' })} onOpen={() => {}} />)
-    const badge = screen.getByText('index failed')
+    const badge = screen.getByText('Index Failed')
     expect(badge.title).toBe('Index failed')
   })
 
-  it('does not show "indexed" badge when index_failed is true', () => {
+  it('does not show "Indexed" badge when index_failed is true', () => {
     // A failed book should not be marked indexed
     render(<BookRow book={makeBook({ indexed: false, index_failed: true })} onOpen={() => {}} />)
-    expect(screen.queryByText('indexed')).not.toBeInTheDocument()
-    expect(screen.getByText('index failed')).toBeInTheDocument()
+    expect(screen.queryByText('Indexed')).not.toBeInTheDocument()
+    expect(screen.getByText('Index Failed')).toBeInTheDocument()
+  })
+
+  // --- is_missing badge ---
+
+  it('shows "Missing" badge when is_missing is true', () => {
+    render(<BookRow book={makeBook({ is_missing: true })} onOpen={() => {}} />)
+    expect(screen.getByText('Missing')).toBeInTheDocument()
+  })
+
+  it('does not show "Missing" badge when is_missing is false', () => {
+    render(<BookRow book={makeBook({ is_missing: false })} onOpen={() => {}} />)
+    expect(screen.queryByText('Missing')).not.toBeInTheDocument()
+  })
+
+  it('"Missing" badge replaces "Indexed" badge', () => {
+    render(<BookRow book={makeBook({ is_missing: true, indexed: true })} onOpen={() => {}} />)
+    expect(screen.getByText('Missing')).toBeInTheDocument()
+    expect(screen.queryByText('Indexed')).not.toBeInTheDocument()
+  })
+
+  it('"Missing" badge replaces "Index Failed" badge', () => {
+    render(<BookRow book={makeBook({ is_missing: true, index_failed: true })} onOpen={() => {}} />)
+    expect(screen.getByText('Missing')).toBeInTheDocument()
+    expect(screen.queryByText('Index Failed')).not.toBeInTheDocument()
   })
 
   // --- explicit badge ---

--- a/frontend/src/components/tokens/TokenCard.jsx
+++ b/frontend/src/components/tokens/TokenCard.jsx
@@ -48,11 +48,16 @@ export default function TokenCard({ token, onClick, bulkMode, selected, onToggle
           background: 'rgba(180,60,60,0.85)', color: '#fff', fontWeight: 600,
         }}>18+</div>
       )}
-      <div style={{ width: '100%', aspectRatio: '1/1', background: 'var(--bg-deep)', display: 'flex', alignItems: 'center', justifyContent: 'center' }}>
+      <div style={{ width: '100%', aspectRatio: '1/1', background: 'var(--bg-deep)', display: 'flex', alignItems: 'center', justifyContent: 'center', position: 'relative' }}>
         {token.has_thumbnail
           ? <img src={mediaUrl(`/tokens/${token.id}/thumbnail`)} alt="" loading="lazy" style={{ width: '100%', height: '100%', objectFit: 'cover' }} />
           : <LuUser size={32} color="var(--text-muted)" aria-hidden="true" style={{ opacity: 0.4 }} />
         }
+        {token.is_missing && (
+          <div style={{ position: 'absolute', bottom: 6, left: 6, fontSize: 11, padding: '1px 6px', borderRadius: 6, background: 'rgba(200,134,10,0.9)', color: '#fff', fontWeight: 600 }}>
+            Missing
+          </div>
+        )}
       </div>
       <div style={{ padding: '8px 10px' }}>
         <div style={{ fontSize: 13, color: 'var(--text)', overflow: 'hidden', textOverflow: 'ellipsis', whiteSpace: 'nowrap' }}>

--- a/tests/test_books.py
+++ b/tests/test_books.py
@@ -43,6 +43,14 @@ class TestListBooks:
         assert len(books) > 0
         assert all("index_failed" in b for b in books)
 
+    def test_list_includes_is_missing_field(self, client, admin_headers, book):
+        resp = client.get("/api/books", headers=admin_headers)
+        assert resp.status_code == 200
+        books = resp.json()["books"]
+        assert len(books) > 0
+        assert all("is_missing" in b for b in books)
+        assert all(isinstance(b["is_missing"], bool) for b in books)
+
     def test_filter_by_category(self, client, admin_headers, book):
         resp = client.get("/api/books?category=core", headers=admin_headers)
         assert resp.status_code == 200
@@ -80,6 +88,14 @@ class TestGetBook:
         assert "index_failed" in body
         assert isinstance(body["index_failed"], bool)
         assert body["index_failed"] is False
+
+    def test_get_book_includes_is_missing(self, client, admin_headers, book):
+        resp = client.get(f"/api/books/{book.id}", headers=admin_headers)
+        assert resp.status_code == 200
+        body = resp.json()
+        assert "is_missing" in body
+        assert isinstance(body["is_missing"], bool)
+        assert body["is_missing"] is False
 
     def test_get_nonexistent_book(self, client, admin_headers):
         resp = client.get("/api/books/does-not-exist", headers=admin_headers)

--- a/tests/test_indexer_resilience.py
+++ b/tests/test_indexer_resilience.py
@@ -1,4 +1,4 @@
-"""Tests for indexer resilience: fitz timeout, getsize guard, index_failed, and scan_failed logic."""
+"""Tests for indexer resilience: fitz timeout, getsize guard, index_failed, scan_failed, and is_missing logic."""
 from __future__ import annotations
 
 import os
@@ -16,7 +16,7 @@ from backend.indexer import (
     index_book_text,
     scan_library,
 )
-from backend.models import Book
+from backend.models import Book, GenericMap, Token
 
 
 # ---------------------------------------------------------------------------
@@ -645,5 +645,169 @@ class TestScanFailed:
                     scan_library(str(lib), tmp, db)
 
             assert len(fitz_calls) == 0, "page count should not be retried when index_error is already set"
+        finally:
+            db.close()
+
+
+# ---------------------------------------------------------------------------
+# scan_library — is_missing detection
+# ---------------------------------------------------------------------------
+
+
+class TestMissingFiles:
+    """Tests for the is_missing flag set/cleared during rescan."""
+
+    def _mk_lib(self) -> tuple[str, Path]:
+        tmp = tempfile.mkdtemp()
+        lib = Path(tmp) / "library"
+        lib.mkdir()
+        return tmp, lib
+
+    def test_missing_book_flagged_after_file_deleted(self):
+        """A book whose file is removed between scans gets is_missing=True on rescan."""
+        tmp, lib = self._mk_lib()
+        books_dir = lib / "books" / "LostSystem"
+        books_dir.mkdir(parents=True)
+        pdf = books_dir / "vanished.pdf"
+        pdf.write_bytes(b"%PDF-1.4")
+
+        db = SessionLocal()
+        try:
+            with patch("backend.indexer.generate_thumbnail", return_value=False):
+                with patch("backend.indexer._fitz_open_with_timeout") as mock_fitz:
+                    mock_doc = MagicMock()
+                    mock_doc.__len__ = lambda _: 1
+                    mock_fitz.return_value = mock_doc
+                    scan_library(str(lib), tmp, db)
+
+            book = db.query(Book).filter_by(filename="vanished.pdf").first()
+            assert book is not None
+            assert book.is_missing is False
+
+            # Delete the file and rescan
+            pdf.unlink()
+            with patch("backend.indexer.generate_thumbnail", return_value=False):
+                with patch("backend.indexer._fitz_open_with_timeout") as mock_fitz:
+                    mock_fitz.return_value = MagicMock(__len__=lambda _: 1)
+                    scan_library(str(lib), tmp, db)
+
+            db.refresh(book)
+            assert book.is_missing is True
+        finally:
+            db.close()
+
+    def test_missing_flag_cleared_when_file_returns(self):
+        """A book pre-seeded with is_missing=True has the flag cleared when its file exists."""
+        tmp, lib = self._mk_lib()
+        books_dir = lib / "books" / "ReturnSystem"
+        books_dir.mkdir(parents=True)
+        pdf = books_dir / "returning.pdf"
+        pdf.write_bytes(b"%PDF-1.4")
+
+        db = SessionLocal()
+        try:
+            # Pre-seed with is_missing=True
+            book = Book(
+                title="Returning",
+                filename="returning.pdf",
+                filepath=str(pdf),
+                relative_path=os.path.relpath(str(pdf), str(lib)),
+                mime_type="application/pdf",
+                has_thumbnail=True,
+                page_count=5,
+                scan_failed=False,
+                is_missing=True,
+            )
+            db.add(book)
+            db.commit()
+
+            # File exists on disk — rescan should clear is_missing
+            with patch("backend.indexer.generate_thumbnail", return_value=False):
+                with patch("backend.indexer._fitz_open_with_timeout") as mock_fitz:
+                    mock_fitz.return_value = MagicMock(__len__=lambda _: 5)
+                    scan_library(str(lib), tmp, db)
+
+            db.refresh(book)
+            assert book.is_missing is False
+        finally:
+            db.close()
+
+    def test_missing_map_flagged_after_file_deleted(self):
+        """A map whose file is removed between scans gets is_missing=True on rescan."""
+        tmp, lib = self._mk_lib()
+        maps_dir = lib / "maps" / "LostMaps"
+        maps_dir.mkdir(parents=True)
+        img = maps_dir / "gone.png"
+        img.write_bytes(b"\x89PNG")
+
+        db = SessionLocal()
+        try:
+            with patch("backend.indexer.generate_thumbnail", return_value=False):
+                scan_library(str(lib), tmp, db)
+
+            m = db.query(GenericMap).filter_by(filename="gone.png").first()
+            assert m is not None
+            assert m.is_missing is False
+
+            img.unlink()
+            with patch("backend.indexer.generate_thumbnail", return_value=False):
+                scan_library(str(lib), tmp, db)
+
+            db.refresh(m)
+            assert m.is_missing is True
+        finally:
+            db.close()
+
+    def test_missing_token_flagged_after_file_deleted(self):
+        """A token whose file is removed between scans gets is_missing=True on rescan."""
+        tmp, lib = self._mk_lib()
+        tokens_dir = lib / "tokens" / "LostTokens"
+        tokens_dir.mkdir(parents=True)
+        img = tokens_dir / "ghost.png"
+        img.write_bytes(b"\x89PNG")
+
+        db = SessionLocal()
+        try:
+            with patch("backend.indexer.generate_thumbnail", return_value=False):
+                scan_library(str(lib), tmp, db)
+
+            t = db.query(Token).filter_by(filename="ghost.png").first()
+            assert t is not None
+            assert t.is_missing is False
+
+            img.unlink()
+            with patch("backend.indexer.generate_thumbnail", return_value=False):
+                scan_library(str(lib), tmp, db)
+
+            db.refresh(t)
+            assert t.is_missing is True
+        finally:
+            db.close()
+
+    def test_scan_stats_include_missing_counts(self):
+        """scan_library returns missing_books/maps/tokens counts in its stats dict."""
+        tmp, lib = self._mk_lib()
+        books_dir = lib / "books" / "StatSystem"
+        books_dir.mkdir(parents=True)
+        pdf = books_dir / "counted.pdf"
+        pdf.write_bytes(b"%PDF-1.4")
+
+        db = SessionLocal()
+        try:
+            with patch("backend.indexer.generate_thumbnail", return_value=False):
+                with patch("backend.indexer._fitz_open_with_timeout") as mock_fitz:
+                    mock_fitz.return_value = MagicMock(__len__=lambda _: 1)
+                    scan_library(str(lib), tmp, db)
+
+            pdf.unlink()
+            with patch("backend.indexer.generate_thumbnail", return_value=False):
+                with patch("backend.indexer._fitz_open_with_timeout") as mock_fitz:
+                    mock_fitz.return_value = MagicMock(__len__=lambda _: 1)
+                    stats = scan_library(str(lib), tmp, db)
+
+            assert "missing_books" in stats
+            assert "missing_maps" in stats
+            assert "missing_tokens" in stats
+            assert stats["missing_books"] >= 1
         finally:
             db.close()

--- a/tests/test_maps.py
+++ b/tests/test_maps.py
@@ -23,6 +23,14 @@ class TestListMaps:
         ids = [m["id"] for m in resp.json()["maps"]]
         assert map_entry.id in ids
 
+    def test_list_includes_is_missing_field(self, client, admin_headers, map_entry):
+        resp = client.get("/api/maps", headers=admin_headers)
+        assert resp.status_code == 200
+        maps = resp.json()["maps"]
+        assert len(maps) > 0
+        assert all("is_missing" in m for m in maps)
+        assert all(isinstance(m["is_missing"], bool) for m in maps)
+
     def test_player_can_list_maps(self, client, player_headers, map_entry):
         resp = client.get("/api/maps", headers=player_headers)
         assert resp.status_code == 200
@@ -43,6 +51,14 @@ class TestGetMap:
         assert resp.status_code == 200
         body = resp.json()
         assert body["id"] == map_entry.id
+
+    def test_get_map_includes_is_missing(self, client, admin_headers, map_entry):
+        resp = client.get(f"/api/maps/{map_entry.id}", headers=admin_headers)
+        assert resp.status_code == 200
+        body = resp.json()
+        assert "is_missing" in body
+        assert isinstance(body["is_missing"], bool)
+        assert body["is_missing"] is False
 
     def test_get_nonexistent_map(self, client, admin_headers):
         resp = client.get("/api/maps/does-not-exist", headers=admin_headers)

--- a/tests/test_systems.py
+++ b/tests/test_systems.py
@@ -68,6 +68,15 @@ class TestGetSystem:
         if books:
             assert all("index_failed" in b for b in books)
 
+    def test_system_books_include_is_missing(self, client, admin_headers, system):
+        from tests.conftest import make_book
+        make_book(system_id=system.id)
+        resp = client.get(f"/api/systems/{system.id}", headers=admin_headers)
+        books = resp.json()["books"]
+        if books:
+            assert all("is_missing" in b for b in books)
+            assert all(isinstance(b["is_missing"], bool) for b in books)
+
     def test_get_nonexistent_system(self, client, admin_headers):
         resp = client.get("/api/systems/does-not-exist", headers=admin_headers)
         assert resp.status_code == 404


### PR DESCRIPTION
Adds an is_missing boolean to Book, GenericMap, and Token models (with runtime migrations). During rescan, scan_library now checks all existing DB records against the filesystem and sets/clears is_missing accordingly. File-serve endpoints (book file, book page, map file, token file) also mark an item missing on-the-fly when a 404 is encountered at view time.

The flag is exposed in all list and detail API responses, including the books embedded in the system detail endpoint (which is what the book list view actually consumes). BookRow shows a capitalized "Missing" badge in place of the indexed/index-failed badges; MapCard and TokenCard show a "Missing" overlay on the thumbnail. All three status badges (Missing, Indexed, Index Failed) are now capitalized consistently.