### PR TITLE
Enhancement: Group books into collapsible subfolders within any category

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,9 +66,17 @@ library/
 │   └── Dungeons and Dragons 5e/
 │       ├── core/
 │       │   ├── Players Handbook.pdf
-│       │   └── Dungeon Masters Guide.pdf
+│       │   ├── Dungeon Masters Guide.pdf
+│       │   └── monsters/              ← subfolder within a category
+│       │       ├── Monster Manual.pdf
+│       │       └── Mordenkainen's Monsters.pdf
 │       ├── supplements/
 │       ├── adventures/
+│       │   ├── Curse of Strahd/       ← adventure path subfolder
+│       │   │   ├── Curse of Strahd.pdf
+│       │   │   └── Strahd DM Screen.pdf
+│       │   └── Lost Mine of Phandelver/
+│       │       └── Lost Mine of Phandelver.pdf
 │       ├── character-sheets/
 │       ├── handouts/
 │       └── homebrew/
@@ -235,6 +243,31 @@ Folder name matching is **case-insensitive**, and hyphens, underscores, and spac
 > Any subfolder name that doesn't match the recognized keywords becomes its own category, slugified from the folder name. For example, a folder named `Bestiary` becomes the `bestiary` category.
 >
 > After adding new files, use **Rescan** in the sidebar (or Settings → Maintenance) to pick up the changes.
+
+#### Subfolders within a category
+
+Any category folder can contain named subfolders to group related books together. Grimoire detects these automatically and displays them as collapsible folder groups within the category section — no configuration needed.
+
+```
+books/
+└── Pathfinder 2e/
+    ├── core/
+    │   ├── Core Rulebook.pdf          ← ungrouped, shown at top of Core Rulebooks
+    │   └── monsters/                  ← subfolder group "Monsters"
+    │       ├── Bestiary.pdf
+    │       ├── Bestiary 2.pdf
+    │       └── Bestiary 3.pdf
+    └── adventures/
+        ├── Standalone Adventure.pdf   ← ungrouped
+        ├── Abomination Vaults/        ← subfolder group "Abomination Vaults"
+        │   ├── Ruins of Gauntlight.pdf
+        │   ├── Hands of the Devil.pdf
+        │   └── Eyes of Empty Death.pdf
+        └── Outlaws of Alkenstar/
+            └── ...
+```
+
+Books without a subfolder are shown ungrouped at the top of their category section, above any subfolder groups. Subfolder groups are collapsible and include a download button for the whole group.
 
 #### Marking a system as explicit
 

--- a/backend/models.py
+++ b/backend/models.py
@@ -89,6 +89,16 @@ class Book(Base):
     game_system = relationship("GameSystem", back_populates="books")
 
 
+class BookFolder(Base):
+    """Tags applied to a book subcategory folder path (e.g. adventure path groupings)."""
+
+    __tablename__ = "book_folders"
+
+    id = Column(String(36), primary_key=True, default=_uuid)
+    path = Column(String(1000), nullable=False, unique=True)
+    tags = Column(JSON, default=list)
+
+
 class GenericMap(Base):
     """A generic map (not tied to a specific game system)."""
 

--- a/backend/routers/downloads.py
+++ b/backend/routers/downloads.py
@@ -175,6 +175,31 @@ def _files_for_system_category(db, system_id: str, category: str, see_explicit: 
     return files, f"{_safe_name(system.name)}_{_safe_name(category)}"
 
 
+def _files_for_book_folder(db, system_id: str, folder: str, see_explicit: bool) -> tuple[list, str]:
+    """Books in a named subfolder within any category.
+    Path structure: books/{SystemName}/{categoryDir}/{folder}/...
+    The folder name is matched against path segment index 3 (0-based).
+    """
+    system = db.query(GameSystem).filter_by(id=system_id).first()
+    if not system:
+        raise HTTPException(404, "System not found")
+
+    q = db.query(Book).filter_by(game_system_id=system_id)
+    if not see_explicit:
+        q = q.filter(Book.is_explicit != True)
+
+    def _in_folder(b: Book) -> bool:
+        parts = b.relative_path.replace("\\", "/").split("/")
+        return len(parts) > 4 and parts[3] == folder
+
+    files = [
+        (safe, _safe_arcname(b.filename))
+        for b in q.all()
+        if _in_folder(b) and (safe := _safe_filepath(b.filepath))
+    ]
+    return files, f"{_safe_name(system.name)}_{_safe_name(folder)}"
+
+
 def _files_for_map_folder(db, folder: str) -> tuple[list, str]:
     prefix = folder.strip("/") + "/"
     maps = db.query(GenericMap).all()
@@ -225,11 +250,11 @@ def _files_for_token_folder(db, folder: str, see_explicit: bool) -> tuple[list, 
     ),
 )
 def download_archive(
-    type: str = Query(..., description="Scope: system | system_category | map_folder | token_folder"),
+    type: str = Query(..., description="Scope: system | system_category | book_folder | map_folder | token_folder"),
     fmt: str = Query("zip", description="Archive format: zip | tar | tar.gz | tar.bz2"),
-    id: Optional[str] = Query(None, description="System ID (system / system_category)"),
+    id: Optional[str] = Query(None, description="System ID (system / system_category / book_folder)"),
     category: Optional[str] = Query(None, description="Book category slug (system_category)"),
-    folder: Optional[str] = Query(None, description="Folder path (map_folder / token_folder)"),
+    folder: Optional[str] = Query(None, description="Folder path (book_folder / map_folder / token_folder)"),
     current_user: CurrentUser = Depends(get_current_user),
 ):
     db = SessionLocal()
@@ -247,6 +272,13 @@ def download_archive(
             if not category:
                 raise HTTPException(400, "category is required for type=system_category")
             files, base = _files_for_system_category(db, id, category, see_explicit)
+
+        elif type == "book_folder":
+            if not id:
+                raise HTTPException(400, "id is required for type=book_folder")
+            if not folder:
+                raise HTTPException(400, "folder is required for type=book_folder")
+            files, base = _files_for_book_folder(db, id, folder, see_explicit)
 
         elif type == "map_folder":
             if not folder:

--- a/backend/routers/systems.py
+++ b/backend/routers/systems.py
@@ -6,13 +6,18 @@ from fastapi import APIRouter, HTTPException, Depends
 from pydantic import BaseModel
 
 from ..config import SessionLocal
-from ..models import GameSystem, Book, User
+from ..models import GameSystem, Book, BookFolder, User
 from ..auth import require_gm_or_admin, get_current_user, CurrentUser
 
 
 class PublisherEntry(BaseModel):
     name: str
     url: str = ""
+
+
+class BookFolderUpdate(BaseModel):
+    path: str
+    tags: list[str]
 
 
 class GameSystemUpdate(BaseModel):
@@ -152,10 +157,49 @@ def get_system(system_id: str, current_user: CurrentUser = Depends(get_current_u
                     "tags": b.tags or [],
                     "is_explicit": bool(b.is_explicit),
                     "is_missing": bool(b.is_missing),
+                    "relative_path": b.relative_path,
                 }
                 for b in books
             ],
         }
