### PR TITLE
Fix: Add no-store cache header to index.html and enhance PWA manifest

### DIFF
--- a/backend/main.py
+++ b/backend/main.py
@@ -162,5 +162,8 @@ def serve_frontend(full_path: str, _: Request):
         return FileResponse(candidate)
     index_path = os.path.join(FRONTEND_DIR, "index.html")
     if os.path.exists(index_path):
-        return FileResponse(index_path)
+        return FileResponse(
+            index_path,
+            headers={"Cache-Control": "no-store"},
+        )
     return JSONResponse({"error": "Frontend not found"}, status_code=500)

--- a/frontend/static/site.webmanifest
+++ b/frontend/static/site.webmanifest
@@ -1,11 +1,30 @@
 {
   "name": "Grimoire",
   "short_name": "Grimoire",
+  "description": "Self-hosted TTRPG library manager for books, maps, and campaigns.",
+  "start_url": "/",
   "icons": [
     { "src": "/android-chrome-192x192.png", "sizes": "192x192", "type": "image/png" },
     { "src": "/android-chrome-512x512.png",  "sizes": "512x512",  "type": "image/png" }
   ],
   "theme_color": "#1a1612",
   "background_color": "#1a1612",
-  "display": "standalone"
+  "display": "standalone",
+  "shortcuts": [
+    {
+      "name": "Library",
+      "url": "/library",
+      "icons": [{ "src": "/android-chrome-192x192.png", "sizes": "192x192" }]
+    },
+    {
+      "name": "Search",
+      "url": "/search",
+      "icons": [{ "src": "/android-chrome-192x192.png", "sizes": "192x192" }]
+    },
+    {
+      "name": "Campaigns",
+      "url": "/campaigns",
+      "icons": [{ "src": "/android-chrome-192x192.png", "sizes": "192x192" }]
+    }
+  ]
 }


### PR DESCRIPTION
## Summary

Prevent the browser from caching the SPA entry point so users always receive the latest frontend after an update. Also flesh out the web manifest with a description, start_url, and app shortcuts for Library, Search, and Campaigns.

## Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / cleanup
- [ ] Docs / configuration only

## Testing

- [x] Backend tests pass (`pytest -q`)
- [x] Frontend tests pass (`npm test`)
- [x] Tested manually in the browser
