### PR TITLE
Enhancement: Persist scroll position and folder expand/collapse state across navigation

### DIFF
--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -1,5 +1,6 @@
 import { useState, useEffect } from 'react'
 import { Routes, Route, Navigate, useLocation, useParams } from 'react-router-dom'
+import useScrollRestoration from './hooks/useScrollRestoration'
 import { useTranslation } from 'react-i18next'
 import { useAuth } from './context/AuthContext'
 import { FavoritesProvider } from './context/FavoritesContext'
@@ -50,6 +51,7 @@ function AppShell() {
   const [isMobile, setIsMobile] = useState(window.innerWidth < 768)
   const location = useLocation()
   const isReader = location.pathname.startsWith('/library/book/') || location.pathname.startsWith('/maps/') || location.pathname.startsWith('/tokens/')
+  const mainRef = useScrollRestoration()
 
   const refreshUiSettings = () => settingsApi.getUi().then(setUiSettings).catch(() => {})
 
@@ -74,7 +76,7 @@ function AppShell() {
         <Sidebar stats={stats} user={user} onLogout={logout} uiSettings={uiSettings} />
       )}
 
-      <main style={{
+      <main ref={mainRef} style={{
         flex: 1, minWidth: 0, height: '100%',
         overflow: isReader ? 'hidden' : 'auto',
         paddingBottom: isMobile ? 64 : 0,

--- a/frontend/src/hooks/useScrollRestoration.js
+++ b/frontend/src/hooks/useScrollRestoration.js
@@ -1,0 +1,69 @@
+import { useEffect, useRef } from 'react'
+import { useLocation } from 'react-router-dom'
+
+/**
+ * Saves and restores the scroll position of a container element as the user
+ * navigates between routes.
+ *
+ * Usage:
+ *   const mainRef = useScrollRestoration()
+ *   <main ref={mainRef} ...>
+ *
+ * Positions are stored in sessionStorage (keyed by pathname) so they survive
+ * in-session navigation but reset on a full page reload.
+ *
+ * Restoration is deferred one frame to let the incoming view finish its initial
+ * render before scrollTop is applied.
+ */
+export default function useScrollRestoration() {
+  const ref = useRef(null)
+  const { pathname } = useLocation()
+  const prevPathname = useRef(pathname)
+
+  // Save scroll position whenever the pathname changes (i.e. we're navigating away).
+  useEffect(() => {
+    const el = ref.current
+    if (!el) return
+
+    const leavingPath = prevPathname.current
+
+    const save = () => {
+      try {
+        sessionStorage.setItem(`grimoire:scroll:${leavingPath}`, String(el.scrollTop))
+      } catch {}
+    }
+
+    // Save the departing path's position before updating the ref.
+    if (leavingPath !== pathname) {
+      save()
+    }
+
+    prevPathname.current = pathname
+
+    // Restore position for the new pathname after the view renders.
+    const frame = requestAnimationFrame(() => {
+      try {
+        const saved = sessionStorage.getItem(`grimoire:scroll:${pathname}`)
+        if (saved !== null && el) {
+          el.scrollTop = Number(saved)
+        }
+      } catch {}
+    })
+
+    return () => cancelAnimationFrame(frame)
+  }, [pathname])
+
+  // Also save on unmount / page unload so the last position isn't lost.
+  useEffect(() => {
+    const el = ref.current
+    const path = pathname
+    return () => {
+      if (!el) return
+      try {
+        sessionStorage.setItem(`grimoire:scroll:${path}`, String(el.scrollTop))
+      } catch {}
+    }
+  }, [pathname])
+
+  return ref
+}

--- a/frontend/src/hooks/useScrollRestoration.test.jsx
+++ b/frontend/src/hooks/useScrollRestoration.test.jsx
@@ -1,0 +1,97 @@
+import { describe, it, expect, beforeEach, vi } from 'vitest'
+import { render, act } from '@testing-library/react'
+import { renderHook } from '@testing-library/react'
+import { MemoryRouter } from 'react-router-dom'
+import useScrollRestoration from './useScrollRestoration'
+
+// Wrap the hook in a MemoryRouter so useLocation works.
+function makeWrapper(initialPath = '/') {
+  return function Wrapper({ children }) {
+    return (
+      <MemoryRouter initialEntries={[initialPath]}>
+        {children}
+      </MemoryRouter>
+    )
+  }
+}
+
+// A component that attaches the hook's ref to a real div so we can test
+// DOM-dependent behaviour (save on unmount, restore on mount).
+function ScrollComponent({ onRef } = {}) {
+  const ref = useScrollRestoration()
+  return <div ref={(el) => { ref.current = el; onRef?.(el) }} style={{ height: '200px', overflow: 'auto' }} />
+}
+
+describe('useScrollRestoration', () => {
+  beforeEach(() => {
+    sessionStorage.clear()
+    vi.clearAllMocks()
+    // requestAnimationFrame is not available in jsdom — stub it to run synchronously.
+    vi.stubGlobal('requestAnimationFrame', (cb) => { cb(); return 0 })
+    vi.stubGlobal('cancelAnimationFrame', () => {})
+  })
+
+  it('returns a ref object', () => {
+    const { result } = renderHook(() => useScrollRestoration(), {
+      wrapper: makeWrapper('/library'),
+    })
+    expect(result.current).toHaveProperty('current')
+  })
+
+  it('does not throw when the ref is not attached to a DOM element', () => {
+    expect(() => {
+      renderHook(() => useScrollRestoration(), {
+        wrapper: makeWrapper('/library'),
+      })
+    }).not.toThrow()
+  })
+
+  it('does not write to sessionStorage on mount when no prior state exists', () => {
+    renderHook(() => useScrollRestoration(), {
+      wrapper: makeWrapper('/library'),
+    })
+    expect(sessionStorage.getItem('grimoire:scroll:/library')).toBeNull()
+  })
+
+  it('saves scrollTop to sessionStorage on unmount', () => {
+    let divEl = null
+    const { unmount } = render(
+      <MemoryRouter initialEntries={['/library']}>
+        <ScrollComponent onRef={(el) => { divEl = el }} />
+      </MemoryRouter>
+    )
+
+    // jsdom div doesn't have real scrollTop, so set it manually.
+    if (divEl) Object.defineProperty(divEl, 'scrollTop', { value: 250, writable: true, configurable: true })
+
+    unmount()
+
+    expect(sessionStorage.getItem('grimoire:scroll:/library')).toBe('250')
+  })
+
+  it('restores scrollTop from sessionStorage after mounting with a saved position', () => {
+    sessionStorage.setItem('grimoire:scroll:/library', '400')
+
+    let divEl = null
+    render(
+      <MemoryRouter initialEntries={['/library']}>
+        <ScrollComponent onRef={(el) => { divEl = el }} />
+      </MemoryRouter>
+    )
+
+    // The rAF stub fires synchronously, so scrollTop should already be set.
+    expect(divEl?.scrollTop).toBe(400)
+  })
+
+  it('leaves scrollTop unchanged when no saved position exists', () => {
+    let divEl = null
+    render(
+      <MemoryRouter initialEntries={['/library']}>
+        <ScrollComponent onRef={(el) => { divEl = el }} />
+      </MemoryRouter>
+    )
+
+    // No saved state — scrollTop stays at its default (0 in jsdom).
+    expect(divEl?.scrollTop ?? 0).toBe(0)
+  })
+})

--- a/frontend/src/hooks/useSessionState.js
+++ b/frontend/src/hooks/useSessionState.js
@@ -1,0 +1,46 @@
+import { useState, useEffect, useRef } from 'react'
+
+/**
+ * Like useState, but the value is persisted in sessionStorage so it survives
+ * in-session navigation (e.g. going to a detail view and coming back).
+ * Values reset on a full page reload, which is the correct default.
+ *
+ * Supports plain values and Set objects.
+ * Sets are stored as JSON arrays and rehydrated as Sets on load.
+ *
+ * @param {string} key        sessionStorage key
+ * @param {*}      initial    initial value (used only when no stored value exists)
+ * @returns [value, setValue] — same API as useState
+ */
+export default function useSessionState(key, initial) {
+  const isSet = initial instanceof Set
+
+  const [value, setValueRaw] = useState(() => {
+    try {
+      const raw = sessionStorage.getItem(key)
+      if (raw === null) return initial
+      const parsed = JSON.parse(raw)
+      return isSet ? new Set(parsed) : parsed
+    } catch {
+      return initial
+    }
+  })
+
+  // Track whether the value has been explicitly set at least once (i.e. data loaded).
+  const hasBeenSet = useRef(value !== initial)
+
+  const setValue = (next) => {
+    hasBeenSet.current = true
+    setValueRaw(next)
+  }
+
+  useEffect(() => {
+    if (!hasBeenSet.current) return
+    try {
+      const toStore = value instanceof Set ? [...value] : value
+      sessionStorage.setItem(key, JSON.stringify(toStore))
+    } catch {}
+  }, [key, value])
+
+  return [value, setValue]
+}

--- a/frontend/src/hooks/useSessionState.test.js
+++ b/frontend/src/hooks/useSessionState.test.js
@@ -1,0 +1,95 @@
+import { describe, it, expect, beforeEach } from 'vitest'
+import { renderHook, act } from '@testing-library/react'
+import useSessionState from './useSessionState'
+
+const KEY = 'grimoire:test-key'
+
+describe('useSessionState', () => {
+  beforeEach(() => {
+    sessionStorage.clear()
+  })
+
+  it('returns the initial value when nothing is stored', () => {
+    const { result } = renderHook(() => useSessionState(KEY, 'default'))
+    expect(result.current[0]).toBe('default')
+  })
+
+  it('rehydrates from sessionStorage on mount', () => {
+    sessionStorage.setItem(KEY, JSON.stringify('stored'))
+    const { result } = renderHook(() => useSessionState(KEY, 'default'))
+    expect(result.current[0]).toBe('stored')
+  })
+
+  it('persists a new value to sessionStorage', () => {
+    const { result } = renderHook(() => useSessionState(KEY, 'initial'))
+    act(() => result.current[1]('updated'))
+    expect(sessionStorage.getItem(KEY)).toBe(JSON.stringify('updated'))
+  })
+
+  it('does NOT write to sessionStorage until setValue is called', () => {
+    renderHook(() => useSessionState(KEY, 'initial'))
+    expect(sessionStorage.getItem(KEY)).toBeNull()
+  })
+
+  it('handles number values', () => {
+    const { result } = renderHook(() => useSessionState(KEY, 0))
+    act(() => result.current[1](42))
+    expect(sessionStorage.getItem(KEY)).toBe('42')
+    const { result: r2 } = renderHook(() => useSessionState(KEY, 0))
+    expect(r2.current[0]).toBe(42)
+  })
+
+  it('handles boolean values', () => {
+    const { result } = renderHook(() => useSessionState(KEY, false))
+    act(() => result.current[1](true))
+    const { result: r2 } = renderHook(() => useSessionState(KEY, false))
+    expect(r2.current[0]).toBe(true)
+  })
+
+  it('handles object values', () => {
+    const obj = { a: 1, b: 'hello' }
+    const { result } = renderHook(() => useSessionState(KEY, {}))
+    act(() => result.current[1](obj))
+    const { result: r2 } = renderHook(() => useSessionState(KEY, {}))
+    expect(r2.current[0]).toEqual(obj)
+  })
+
+  it('returns the initial value when stored JSON is invalid', () => {
+    sessionStorage.setItem(KEY, 'not-json{{{')
+    const { result } = renderHook(() => useSessionState(KEY, 'fallback'))
+    expect(result.current[0]).toBe('fallback')
+  })
+
+  describe('Set support', () => {
+    it('returns the initial Set when nothing is stored', () => {
+      const { result } = renderHook(() => useSessionState(KEY, new Set(['a', 'b'])))
+      expect(result.current[0]).toBeInstanceOf(Set)
+      expect([...result.current[0]]).toEqual(['a', 'b'])
+    })
+
+    it('rehydrates a Set from sessionStorage', () => {
+      sessionStorage.setItem(KEY, JSON.stringify(['x', 'y']))
+      const { result } = renderHook(() => useSessionState(KEY, new Set()))
+      expect(result.current[0]).toBeInstanceOf(Set)
+      expect(result.current[0].has('x')).toBe(true)
+      expect(result.current[0].has('y')).toBe(true)
+    })
+
+    it('persists a Set as a JSON array', () => {
+      const { result } = renderHook(() => useSessionState(KEY, new Set()))
+      act(() => result.current[1](new Set(['foo', 'bar'])))
+      const stored = JSON.parse(sessionStorage.getItem(KEY))
+      expect(Array.isArray(stored)).toBe(true)
+      expect(stored).toContain('foo')
+      expect(stored).toContain('bar')
+    })
+
+    it('empty Set is stored and rehydrated correctly', () => {
+      const { result } = renderHook(() => useSessionState(KEY, new Set(['seed'])))
+      act(() => result.current[1](new Set()))
+      const { result: r2 } = renderHook(() => useSessionState(KEY, new Set(['seed'])))
+      expect(r2.current[0]).toBeInstanceOf(Set)
+      expect(r2.current[0].size).toBe(0)
+    })
+  })
+})

--- a/frontend/src/test/setup.js
+++ b/frontend/src/test/setup.js
@@ -1,19 +1,28 @@
 import '@testing-library/jest-dom'
 import '../i18n'
 
-// Node.js 22+ has a native localStorage that lacks clear() and doesn't reset
-// between tests. Replace it with a proper in-memory implementation for all tests.
-let _store = {}
-const localStorageMock = {
-  getItem:    (key)       => Object.prototype.hasOwnProperty.call(_store, key) ? _store[key] : null,
-  setItem:    (key, val)  => { _store[key] = String(val) },
-  removeItem: (key)       => { delete _store[key] },
-  clear:      ()          => { _store = {} },
-  get length()            { return Object.keys(_store).length },
-  key:        (i)         => Object.keys(_store)[i] ?? null,
+// Node.js 22+ has a native localStorage/sessionStorage that lacks clear() and
+// doesn't reset between tests. Replace both with proper in-memory implementations.
+function makeStorageMock() {
+  let _store = {}
+  return {
+    getItem:    (key)       => Object.prototype.hasOwnProperty.call(_store, key) ? _store[key] : null,
+    setItem:    (key, val)  => { _store[key] = String(val) },
+    removeItem: (key)       => { delete _store[key] },
+    clear:      ()          => { _store = {} },
+    get length()            { return Object.keys(_store).length },
+    key:        (i)         => Object.keys(_store)[i] ?? null,
+  }
 }
+const localStorageMock = makeStorageMock()
+const sessionStorageMock = makeStorageMock()
 Object.defineProperty(globalThis, 'localStorage', {
   value: localStorageMock,
+  writable: true,
+  configurable: true,
+})
+Object.defineProperty(globalThis, 'sessionStorage', {
+  value: sessionStorageMock,
   writable: true,
   configurable: true,
 })
@@ -34,7 +43,8 @@ Object.defineProperty(globalThis, 'matchMedia', {
   }),
 })
 
-// Clear localStorage before each test so state never leaks between tests.
+// Clear storage before each test so state never leaks between tests.
 beforeEach(() => {
   localStorageMock.clear()
+  sessionStorageMock.clear()
 })

--- a/frontend/src/views/MapsView.jsx
+++ b/frontend/src/views/MapsView.jsx
@@ -1,5 +1,6 @@
 import { useState, useEffect, useRef } from 'react'
 import { useNavigate } from 'react-router-dom'
+import useSessionState from '../hooks/useSessionState'
 import { useTranslation } from 'react-i18next'
 import { LuMap, LuX, LuTag, LuSearch } from 'react-icons/lu'
 import api from '../api'
@@ -34,7 +35,7 @@ export default function MapsView() {
   const [folderTags, setFolderTags] = useState({})
   const [filter, setFilter] = useState('')
   const [selectedTags, setSelectedTags] = useState(new Set())
-  const [collapsed, setCollapsed] = useState(new Set())
+  const [collapsed, setCollapsed] = useSessionState('grimoire:maps:collapsed', new Set())
   const [editingFolder, setEditingFolder] = useState(null)
   const [showAllTags, setShowAllTags] = useState(false)
   const [downloadModal, setDownloadModal] = useState(null)
@@ -53,14 +54,18 @@ export default function MapsView() {
       const ft = {}
       for (const f of foldersData.folders) ft[f.path] = f.tags
       setFolderTags(ft)
-      const keys = new Set()
-      mapsData.maps.forEach(m => {
-        const folder = getTopFolder(m)
-        const subPath = getSubPath(m)
-        keys.add(folder)
-        if (subPath) keys.add(`${folder}::${subPath}`)
-      })
-      setCollapsed(keys)
+      // Only set default collapsed state (all collapsed) when no saved state exists.
+      const hasSaved = sessionStorage.getItem('grimoire:maps:collapsed') !== null
+      if (!hasSaved) {
+        const keys = new Set()
+        mapsData.maps.forEach(m => {
+          const folder = getTopFolder(m)
+          const subPath = getSubPath(m)
+          keys.add(folder)
+          if (subPath) keys.add(`${folder}::${subPath}`)
+        })
+        setCollapsed(keys)
+      }
     })
   }, [])
 

--- a/frontend/src/views/SystemDetailView.jsx
+++ b/frontend/src/views/SystemDetailView.jsx
@@ -1,5 +1,6 @@
 import { useState, useEffect, useCallback, useRef } from 'react'
 import { useParams, useNavigate } from 'react-router-dom'
+import useSessionState from '../hooks/useSessionState'
 import { useTranslation } from 'react-i18next'
 import {
   LuArrowLeft, LuPencil, LuClipboard,
@@ -27,7 +28,7 @@ export default function SystemDetailView() {
   const [system, setSystem] = useState(null)
   const [editing, setEditing] = useState(false)
   const [editingBookId, setEditingBookId] = useState(null)
-  const [collapsedCats, setCollapsedCats] = useState(new Set())
+  const [collapsedCats, setCollapsedCats] = useSessionState(`grimoire:system:${systemId}:collapsed`, new Set())
   const [selectedTags, setSelectedTags] = useState(new Set())
   const [showAllTags, setShowAllTags] = useState(false)
   const [bookSort, setBookSort] = useState('title')

--- a/frontend/src/views/TokensView.jsx
+++ b/frontend/src/views/TokensView.jsx
@@ -1,5 +1,6 @@
 import { useState, useEffect, useRef } from 'react'
 import { useNavigate } from 'react-router-dom'
+import useSessionState from '../hooks/useSessionState'
 import { useTranslation } from 'react-i18next'
 import { LuUser, LuX, LuTag, LuSearch } from 'react-icons/lu'
 import api from '../api'
@@ -34,7 +35,7 @@ export default function TokensView() {
   const [folderTags, setFolderTags] = useState({})
   const [filter, setFilter] = useState('')
   const [selectedTags, setSelectedTags] = useState(new Set())
-  const [collapsed, setCollapsed] = useState(new Set())
+  const [collapsed, setCollapsed] = useSessionState('grimoire:tokens:collapsed', new Set())
   const [editingFolder, setEditingFolder] = useState(null)
   const [showAllTags, setShowAllTags] = useState(false)
   const [downloadModal, setDownloadModal] = useState(null)
@@ -53,14 +54,18 @@ export default function TokensView() {
       const ft = {}
       for (const f of foldersData.folders) ft[f.path] = f.tags
       setFolderTags(ft)
-      const keys = new Set()
-      tokensData.tokens.forEach(tok => {
-        const folder = getTopFolder(tok)
-        const subPath = getSubPath(tok)
-        keys.add(folder)
-        if (subPath) keys.add(`${folder}::${subPath}`)
-      })
-      setCollapsed(keys)
+      // Only set default collapsed state (all collapsed) when no saved state exists.
+      const hasSaved = sessionStorage.getItem('grimoire:tokens:collapsed') !== null
+      if (!hasSaved) {
+        const keys = new Set()
+        tokensData.tokens.forEach(tok => {
+          const folder = getTopFolder(tok)
+          const subPath = getSubPath(tok)
+          keys.add(folder)
+          if (subPath) keys.add(`${folder}::${subPath}`)
+        })
+        setCollapsed(keys)
+      }
     })
   }, [])
 


### PR DESCRIPTION
## Summary

* Add useScrollRestoration hook: saves/restores the main scroll container's
  position per-route in sessionStorage, deferred one rAF so the incoming view
  finishes rendering before scrollTop is applied
*  Add useSessionState hook: drop-in useState replacement that persists values
  (including Set objects) to sessionStorage, surviving in-session navigation
  but resetting on full page reload
*  Wire useScrollRestoration into AppShell's <main> ref
*  Use useSessionState for collapsed-folder state in MapsView, TokensView, and
  SystemDetailView (keyed per-system); default "all collapsed" is only applied
  when no saved state exists so returning users see their last layout
* Add tests for both hooks; extend test setup to mock sessionStorage alongside
  localStorage

## Type of change

- [ ] Bug fix
- [x] New feature
- [ ] Refactor / cleanup
- [ ] Docs / configuration only

## Testing

- [x] Backend tests pass (`pytest -q`)
- [x] Frontend tests pass (`npm test`)
- [x] Tested manually in the browser

## Notes for reviewer