+    finally:
+        db.close()
+
+
+@router.get(
+    "/{system_id}/book-folders",
+    summary="List book folders",
+    description="Returns all known book subcategory folder paths for a system and their associated tags.",
+)
+def list_book_folders(system_id: str, _: CurrentUser = Depends(get_current_user)):
+    db = SessionLocal()
+    try:
+        system = db.query(GameSystem).filter_by(id=system_id).first()
+        if not system:
+            raise HTTPException(404, "System not found")
+        folders = db.query(BookFolder).filter(BookFolder.path.like(f"{system_id}/%")).all()
+        return {"folders": [{"path": f.path, "tags": f.tags or []} for f in folders]}
+    finally:
+        db.close()
+
+
+@router.patch(
+    "/{system_id}/book-folders",
+    summary="Set tags on a book folder",
+    description="Creates or replaces the tag list for a book subcategory folder. GM or admin role required.",
+)
+def update_book_folder(
+    system_id: str, data: BookFolderUpdate, _: CurrentUser = Depends(require_gm_or_admin)  # noqa: ARG001
+):
+    db = SessionLocal()
+    try:
+        folder = db.query(BookFolder).filter_by(path=data.path).first()
+        if folder:
+            folder.tags = data.tags
+        else:
+            db.add(BookFolder(path=data.path, tags=data.tags))
+        db.commit()
+        return {"path": data.path, "tags": data.tags}
     finally:
         db.close()
 

--- a/docker-compose.dev.yml
+++ b/docker-compose.dev.yml
@@ -19,6 +19,7 @@ services:
       - SECRET_KEY=7ba05239cdd5752065eb6bd5db866bf8a0919d2760b1fcf158744f5ef5833834
       - VALKEY_URL=redis://valkey:6379/0
       - OPDS_ENABLED=true
+      - LOG_LEVEL=debug
     develop:
       watch:
         - action: sync+restart

--- a/frontend/src/components/system/BookFolderGroup.jsx
+++ b/frontend/src/components/system/BookFolderGroup.jsx
@@ -1,0 +1,113 @@
+import { LuFolder, LuChevronDown, LuChevronRight, LuDownload } from 'react-icons/lu'
+import { toTitleCase } from '../../utils'
+import BookRow from './BookRow'
+import BookEditor from './BookEditor'
+
+/**
+ * Renders a single subfolder group within a book category section.
+ * Used in SystemDetailView whenever a category has books organised into subfolders.
+ *
+ * Props:
+ *   folder           – string folder name (e.g. "Monsters", "Curse of Strahd")
+ *   books            – sorted array of book objects in this folder
+ *   systemId         – string system id (for download scoping)
+ *   category         – string category slug (for download scoping)
+ *   collapsed        – Set of collapsed folder keys
+ *   onToggle         – (key: string) => void
+ *   editingBookId    – currently-open book editor id
+ *   setEditingBookId – setter
+ *   onOpenBook       – (book) => void
+ *   isEditor         – bool
+ *   onSaveBook       – (bookId, updated) => void
+ *   onDownload       – ({ title, params }) => void
+ */
+export default function BookFolderGroup({
+  folder,
+  books,
+  systemId,
+  category,
+  collapsed,
+  onToggle,
+  editingBookId,
+  setEditingBookId,
+  onOpenBook,
+  isEditor,
+  onSaveBook,
+  onDownload,
+}) {
+  const isCollapsed = collapsed.has(`${category}::${folder}`)
+  const toggleKey = `${category}::${folder}`
+
+  return (
+    <div style={{ marginBottom: 8, border: '1px solid var(--border)', borderRadius: 10, overflow: 'hidden' }}>
+      {/* Folder header */}
+      <div style={{
+        padding: '10px 16px',
+        background: 'var(--bg-panel)',
+        borderBottom: isCollapsed ? 'none' : '1px solid var(--border)',
+        display: 'flex',
+        alignItems: 'center',
+        gap: 10,
+      }}>
+        <button
+          onClick={() => onToggle(toggleKey)}
+          aria-expanded={!isCollapsed}
+          style={{
+            display: 'flex', alignItems: 'center', gap: 8,
+            background: 'none', border: 'none', cursor: 'pointer',
+            padding: 0, flex: 1, minWidth: 0, overflow: 'hidden',
+          }}
+        >
+          {isCollapsed
+            ? <LuChevronRight size={15} color="var(--gold-dim)" style={{ flexShrink: 0 }} />
+            : <LuChevronDown size={15} color="var(--gold-dim)" style={{ flexShrink: 0 }} />
+          }
+          <LuFolder size={15} color="var(--gold-dim)" style={{ flexShrink: 0 }} />
+          <span style={{ fontSize: 16, color: 'var(--gold-dim)', fontFamily: 'Cinzel, serif', fontWeight: 600, whiteSpace: 'nowrap', overflow: 'hidden', textOverflow: 'ellipsis' }}>
+            {toTitleCase(folder)}
+          </span>
+          <span style={{ fontSize: 13, color: 'var(--text-muted)', flexShrink: 0, marginLeft: 4 }}>
+            ({books.length})
+          </span>
+        </button>
+        <button
+          onClick={e => { e.stopPropagation(); onDownload?.({ title: toTitleCase(folder), params: { type: 'book_folder', id: systemId, category, folder } }) }}
+          style={zipBtnStyle}
+          title={`Download all books in ${folder}`}
+        >
+          <LuDownload size={11} /> Download
+        </button>
+      </div>
+
+      {/* Book list */}
+      {!isCollapsed && (
+        <div style={{ padding: '12px 16px', display: 'flex', flexDirection: 'column', gap: 8 }}>
+          {books.map(book => (
+            <div key={book.id}>
+              <BookRow
+                book={book}
+                onOpen={() => onOpenBook(book)}
+                onEdit={isEditor ? () => setEditingBookId(id => id === book.id ? null : book.id) : null}
+                editing={editingBookId === book.id}
+              />
+              {editingBookId === book.id && (
+                <BookEditor
+                  book={book}
+                  onSave={(updated) => { onSaveBook(book.id, updated); setEditingBookId(null) }}
+                  onClose={() => setEditingBookId(null)}
+                />
+              )}
+            </div>
+          ))}
+        </div>
+      )}
+    </div>
+  )
+}
+
+const zipBtnStyle = {
+  display: 'inline-flex', alignItems: 'center', gap: 3,
+  padding: '2px 7px', borderRadius: 5, fontSize: 12, flexShrink: 0,
+  color: 'var(--text-muted)', border: '1px solid var(--border)',
+  background: 'var(--bg-card)', cursor: 'pointer',
+}

--- a/frontend/src/components/system/BookFolderGroup.test.jsx
+++ b/frontend/src/components/system/BookFolderGroup.test.jsx
@@ -1,0 +1,196 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { render, screen } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+import BookFolderGroup from './BookFolderGroup'
+import * as FavCtx from '../../context/FavoritesContext'
+import * as api from '../../api'
+
+vi.mock('../../context/FavoritesContext', () => ({
+  useFavorites: vi.fn(),
+}))
+
+vi.mock('../../api', () => ({
+  default: {},
+  mediaUrl: (path) => `http://localhost${path}`,
+}))
+
+// BookEditor makes its own API calls — stub it out so tests stay focused.
+vi.mock('./BookEditor', () => ({
+  default: ({ onClose }) => (
+    <div data-testid="book-editor">
+      <button onClick={onClose}>Close Editor</button>
+    </div>
+  ),
+}))
+
+function makeBook(overrides = {}) {
+  return {
+    id: `book-${Math.random().toString(36).slice(2)}`,
+    title: 'Test Book',
+    category: 'adventure',
+    page_count: 200,
+    year: 2021,
+    publisher: 'Paizo',
+    has_thumbnail: false,
+    is_explicit: false,
+    is_missing: false,
+    indexed: false,
+    index_failed: false,
+    index_error: '',
+    tags: [],
+    relative_path: 'books/PF2e/adventures/Abomination Vaults/book.pdf',
+    ...overrides,
+  }
+}
+
+function makeProps(overrides = {}) {
+  return {
+    folder: 'Abomination Vaults',
+    books: [makeBook()],
+    systemId: 'system-1',
+    category: 'adventure',
+    collapsed: new Set(),
+    onToggle: vi.fn(),
+    editingBookId: null,
+    setEditingBookId: vi.fn(),
+    onOpenBook: vi.fn(),
+    isEditor: false,
+    onSaveBook: vi.fn(),
+    onDownload: vi.fn(),
+    ...overrides,
+  }
+}
+
+describe('BookFolderGroup', () => {
+  beforeEach(() => {
+    FavCtx.useFavorites.mockReturnValue({
+      isFavorite: () => false,
+      toggleFavorite: vi.fn(),
+    })
+  })
+
+  // --- Folder header ---
+
+  it('renders the folder name in the header', () => {
+    render(<BookFolderGroup {...makeProps()} />)
+    expect(screen.getByText('Abomination Vaults')).toBeInTheDocument()
+  })
+
+  it('renders the book count in the header', () => {
+    const books = [makeBook(), makeBook()]
+    render(<BookFolderGroup {...makeProps({ books })} />)
+    expect(screen.getByText('(2)')).toBeInTheDocument()
+  })
+
+  it('renders a download button', () => {
+    render(<BookFolderGroup {...makeProps()} />)
+    expect(screen.getByText('Download')).toBeInTheDocument()
+  })
+
+  // --- Expand / collapse ---
+
+  it('shows book rows when folder is expanded', () => {
+    const book = makeBook({ title: 'Ruins of Gauntlight' })
+    render(<BookFolderGroup {...makeProps({ books: [book] })} />)
+    expect(screen.getByText('Ruins of Gauntlight')).toBeInTheDocument()
+  })
+
+  it('hides book rows when folder key is in collapsed set', () => {
+    const book = makeBook({ title: 'Ruins of Gauntlight' })
+    const collapsed = new Set(['adventure::Abomination Vaults'])
+    render(<BookFolderGroup {...makeProps({ books: [book], collapsed })} />)
+    expect(screen.queryByText('Ruins of Gauntlight')).not.toBeInTheDocument()
+  })
+
+  it('calls onToggle with category::folder key when header is clicked', async () => {
+    const onToggle = vi.fn()
+    render(<BookFolderGroup {...makeProps({ onToggle })} />)
+    await userEvent.click(screen.getByRole('button', { name: /abomination vaults/i }))
+    expect(onToggle).toHaveBeenCalledWith('adventure::Abomination Vaults')
+  })
+
+  // --- Collapse key is namespaced by category ---
+
+  it('uses category::folder as the collapse key, so same name in different categories collapses independently', () => {
+    // A "monsters" folder under core should collapse independently from one under supplement
+    const coreProps = makeProps({ folder: 'monsters', category: 'core', collapsed: new Set(['core::monsters']) })
+    const { rerender } = render(<BookFolderGroup {...coreProps} />)
+    expect(screen.queryByText(coreProps.books[0].title)).not.toBeInTheDocument()
+
+    const suppProps = makeProps({ folder: 'monsters', category: 'supplement', collapsed: new Set() })
+    rerender(<BookFolderGroup {...suppProps} />)
+    expect(screen.getByText(suppProps.books[0].title)).toBeInTheDocument()
+  })
+
+  // --- Multiple books ---
+
+  it('renders all books in the folder', () => {
+    const books = [
+      makeBook({ title: 'Ruins of Gauntlight' }),
+      makeBook({ title: 'Hands of the Devil' }),
+      makeBook({ title: 'Eyes of Empty Death' }),
+    ]
+    render(<BookFolderGroup {...makeProps({ books })} />)
+    expect(screen.getByText('Ruins of Gauntlight')).toBeInTheDocument()
+    expect(screen.getByText('Hands of the Devil')).toBeInTheDocument()
+    expect(screen.getByText('Eyes of Empty Death')).toBeInTheDocument()
+  })
+
+  // --- onOpenBook callback ---
+
+  it('calls onOpenBook when a book row is clicked', async () => {
+    const onOpenBook = vi.fn()
+    const book = makeBook({ title: 'Ruins of Gauntlight' })
+    render(<BookFolderGroup {...makeProps({ books: [book], onOpenBook })} />)
+    await userEvent.click(screen.getByRole('button', { name: /ruins of gauntlight/i }))
+    expect(onOpenBook).toHaveBeenCalledWith(book)
+  })
+
+  // --- Edit button ---
+
+  it('does not show edit button when isEditor is false', () => {
+    render(<BookFolderGroup {...makeProps({ isEditor: false })} />)
+    expect(screen.queryByLabelText(/edit metadata/i)).not.toBeInTheDocument()
+  })
+
+  it('shows edit button when isEditor is true', () => {
+    render(<BookFolderGroup {...makeProps({ isEditor: true })} />)
+    expect(screen.getByLabelText(/edit metadata/i)).toBeInTheDocument()
+  })
+
+  it('calls setEditingBookId when edit button is clicked', async () => {
+    const setEditingBookId = vi.fn()
+    render(<BookFolderGroup {...makeProps({ isEditor: true, setEditingBookId })} />)
+    await userEvent.click(screen.getByLabelText(/edit metadata/i))
+    expect(setEditingBookId).toHaveBeenCalled()
+  })
+
+  it('renders BookEditor when editingBookId matches a book', () => {
+    const book = makeBook()
+    render(<BookFolderGroup {...makeProps({ books: [book], editingBookId: book.id, isEditor: true })} />)
+    expect(screen.getByTestId('book-editor')).toBeInTheDocument()
+  })
+
+  it('does not render BookEditor when editingBookId does not match any book', () => {
+    render(<BookFolderGroup {...makeProps({ editingBookId: 'other-id' })} />)
+    expect(screen.queryByTestId('book-editor')).not.toBeInTheDocument()
+  })
+
+  // --- Download callback ---
+
+  it('calls onDownload with correct params when download button is clicked', async () => {
+    const onDownload = vi.fn()
+    render(<BookFolderGroup {...makeProps({ onDownload, systemId: 'sys-42', category: 'adventure', folder: 'Abomination Vaults' })} />)
+    await userEvent.click(screen.getByText('Download'))
+    expect(onDownload).toHaveBeenCalledWith(
+      expect.objectContaining({
+        params: expect.objectContaining({
+          type: 'book_folder',
+          id: 'sys-42',
+          category: 'adventure',
+          folder: 'Abomination Vaults',
+        }),
+      })
+    )
+  })
+})

--- a/frontend/src/views/SystemDetailView.jsx
+++ b/frontend/src/views/SystemDetailView.jsx
@@ -16,8 +16,18 @@ import Tag from '../components/Tag'
 import BookRow from '../components/system/BookRow'
 import BookEditor from '../components/system/BookEditor'
 import SystemEditor from '../components/system/SystemEditor'
+import BookFolderGroup from '../components/system/BookFolderGroup'
 import FavoriteButton from '../components/FavoriteButton'
 import { CATEGORY_ICONS, CATEGORY_ORDER } from '../constants'
+
+/** Extract the subfolder name from a book's relative_path.
+ *  Path structure: books/{SystemName}/{categoryDir}/{SubFolder}/book.pdf
+ *  Returns the subfolder name, or null if the book sits directly in the category dir. */
+function getBookSubfolder(book) {
+  const parts = (book.relative_path || '').replace(/\\/g, '/').split('/')
+  // parts[0]=books, parts[1]=SystemName, parts[2]=category dir, parts[3]=subfolder or filename
+  return parts.length > 4 ? parts[3] : null
+}
 
 export default function SystemDetailView() {
   const { t } = useTranslation()
@@ -29,6 +39,7 @@ export default function SystemDetailView() {
   const [editing, setEditing] = useState(false)
   const [editingBookId, setEditingBookId] = useState(null)
   const [collapsedCats, setCollapsedCats] = useSessionState(`grimoire:system:${systemId}:collapsed`, new Set())
+  const [collapsedSubfolders, setCollapsedSubfolders] = useSessionState(`grimoire:system:${systemId}:subfolders`, new Set())
   const [selectedTags, setSelectedTags] = useState(new Set())
   const [showAllTags, setShowAllTags] = useState(false)
   const [bookSort, setBookSort] = useState('title')
@@ -335,30 +346,97 @@ export default function SystemDetailView() {
                 <LuDownload size={11} /> {t('systemDetail.download')}
               </button>
             </div>
-              {!isCollapsed && (
-                <div style={{ display: 'flex', flexDirection: 'column', gap: 8 }}>
-                  {books.map(book => (
-                    <div key={book.id}>
-                      <BookRow
-                        book={book}
-                        onOpen={() => navigate(`/library/book/${book.id}`)}
-                        onEdit={isEditor ? () => setEditingBookId(id => id === book.id ? null : book.id) : null}
-                        editing={editingBookId === book.id}
-                      />
-                      {editingBookId === book.id && (
-                        <BookEditor
-                          book={book}
-                          onSave={(updated) => {
-                            setSystem(s => ({ ...s, books: s.books.map(b => b.id === book.id ? { ...b, ...updated } : b) }))
-                            setEditingBookId(null)
-                          }}
-                          onClose={() => setEditingBookId(null)}
-                        />
-                      )}
+              {!isCollapsed && (() => {
+                // Group books by subfolder (derived from relative_path).
+                // Books sitting directly in the category dir have no subfolder (key='').
+                const folderMap = {}
+                for (const book of books) {
+                  const sub = getBookSubfolder(book)
+                  const key = sub || ''
+                  if (!folderMap[key]) folderMap[key] = []
+                  folderMap[key].push(book)
+                }
+                const hasFolders = Object.keys(folderMap).some(k => k !== '')
+                const toggleSubfolder = (key) => setCollapsedSubfolders(prev => {
+                  const next = new Set(prev)
+                  next.has(key) ? next.delete(key) : next.add(key)
+                  return next
+                })
+                const saveBook = (bookId, updated) => setSystem(s => ({ ...s, books: s.books.map(b => b.id === bookId ? { ...b, ...updated } : b) }))
+
+                if (!hasFolders) {
+                  // No subfolders — render flat list
+                  return (
+                    <div style={{ display: 'flex', flexDirection: 'column', gap: 8 }}>
+                      {books.map(book => (
+                        <div key={book.id}>
+                          <BookRow
+                            book={book}
+                            onOpen={() => navigate(`/library/book/${book.id}`)}
+                            onEdit={isEditor ? () => setEditingBookId(id => id === book.id ? null : book.id) : null}
+                            editing={editingBookId === book.id}
+                          />
+                          {editingBookId === book.id && (
+                            <BookEditor
+                              book={book}
+                              onSave={(updated) => { saveBook(book.id, updated); setEditingBookId(null) }}
+                              onClose={() => setEditingBookId(null)}
+                            />
+                          )}
+                        </div>
+                      ))}
                     </div>
-                  ))}
-                </div>
-              )}
+                  )
+                }
+
+                const sortedFolderKeys = Object.keys(folderMap).sort((a, b) => {
+                  if (a === '') return 1
+                  if (b === '') return -1
+                  return a.localeCompare(b)
+                })
+                return (
+                  <div style={{ display: 'flex', flexDirection: 'column', gap: 4 }}>
+                    {sortedFolderKeys.map(key => key === '' ? (
+                      // Ungrouped books (no subfolder) — render flat above the folder widgets
+                      <div key="__ungrouped__" style={{ display: 'flex', flexDirection: 'column', gap: 8, marginBottom: 4 }}>
+                        {folderMap[''].map(book => (
+                          <div key={book.id}>
+                            <BookRow
+                              book={book}
+                              onOpen={() => navigate(`/library/book/${book.id}`)}
+                              onEdit={isEditor ? () => setEditingBookId(id => id === book.id ? null : book.id) : null}
+                              editing={editingBookId === book.id}
+                            />
+                            {editingBookId === book.id && (
+                              <BookEditor
+                                book={book}
+                                onSave={(updated) => { saveBook(book.id, updated); setEditingBookId(null) }}
+                                onClose={() => setEditingBookId(null)}
+                              />
+                            )}
+                          </div>
+                        ))}
+                      </div>
+                    ) : (
+                      <BookFolderGroup
+                        key={key}
+                        folder={key}
+                        books={folderMap[key]}
+                        systemId={system.id}
+                        category={cat}
+                        collapsed={collapsedSubfolders}
+                        onToggle={toggleSubfolder}
+                        editingBookId={editingBookId}
+                        setEditingBookId={setEditingBookId}
+                        onOpenBook={(book) => navigate(`/library/book/${book.id}`)}
+                        isEditor={isEditor}
+                        onSaveBook={saveBook}
+                        onDownload={setDownloadModal}
+                      />
+                    ))}
+                  </div>
+                )
+              })()}
             </div>
           )
         })}

--- a/frontend/src/views/SystemDetailView.test.jsx
+++ b/frontend/src/views/SystemDetailView.test.jsx
@@ -1,0 +1,260 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { render, screen, waitFor } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+import { MemoryRouter } from 'react-router-dom'
+import SystemDetailView from './SystemDetailView'
+import api from '../api'
+
+// ── Mocks ────────────────────────────────────────────────────────────────────
+
+vi.mock('../api', () => ({
+  default: { get: vi.fn(), patch: vi.fn() },
+  mediaUrl: (path) => `http://localhost${path}`,
+}))
+
+vi.mock('react-router-dom', async (importOriginal) => {
+  const actual = await importOriginal()
+  return {
+    ...actual,
+    useParams: () => ({ systemId: 'system-1' }),
+    useNavigate: () => vi.fn(),
+  }
+})
+
+vi.mock('../context/AuthContext', () => ({
+  useAuth: () => ({ user: { id: 'u1', role: 'admin' } }),
+}))
+
+vi.mock('../context/FavoritesContext', () => ({
+  useFavorites: () => ({ isFavorite: () => false, toggleFavorite: vi.fn() }),
+}))
+
+vi.mock('../components/FavoriteButton', () => ({
+  default: () => null,
+}))
+
+vi.mock('../components/DownloadArchiveModal', () => ({
+  default: ({ onClose }) => (
+    <div data-testid="download-modal">
+      <button onClick={onClose}>Close</button>
+    </div>
+  ),
+}))
+
+vi.mock('../components/system/BookEditor', () => ({
+  default: ({ onClose }) => (
+    <div data-testid="book-editor">
+      <button onClick={onClose}>Close Editor</button>
+    </div>
+  ),
+}))
+
+vi.mock('../components/system/SystemEditor', () => ({
+  default: () => <div data-testid="system-editor" />,
+}))
+
+// ── Fixtures ─────────────────────────────────────────────────────────────────
+
+function makeBook(overrides = {}) {
+  const id = overrides.id ?? `book-${Math.random().toString(36).slice(2)}`
+  return {
+    id,
+    title: 'Test Book',
+    category: 'core',
+    page_count: 100,
+    year: 2020,
+    publisher: 'Publisher',
+    has_thumbnail: false,
+    is_explicit: false,
+    is_missing: false,
+    indexed: false,
+    index_failed: false,
+    index_error: '',
+    tags: [],
+    relative_path: `books/TestSystem/core/book.pdf`,
+    ...overrides,
+  }
+}
+
+function makeSystem(books = []) {
+  return {
+    id: 'system-1',
+    name: 'Test System',
+    slug: 'test-system',
+    description: '',
+    publishers: [],
+    character_builder_url: '',
+    tags: [],
+    genre: '',
+    cover_image: '',
+    cover_book_id: null,
+    is_explicit: false,
+    books,
+  }
+}
+
+function renderView() {
+  return render(
+    <MemoryRouter initialEntries={['/library/system/system-1']}>
+      <SystemDetailView />
+    </MemoryRouter>
+  )
+}
+
+// ── Tests ─────────────────────────────────────────────────────────────────────
+
+describe('SystemDetailView — subfolder grouping', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+  })
+
+  describe('getBookSubfolder logic (via render)', () => {
+    it('renders a flat list when no books have subfolders', async () => {
+      const books = [
+        makeBook({ title: 'PHB', relative_path: 'books/TestSystem/core/phb.pdf' }),
+        makeBook({ title: 'DMG', relative_path: 'books/TestSystem/core/dmg.pdf' }),
+      ]
+      api.get.mockResolvedValue(makeSystem(books))
+      renderView()
+
+      await waitFor(() => expect(screen.getByText('PHB')).toBeInTheDocument())
+      expect(screen.getByText('DMG')).toBeInTheDocument()
+      // No folder headers rendered — books show directly
+      expect(screen.queryByRole('button', { name: /monsters/i })).not.toBeInTheDocument()
+    })
+
+    it('renders BookFolderGroup headers when books have subfolders', async () => {
+      const books = [
+        makeBook({ title: 'Bestiary 1', relative_path: 'books/TestSystem/core/monsters/Bestiary 1.pdf' }),
+        makeBook({ title: 'Bestiary 2', relative_path: 'books/TestSystem/core/monsters/Bestiary 2.pdf' }),
+      ]
+      api.get.mockResolvedValue(makeSystem(books))
+      renderView()
+
+      await waitFor(() =>
+        expect(screen.getByRole('button', { name: /monsters/i })).toBeInTheDocument()
+      )
+    })
+
+    it('books in a subfolder are grouped under one folder header', async () => {
+      const books = [
+        makeBook({ title: 'Bestiary 1', relative_path: 'books/TestSystem/core/monsters/b1.pdf' }),
+        makeBook({ title: 'Bestiary 2', relative_path: 'books/TestSystem/core/monsters/b2.pdf' }),
+        makeBook({ title: 'Bestiary 3', relative_path: 'books/TestSystem/core/monsters/b3.pdf' }),
+      ]
+      api.get.mockResolvedValue(makeSystem(books))
+      renderView()
+
+      await waitFor(() => expect(screen.getByText('Bestiary 1')).toBeInTheDocument())
+      expect(screen.getByText('Bestiary 2')).toBeInTheDocument()
+      expect(screen.getByText('Bestiary 3')).toBeInTheDocument()
+      // Only one "monsters" folder header
+      expect(screen.getAllByRole('button', { name: /monsters/i })).toHaveLength(1)
+    })
+
+    it('ungrouped books (no subfolder) render flat above folder groups', async () => {
+      const books = [
+        makeBook({ title: 'Core Rulebook', relative_path: 'books/TestSystem/core/crb.pdf' }),
+        makeBook({ title: 'Bestiary',      relative_path: 'books/TestSystem/core/monsters/Bestiary.pdf' }),
+      ]
+      api.get.mockResolvedValue(makeSystem(books))
+      renderView()
+
+      await waitFor(() => expect(screen.getByText('Core Rulebook')).toBeInTheDocument())
+      expect(screen.getByText('Bestiary')).toBeInTheDocument()
+      expect(screen.getByRole('button', { name: /monsters/i })).toBeInTheDocument()
+    })
+
+    it('works for adventure category subfolders', async () => {
+      const books = [
+        makeBook({
+          title: 'Ruins of Gauntlight',
+          category: 'adventure',
+          relative_path: 'books/TestSystem/adventures/Abomination Vaults/rog.pdf',
+        }),
+        makeBook({
+          title: 'Strahd AP',
+          category: 'adventure',
+          relative_path: 'books/TestSystem/adventures/Curse of Strahd/cos.pdf',
+        }),
+      ]
+      api.get.mockResolvedValue(makeSystem(books))
+      renderView()
+
+      // Each AP name should appear as a folder header button (aria-expanded)
+      await waitFor(() =>
+        expect(screen.getByRole('button', { name: /abomination vaults/i })).toBeInTheDocument()
+      )
+      expect(screen.getByRole('button', { name: /curse of strahd/i })).toBeInTheDocument()
+    })
+
+    it('two different categories can each have subfolders independently', async () => {
+      const books = [
+        makeBook({
+          title: 'Bestiary',
+          category: 'core',
+          relative_path: 'books/TestSystem/core/monsters/bestiary.pdf',
+        }),
+        makeBook({
+          title: 'Adventure AP',
+          category: 'adventure',
+          relative_path: 'books/TestSystem/adventures/Big AP/ap.pdf',
+        }),
+      ]
+      api.get.mockResolvedValue(makeSystem(books))
+      renderView()
+
+      await waitFor(() =>
+        expect(screen.getByRole('button', { name: /monsters/i })).toBeInTheDocument()
+      )
+      expect(screen.getByRole('button', { name: /big ap/i })).toBeInTheDocument()
+    })
+
+    it('subfolder collapse toggles visibility', async () => {
+      const books = [
+        makeBook({ title: 'Bestiary', relative_path: 'books/TestSystem/core/monsters/bestiary.pdf' }),
+      ]
+      api.get.mockResolvedValue(makeSystem(books))
+      renderView()
+
+      await waitFor(() => expect(screen.getByText('Bestiary')).toBeInTheDocument())
+
+      // Collapse the folder
+      await userEvent.click(screen.getByRole('button', { name: /monsters/i }))
+      expect(screen.queryByText('Bestiary')).not.toBeInTheDocument()
+
+      // Expand again
+      await userEvent.click(screen.getByRole('button', { name: /monsters/i }))
+      expect(screen.getByText('Bestiary')).toBeInTheDocument()
+    })
+  })
+
+  describe('system header', () => {
+    it('renders the system name', async () => {
+      api.get.mockResolvedValue(makeSystem())
+      renderView()
+      await waitFor(() => expect(screen.getByText('Test System')).toBeInTheDocument())
+    })
+
+    it('shows a spinner while loading', () => {
+      api.get.mockReturnValue(new Promise(() => {})) // never resolves
+      renderView()
+      expect(document.querySelector('svg')).toBeInTheDocument() // Spinner renders an SVG
+    })
+  })
+
+  describe('category section collapse', () => {
+    it('collapses a category section when its header is clicked', async () => {
+      const books = [
+        makeBook({ title: 'PHB', relative_path: 'books/TestSystem/core/phb.pdf' }),
+      ]
+      api.get.mockResolvedValue(makeSystem(books))
+      renderView()
+
+      await waitFor(() => expect(screen.getByText('PHB')).toBeInTheDocument())
+
+      await userEvent.click(screen.getByRole('button', { name: /core rulebooks/i }))
+      expect(screen.queryByText('PHB')).not.toBeInTheDocument()
+    })
+  })
+})

--- a/tests/test_downloads.py
+++ b/tests/test_downloads.py
@@ -298,6 +298,56 @@ class TestDownloadAuth:
 # ---------------------------------------------------------------------------
 
 
+@pytest.fixture(scope="module")
+def adventure_system():
+    return make_game_system(name=f"AdventureSystem-{uuid.uuid4().hex[:6]}")
+
+
+@pytest.fixture(scope="module")
+def subfolder_book_in_folder(adventure_system):
+    """A book at books/{System}/adventures/Curse of Strahd/cos.pdf."""
+    uid = uuid.uuid4().hex[:6]
+    path = _real_file(f"cos_{uid}.pdf", b"%PDF-1.4 strahd")
+    return make_book(
+        system_id=adventure_system.id,
+        title=f"Curse of Strahd {uid}",
+        filename=os.path.basename(path),
+        filepath=path,
+        relative_path=f"books/AdventureSystem/adventures/Curse of Strahd/{os.path.basename(path)}",
+        category="adventure",
+    )
+
+
+@pytest.fixture(scope="module")
+def subfolder_book_other_folder(adventure_system):
+    """A book in a different subfolder of the same system — should not appear in Strahd download."""
+    uid = uuid.uuid4().hex[:6]
+    path = _real_file(f"lmop_{uid}.pdf", b"%PDF-1.4 lmop")
+    return make_book(
+        system_id=adventure_system.id,
+        title=f"Lost Mine {uid}",
+        filename=os.path.basename(path),
+        filepath=path,
+        relative_path=f"books/AdventureSystem/adventures/Lost Mine/{os.path.basename(path)}",
+        category="adventure",
+    )
+
+
+@pytest.fixture(scope="module")
+def core_subfolder_book(adventure_system):
+    """A book in core/monsters subfolder — tests that book_folder works across categories."""
+    uid = uuid.uuid4().hex[:6]
+    path = _real_file(f"bestiary_{uid}.pdf", b"%PDF-1.4 bestiary")
+    return make_book(
+        system_id=adventure_system.id,
+        title=f"Bestiary {uid}",
+        filename=os.path.basename(path),
+        filepath=path,
+        relative_path=f"books/AdventureSystem/core/monsters/{os.path.basename(path)}",
+        category="core",
+    )
+
+
 class TestDownloadValidation:
     def test_unknown_type_returns_400(self, client, admin_headers):
         resp = client.get(
@@ -336,6 +386,22 @@ class TestDownloadValidation:
             "/api/downloads/archive",
             headers=admin_headers,
             params={"type": "token_folder"},
+        )
+        assert resp.status_code == 400
+
+    def test_book_folder_missing_id_returns_400(self, client, admin_headers):
+        resp = client.get(
+            "/api/downloads/archive",
+            headers=admin_headers,
+            params={"type": "book_folder", "folder": "Curse of Strahd"},
+        )
+        assert resp.status_code == 400
+
+    def test_book_folder_missing_folder_returns_400(self, client, admin_headers, system):
+        resp = client.get(
+            "/api/downloads/archive",
+            headers=admin_headers,
+            params={"type": "book_folder", "id": system.id},
         )
         assert resp.status_code == 400
 
@@ -532,6 +598,88 @@ class TestDownloadTokenFolderZip:
             "/api/downloads/archive",
             headers=admin_headers,
             params={"type": "token_folder", "folder": "no_such_folder"},
+        )
+        assert resp.status_code == 404
+
+
+# ---------------------------------------------------------------------------
+# ZIP — book_folder scope
+# ---------------------------------------------------------------------------
+
+
+class TestDownloadBookFolderZip:
+    def test_contains_book_in_subfolder(
+        self, client, admin_headers, adventure_system, subfolder_book_in_folder
+    ):
+        content = _get_archive(
+            client,
+            admin_headers,
+            {"type": "book_folder", "id": adventure_system.id, "folder": "Curse of Strahd"},
+        )
+        names = _zip_names(content)
+        assert any(subfolder_book_in_folder.filename in n for n in names)
+
+    def test_excludes_book_from_different_subfolder(
+        self, client, admin_headers, adventure_system,
+        subfolder_book_in_folder, subfolder_book_other_folder
+    ):
+        content = _get_archive(
+            client,
+            admin_headers,
+            {"type": "book_folder", "id": adventure_system.id, "folder": "Curse of Strahd"},
+        )
+        names = _zip_names(content)
+        assert subfolder_book_other_folder.filename not in names
+
+    def test_works_for_non_adventure_category(
+        self, client, admin_headers, adventure_system, core_subfolder_book
+    ):
+        """book_folder works for any category, not just adventures."""
+        content = _get_archive(
+            client,
+            admin_headers,
+            {"type": "book_folder", "id": adventure_system.id, "folder": "monsters"},
+        )
+        names = _zip_names(content)
+        assert any(core_subfolder_book.filename in n for n in names)
+
+    def test_content_type_is_zip(
+        self, client, admin_headers, adventure_system, subfolder_book_in_folder
+    ):
+        resp = client.get(
+            "/api/downloads/archive",
+            headers=admin_headers,
+            params={"type": "book_folder", "id": adventure_system.id, "folder": "Curse of Strahd"},
+        )
+        assert resp.status_code == 200
+        assert "zip" in resp.headers["content-type"]
+
+    def test_content_disposition_includes_folder_name(
+        self, client, admin_headers, adventure_system, subfolder_book_in_folder
+    ):
+        resp = client.get(
+            "/api/downloads/archive",
+            headers=admin_headers,
+            params={"type": "book_folder", "id": adventure_system.id, "folder": "Curse of Strahd"},
+        )
+        cd = resp.headers["content-disposition"]
+        assert "Curse_of_Strahd" in cd
+
+    def test_nonexistent_folder_returns_404(
+        self, client, admin_headers, adventure_system
+    ):
+        resp = client.get(
+            "/api/downloads/archive",
+            headers=admin_headers,
+            params={"type": "book_folder", "id": adventure_system.id, "folder": "no-such-folder"},
+        )
+        assert resp.status_code == 404
+
+    def test_nonexistent_system_returns_404(self, client, admin_headers):
+        resp = client.get(
+            "/api/downloads/archive",
+            headers=admin_headers,
+            params={"type": "book_folder", "id": "no-such-system", "folder": "anything"},
         )
         assert resp.status_code == 404
 

--- a/tests/test_indexer_category.py
+++ b/tests/test_indexer_category.py
@@ -77,3 +77,50 @@ class TestNoSubfolder:
     def test_single_segment_path(self):
         # Degenerate case — still returns 'core'
         assert guess_category("phb.pdf") == "core"
+
+
+class TestSubfoldersWithinCategory:
+    """Files nested one level deeper than the category folder.
+
+    The category is determined by the *category* folder name (segment 2),
+    not by the subfolder name (segment 3).  The subfolder is preserved in
+    relative_path and used for display grouping only.
+    """
+
+    def test_adventure_subfolder_still_adventure(self):
+        # books/PF2e/adventures/Abomination Vaults/ruins.pdf → adventure
+        result = guess_category("books/PF2e/adventures/Abomination Vaults/ruins.pdf")
+        assert result == "adventure"
+
+    def test_core_subfolder_still_core(self):
+        # books/PF2e/core/monsters/Bestiary.pdf → core
+        result = guess_category("books/PF2e/core/monsters/Bestiary.pdf")
+        assert result == "core"
+
+    def test_supplement_subfolder_still_supplement(self):
+        result = guess_category("books/D&D 5e/supplements/Settings/sword-coast.pdf")
+        assert result == "supplement"
+
+    def test_homebrew_subfolder_still_homebrew(self):
+        # Use a subfolder name that doesn't accidentally contain a category keyword
+        # as a substring (e.g. "Community" contains "mm" which matches "core").
+        result = guess_category("books/D&D 5e/homebrew/Personal/custom.pdf")
+        assert result == "homebrew"
+
+    def test_subfolder_keyword_takes_priority_over_outer_folder(self):
+        # guess_category scans innermost-first, so a subfolder whose name matches
+        # a category keyword takes priority over its parent category folder.
+        # A subfolder named "core" inside "adventures" → returns "core".
+        result = guess_category("books/PF2e/adventures/core/book.pdf")
+        assert result == "core"
+
+    def test_non_keyword_subfolder_does_not_override_category_folder(self):
+        # A subfolder with a non-keyword name: category folder wins.
+        result = guess_category("books/PF2e/adventures/Abomination Vaults/ruins.pdf")
+        assert result == "adventure"
+
+    def test_deeply_nested_non_keyword_leaf(self):
+        # Three levels deep with non-keyword names throughout inner segments:
+        # books/System/adventures/AP Name/Part 1/chapter.pdf → adventure
+        result = guess_category("books/PF2e/adventures/Abomination Vaults/Part 1/ruins.pdf")
+        assert result == "adventure"

--- a/tests/test_systems.py
+++ b/tests/test_systems.py
@@ -77,8 +77,102 @@ class TestGetSystem:
             assert all("is_missing" in b for b in books)
             assert all(isinstance(b["is_missing"], bool) for b in books)
 
+    def test_system_books_include_relative_path(self, client, admin_headers, system):
+        from tests.conftest import make_book
+        make_book(
+            system_id=system.id,
+            relative_path="books/Dungeons and Dragons 5e/adventures/Curse of Strahd/cos.pdf",
+        )
+        resp = client.get(f"/api/systems/{system.id}", headers=admin_headers)
+        books = resp.json()["books"]
+        assert all("relative_path" in b for b in books)
+
+    def test_system_books_relative_path_value(self, client, admin_headers, system):
+        from tests.conftest import make_book
+        rp = "books/Dungeons and Dragons 5e/adventures/Lost Mine/lmop.pdf"
+        book = make_book(system_id=system.id, relative_path=rp)
+        resp = client.get(f"/api/systems/{system.id}", headers=admin_headers)
+        books = {b["id"]: b for b in resp.json()["books"]}
+        assert books[book.id]["relative_path"] == rp
+
     def test_get_nonexistent_system(self, client, admin_headers):
         resp = client.get("/api/systems/does-not-exist", headers=admin_headers)
+        assert resp.status_code == 404
+
+
+class TestBookFolders:
+    """Tests for GET/PATCH /api/systems/{id}/book-folders."""
+
+    @pytest.fixture(scope="class")
+    def folder_system(self):
+        return make_game_system(name=f"FolderSys-{uuid.uuid4().hex[:6]}")
+
+    def test_list_book_folders_empty(self, client, admin_headers, folder_system):
+        resp = client.get(f"/api/systems/{folder_system.id}/book-folders", headers=admin_headers)
+        assert resp.status_code == 200
+        assert resp.json()["folders"] == []
+
+    def test_create_book_folder(self, client, admin_headers, folder_system):
+        path = f"{folder_system.id}/Abomination Vaults"
+        resp = client.patch(
+            f"/api/systems/{folder_system.id}/book-folders",
+            json={"path": path, "tags": ["pathfinder", "horror"]},
+            headers=admin_headers,
+        )
+        assert resp.status_code == 200
+        body = resp.json()
+        assert body["path"] == path
+        assert body["tags"] == ["pathfinder", "horror"]
+
+    def test_list_book_folders_returns_created(self, client, admin_headers, folder_system):
+        path = f"{folder_system.id}/Some AP"
+        client.patch(
+            f"/api/systems/{folder_system.id}/book-folders",
+            json={"path": path, "tags": ["adventure"]},
+            headers=admin_headers,
+        )
+        resp = client.get(f"/api/systems/{folder_system.id}/book-folders", headers=admin_headers)
+        paths = [f["path"] for f in resp.json()["folders"]]
+        assert path in paths
+
+    def test_update_existing_book_folder_tags(self, client, admin_headers, folder_system):
+        path = f"{folder_system.id}/Editable AP"
+        client.patch(
+            f"/api/systems/{folder_system.id}/book-folders",
+            json={"path": path, "tags": ["old-tag"]},
+            headers=admin_headers,
+        )
+        client.patch(
+            f"/api/systems/{folder_system.id}/book-folders",
+            json={"path": path, "tags": ["new-tag"]},
+            headers=admin_headers,
+        )
+        resp = client.get(f"/api/systems/{folder_system.id}/book-folders", headers=admin_headers)
+        entry = next(f for f in resp.json()["folders"] if f["path"] == path)
+        assert entry["tags"] == ["new-tag"]
+
+    def test_player_can_list_book_folders(self, client, player_headers, folder_system):
+        resp = client.get(f"/api/systems/{folder_system.id}/book-folders", headers=player_headers)
+        assert resp.status_code == 200
+
+    def test_player_cannot_patch_book_folders(self, client, player_headers, folder_system):
+        resp = client.patch(
+            f"/api/systems/{folder_system.id}/book-folders",
+            json={"path": f"{folder_system.id}/blocked", "tags": []},
+            headers=player_headers,
+        )
+        assert resp.status_code == 403
+
+    def test_gm_can_patch_book_folders(self, client, gm_headers, folder_system):
+        resp = client.patch(
+            f"/api/systems/{folder_system.id}/book-folders",
+            json={"path": f"{folder_system.id}/gm-folder", "tags": ["gm"]},
+            headers=gm_headers,
+        )
+        assert resp.status_code == 200
+
+    def test_book_folders_nonexistent_system_returns_404(self, client, admin_headers):
+        resp = client.get("/api/systems/no-such-id/book-folders", headers=admin_headers)
         assert resp.status_code == 404
 
 


### PR DESCRIPTION
## Summary

Books nested one level deeper than their category folder (e.g. books/System/adventures/Abomination Vaults/*.pdf) are automatically detected and displayed as collapsible folder groups in the system detail view. Collapse state is persisted per-session and namespaced by category so same-named folders across categories collapse independently.

## Type of change

- [ ] Bug fix
- [x] New feature
- [ ] Refactor / cleanup
- [ ] Docs / configuration only

## Testing

<!-- How did you verify this works? Check all that apply. -->

- [x] Backend tests pass (`pytest -q`)
- [x] Frontend tests pass (`npm test`)
- [x] Tested manually in the browser

## Notes for reviewer

<!-- Anything that needs extra context, known limitations, or follow-up work. Delete if not needed. -->
