### PR TITLE
Enhancement: Add version update notifications and About modal

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -53,6 +53,7 @@ jobs:
           platforms: linux/amd64,linux/arm64/v8
           build-args: |
             APP_VERSION=${{ steps.ver.outputs.version }}
+            COMMIT_HASH=${{ github.sha }}
           tags: |
             ${{ env.IMAGE }}:latest
             ${{ env.IMAGE }}:${{ steps.ver.outputs.major }}

--- a/Dockerfile
+++ b/Dockerfile
@@ -27,7 +27,9 @@ COPY --from=frontend-builder /app/frontend/dist ./frontend/dist
 RUN mkdir -p /data /library
 
 ARG APP_VERSION=dev
+ARG COMMIT_HASH="dev"
 ENV APP_VERSION=${APP_VERSION}
+ENV COMMIT_HASH=${COMMIT_HASH}
 ENV PYTHONUNBUFFERED=1
 
 EXPOSE 9481

--- a/backend/config.py
+++ b/backend/config.py
@@ -8,6 +8,7 @@ from typing import Optional
 from .models import init_db
 
 VERSION = os.environ.get("APP_VERSION", "1.0.0")
+COMMIT_HASH = os.environ.get("COMMIT_HASH", "")
 OPDS_ENABLED = os.environ.get("OPDS_ENABLED", "false").lower() == "true"
 # Public base URL of this instance (e.g. "https://grimoire.example.com").
 # Used to build absolute links in OPDS feeds and anywhere a fully-qualified URL is needed.

--- a/backend/routers/library/core.py
+++ b/backend/routers/library/core.py
@@ -1,10 +1,11 @@
 """Library scan-status, rescan, and stats endpoints."""
+import sys
 from typing import Optional
 
 from fastapi import APIRouter, BackgroundTasks, Depends, HTTPException, Header
 from sqlalchemy import func
 
-from ...config import SessionLocal, VERSION
+from ...config import SessionLocal, VERSION, COMMIT_HASH
 from ...models import GameSystem, Book, GenericMap, Token
 from ...auth import require_admin, optional_get_current_user, CurrentUser
 from ..settings import get_stats_api_key
@@ -73,6 +74,8 @@ def get_stats(
             "total_pages": db.query(func.sum(Book.page_count)).scalar() or 0,
             "total_size_mb": round((db.query(func.sum(Book.file_size)).scalar() or 0) / 1048576, 1),
             "version": VERSION,
+            "commit_hash": COMMIT_HASH,
+            "python_version": f"{sys.version_info.major}.{sys.version_info.minor}.{sys.version_info.micro}",
         }
     finally:
         db.close()

--- a/backend/routers/settings/_helpers.py
+++ b/backend/routers/settings/_helpers.py
@@ -22,7 +22,6 @@ _DEFAULTS = {
     "show_stat_maps": "false",
     "show_stat_tokens": "false",
     "show_stat_size": "true",
-    "show_stat_version": "true",
 }
 
 
@@ -57,7 +56,6 @@ def _to_typed(raw: dict) -> dict:
         "show_stat_maps": raw["show_stat_maps"] == "true",
         "show_stat_tokens": raw["show_stat_tokens"] == "true",
         "show_stat_size": raw["show_stat_size"] == "true",
-        "show_stat_version": raw["show_stat_version"] == "true",
     }
 
 

--- a/backend/routers/settings/_schemas.py
+++ b/backend/routers/settings/_schemas.py
@@ -19,4 +19,3 @@ class SettingsPatch(BaseModel):
     show_stat_maps: Optional[bool] = None
     show_stat_tokens: Optional[bool] = None
     show_stat_size: Optional[bool] = None
-    show_stat_version: Optional[bool] = None

--- a/backend/routers/settings/core.py
+++ b/backend/routers/settings/core.py
@@ -56,7 +56,6 @@ def update_settings(data: SettingsPatch, _: CurrentUser = Depends(require_admin)
             "show_stat_maps",
             "show_stat_tokens",
             "show_stat_size",
-            "show_stat_version",
         ):
             val = getattr(data, key)
             if val is not None:
@@ -107,7 +106,6 @@ def get_ui_settings(_: CurrentUser = Depends(get_current_user)):
             "show_stat_maps": raw["show_stat_maps"] == "true",
             "show_stat_tokens": raw["show_stat_tokens"] == "true",
             "show_stat_size": raw["show_stat_size"] == "true",
-            "show_stat_version": raw["show_stat_version"] == "true",
         }
     finally:
         db.close()

--- a/frontend/src/components/AboutModal.jsx
+++ b/frontend/src/components/AboutModal.jsx
@@ -1,0 +1,151 @@
+import { useEffect, useRef } from 'react'
+import { createPortal } from 'react-dom'
+import { useTranslation } from 'react-i18next'
+import { LuX, LuExternalLink } from 'react-icons/lu'
+import { SiGithub } from 'react-icons/si'
+
+const GITHUB_REPO_URL = 'https://github.com/hunter-read/grimoire'
+
+export default function AboutModal({ stats, latestVersion, hasUpdate, onClose }) {
+  const { t } = useTranslation()
+  const closeRef = useRef(null)
+
+  useEffect(() => {
+    closeRef.current?.focus()
+    const onKey = e => { if (e.key === 'Escape') onClose() }
+    window.addEventListener('keydown', onKey)
+    return () => window.removeEventListener('keydown', onKey)
+  }, [onClose])
+
+  const currentVersion = stats?.version ?? '—'
+  const commitHash = stats?.commit_hash || null
+  const pythonVersion = stats?.python_version ?? '—'
+  const releaseUrl = `${GITHUB_REPO_URL}/releases/tag/v${currentVersion}`
+
+  const rowStyle = {
+    display: 'flex', justifyContent: 'space-between', alignItems: 'baseline',
+    gap: 12, marginBottom: 10,
+  }
+  const labelStyle = { fontSize: 13, color: 'var(--text-muted)', whiteSpace: 'nowrap' }
+  const valueStyle = { fontSize: 13, color: 'var(--text)', fontFamily: 'monospace', textAlign: 'right' }
+  const dotStyle = { flex: 1, borderBottom: '1px dotted var(--border)', minWidth: 16 }
+
+  return createPortal(
+    <div
+      role="dialog"
+      aria-modal="true"
+      aria-labelledby="about-modal-title"
+      style={{
+        position: 'fixed', inset: 0, zIndex: 1200,
+        display: 'flex', alignItems: 'center', justifyContent: 'center',
+        background: 'rgba(0,0,0,0.55)',
+      }}
+      onClick={e => { if (e.target === e.currentTarget) onClose() }}
+    >
+      <div style={{
+        background: 'var(--bg-panel)', border: '1px solid var(--border)',
+        borderRadius: 10, padding: 24, width: 380, maxWidth: '92vw',
+        boxSizing: 'border-box',
+      }}>
+        {/* Header */}
+        <div style={{ display: 'flex', alignItems: 'center', justifyContent: 'space-between', marginBottom: 4 }}>
+          <span id="about-modal-title" style={{ fontSize: 15, fontWeight: 600 }}>
+            {t('about.title')}
+          </span>
+          <button
+            ref={closeRef}
+            onClick={onClose}
+            style={{ background: 'none', border: 'none', cursor: 'pointer', color: 'var(--text-muted)', display: 'flex', padding: 2 }}
+            aria-label={t('common.close')}
+          >
+            <LuX size={16} />
+          </button>
+        </div>
+
+        <p style={{ fontSize: 13, color: 'var(--text-muted)', marginBottom: 20 }}>
+          {t('about.subtitle')}
+        </p>
+
+        {/* Info table */}
+        <div style={{
+          background: 'var(--bg-card)', border: '1px solid var(--border)',
+          borderRadius: 8, padding: '14px 16px', marginBottom: 16,
+        }}>
+          <div style={rowStyle}>
+            <span style={labelStyle}>{t('about.version')}</span>
+            <span style={dotStyle} />
+            <span style={valueStyle}>v{currentVersion}</span>
+          </div>
+          {commitHash && (
+            <div style={rowStyle}>
+              <span style={labelStyle}>{t('about.commitHash')}</span>
+              <span style={dotStyle} />
+              <span style={{ ...valueStyle, fontSize: 12 }}>{commitHash.slice(0, 12)}</span>
+            </div>
+          )}
+          <div style={rowStyle}>
+            <span style={labelStyle}>{t('about.pythonVersion')}</span>
+            <span style={dotStyle} />
+            <span style={valueStyle}>{pythonVersion}</span>
+          </div>
+          <div style={{ ...rowStyle, marginBottom: hasUpdate ? 10 : 0 }}>
+            <span style={labelStyle}>{t('about.reactVersion')}</span>
+            <span style={dotStyle} />
+            <span style={valueStyle}>{__REACT_VERSION__}</span>
+          </div>
+
+          {hasUpdate && (
+            <div style={{
+              ...rowStyle, marginBottom: 0,
+              paddingTop: 10, borderTop: '1px solid var(--border)',
+            }}>
+              <span style={{ ...labelStyle, color: 'var(--gold)' }}>{t('about.updateAvailable')}</span>
+              <span style={dotStyle} />
+              <a
+                href={`${GITHUB_REPO_URL}/releases/tag/v${latestVersion}`}
+                target="_blank"
+                rel="noreferrer"
+                style={{ ...valueStyle, color: 'var(--gold)', textDecoration: 'none' }}
+              >
+                v{latestVersion}
+              </a>
+            </div>
+          )}
+        </div>
+
+        {/* Action buttons */}
+        <div style={{ display: 'flex', gap: 8, alignItems: 'center' }}>
+          <a
+            href={releaseUrl}
+            target="_blank"
+            rel="noreferrer"
+            style={{
+              flex: 1, display: 'inline-flex', alignItems: 'center', justifyContent: 'center', gap: 6,
+              padding: '7px 14px', borderRadius: 6, fontSize: 13, fontWeight: 500,
+              background: 'var(--gold-dim)', border: 'none', color: 'var(--bg-deep)',
+              textDecoration: 'none', cursor: 'pointer',
+            }}
+          >
+            <LuExternalLink size={13} /> {t('about.viewRelease')}
+          </a>
+          <a
+            href={GITHUB_REPO_URL}
+            target="_blank"
+            rel="noreferrer"
+            title={t('about.github')}
+            aria-label={t('about.github')}
+            style={{
+              display: 'inline-flex', alignItems: 'center', justifyContent: 'center',
+              padding: '7px 10px', borderRadius: 6, fontSize: 13,
+              background: 'var(--bg-card)', border: '1px solid var(--border)',
+              color: 'var(--text-dim)', textDecoration: 'none', cursor: 'pointer',
+            }}
+          >
+            <SiGithub size={16} />
+          </a>
+        </div>
+      </div>
+    </div>,
+    document.body
+  )
+}

--- a/frontend/src/components/AboutModal.test.jsx
+++ b/frontend/src/components/AboutModal.test.jsx
@@ -1,0 +1,194 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
+import { render, screen, fireEvent } from '@testing-library/react'
+import AboutModal from './AboutModal'
+
+// __REACT_VERSION__ is injected by Vite at build time; stub it for tests.
+globalThis.__REACT_VERSION__ = '18.3.1'
+
+const defaultStats = {
+  version: '1.2.0',
+  commit_hash: 'abc123def456789',
+  python_version: '3.12.4',
+}
+
+function renderModal(props = {}) {
+  return render(
+    <AboutModal
+      stats={defaultStats}
+      latestVersion={null}
+      hasUpdate={false}
+      onClose={vi.fn()}
+      {...props}
+    />
+  )
+}
+
+// ---------------------------------------------------------------------------
+// Rendering
+// ---------------------------------------------------------------------------
+
+describe('AboutModal — rendering', () => {
+  it('renders the About Grimoire heading', () => {
+    renderModal()
+    expect(screen.getByText('About Grimoire')).toBeInTheDocument()
+  })
+
+  it('renders the current version', () => {
+    renderModal()
+    expect(screen.getByText('v1.2.0')).toBeInTheDocument()
+  })
+
+  it('renders the truncated commit hash (first 12 chars)', () => {
+    renderModal()
+    expect(screen.getByText('abc123def456')).toBeInTheDocument()
+  })
+
+  it('does not render commit hash row when commit_hash is empty', () => {
+    renderModal({ stats: { ...defaultStats, commit_hash: '' } })
+    expect(screen.queryByText(/commit hash/i)).toBeNull()
+  })
+
+  it('does not render commit hash row when commit_hash is null', () => {
+    renderModal({ stats: { ...defaultStats, commit_hash: null } })
+    expect(screen.queryByText(/commit hash/i)).toBeNull()
+  })
+
+  it('renders the python version', () => {
+    renderModal()
+    expect(screen.getByText('3.12.4')).toBeInTheDocument()
+  })
+
+  it('renders the react version from __REACT_VERSION__', () => {
+    renderModal()
+    expect(screen.getByText('18.3.1')).toBeInTheDocument()
+  })
+
+  it('renders a View Release link', () => {
+    renderModal()
+    expect(screen.getByRole('link', { name: /view release/i })).toBeInTheDocument()
+  })
+
+  it('View Release link points to the correct release URL', () => {
+    renderModal()
+    const link = screen.getByRole('link', { name: /view release/i })
+    expect(link).toHaveAttribute('href', 'https://github.com/hunter-read/grimoire/releases/tag/v1.2.0')
+  })
+
+  it('renders a GitHub repository link', () => {
+    renderModal()
+    expect(screen.getByRole('link', { name: /github repository/i })).toBeInTheDocument()
+  })
+
+  it('GitHub link points to the repo root', () => {
+    renderModal()
+    const link = screen.getByRole('link', { name: /github repository/i })
+    expect(link).toHaveAttribute('href', 'https://github.com/hunter-read/grimoire')
+  })
+
+  it('renders a close button', () => {
+    renderModal()
+    expect(screen.getByRole('button', { name: /close/i })).toBeInTheDocument()
+  })
+
+  it('renders fallback dashes when stats is null', () => {
+    renderModal({ stats: null })
+    // version shows '—' when stats is null
+    expect(screen.getByText('v—')).toBeInTheDocument()
+  })
+})
+
+// ---------------------------------------------------------------------------
+// Update available row
+// ---------------------------------------------------------------------------
+
+describe('AboutModal — update available', () => {
+  it('does not render the update row when hasUpdate is false', () => {
+    renderModal({ hasUpdate: false })
+    expect(screen.queryByText(/update available/i)).toBeNull()
+  })
+
+  it('renders the update row when hasUpdate is true', () => {
+    renderModal({ hasUpdate: true, latestVersion: '2.0.0' })
+    expect(screen.getByText(/update available/i)).toBeInTheDocument()
+  })
+
+  it('shows the latest version number in the update row', () => {
+    renderModal({ hasUpdate: true, latestVersion: '2.0.0' })
+    expect(screen.getByText('v2.0.0')).toBeInTheDocument()
+  })
+
+  it('update row links to the latest release', () => {
+    renderModal({ hasUpdate: true, latestVersion: '2.0.0' })
+    const link = screen.getByRole('link', { name: 'v2.0.0' })
+    expect(link).toHaveAttribute('href', 'https://github.com/hunter-read/grimoire/releases/tag/v2.0.0')
+  })
+})
+
+// ---------------------------------------------------------------------------
+// Close behaviour
+// ---------------------------------------------------------------------------
+
+describe('AboutModal — close behaviour', () => {
+  it('calls onClose when the X button is clicked', () => {
+    const onClose = vi.fn()
+    renderModal({ onClose })
+    fireEvent.click(screen.getByRole('button', { name: /close/i }))
+    expect(onClose).toHaveBeenCalledOnce()
+  })
+
+  it('calls onClose when the backdrop is clicked', () => {
+    const onClose = vi.fn()
+    renderModal({ onClose })
+    fireEvent.click(screen.getByRole('dialog'))
+    expect(onClose).toHaveBeenCalledOnce()
+  })
+
+  it('does not call onClose when clicking inside the modal card', () => {
+    const onClose = vi.fn()
+    renderModal({ onClose })
+    fireEvent.click(screen.getByText('About Grimoire'))
+    expect(onClose).not.toHaveBeenCalled()
+  })
+
+  it('calls onClose when Escape is pressed', () => {
+    const onClose = vi.fn()
+    renderModal({ onClose })
+    fireEvent.keyDown(window, { key: 'Escape' })
+    expect(onClose).toHaveBeenCalledOnce()
+  })
+})
+
+// ---------------------------------------------------------------------------
+// Accessibility
+// ---------------------------------------------------------------------------
+
+describe('AboutModal — accessibility', () => {
+  it('has role="dialog"', () => {
+    renderModal()
+    expect(screen.getByRole('dialog')).toBeInTheDocument()
+  })
+
+  it('has aria-modal="true"', () => {
+    renderModal()
+    expect(screen.getByRole('dialog')).toHaveAttribute('aria-modal', 'true')
+  })
+
+  it('is labelled by the heading element', () => {
+    renderModal()
+    const dialog = screen.getByRole('dialog')
+    const labelId = dialog.getAttribute('aria-labelledby')
+    expect(labelId).toBeTruthy()
+    const label = document.getElementById(labelId)
+    expect(label).toBeInTheDocument()
+    expect(label.textContent).toMatch(/About Grimoire/i)
+  })
+
+  it('both external links open in a new tab', () => {
+    renderModal({ hasUpdate: true, latestVersion: '2.0.0' })
+    const links = screen.getAllByRole('link')
+    for (const link of links) {
+      expect(link).toHaveAttribute('target', '_blank')
+      expect(link).toHaveAttribute('rel', 'noreferrer')
+    }
+  })
+})

--- a/frontend/src/components/Sidebar.jsx
+++ b/frontend/src/components/Sidebar.jsx
@@ -1,9 +1,46 @@
+import { useState, useEffect, useRef } from 'react'
 import { NavLink } from 'react-router-dom'
 import { useTranslation } from 'react-i18next'
 import {
   LuLibrary, LuMap, LuSearch, LuSettings,
-  LuLogOut, LuUser, LuHeart, LuScroll,
+  LuLogOut, LuUser, LuHeart, LuScroll, LuX,
 } from 'react-icons/lu'
+import AboutModal from './AboutModal'
+
+const GITHUB_REPO = 'hunter-read/grimoire'
+const UPDATE_DISMISSED_KEY = 'grimoire_update_dismissed'
+
+function useLatestRelease() {
+  const [latest, setLatest] = useState(null)
+
+  useEffect(() => {
+    let cancelled = false
+    fetch(`https://api.github.com/repos/${GITHUB_REPO}/releases/latest`, {
+      headers: { Accept: 'application/vnd.github+json' },
+      signal: AbortSignal.timeout(5000),
+    })
+      .then(r => r.ok ? r.json() : null)
+      .then(data => {
+        if (!cancelled && data?.tag_name) {
+          setLatest(data.tag_name.replace(/^v/, ''))
+        }
+      })
+      .catch(() => {/* silently ignore network errors */})
+    return () => { cancelled = true }
+  }, [])
+
+  return latest
+}
+
+function isNewer(latestVersion, currentVersion) {
+  if (!latestVersion || !currentVersion || currentVersion === 'dev') return false
+  const parse = v => v.split('.').map(Number)
+  const [lMaj, lMin, lPat] = parse(latestVersion)
+  const [cMaj, cMin, cPat] = parse(currentVersion)
+  if (lMaj !== cMaj) return lMaj > cMaj
+  if (lMin !== cMin) return lMin > cMin
+  return lPat > cPat
+}
 
 export default function Sidebar({ stats, user, onLogout, uiSettings = {} }) {
   const { t } = useTranslation()
@@ -17,8 +54,34 @@ export default function Sidebar({ stats, user, onLogout, uiSettings = {} }) {
     show_stat_maps    = false,
     show_stat_tokens  = false,
     show_stat_size    = true,
-    show_stat_version = true,
   } = uiSettings
+
+
+  const [showAbout, setShowAbout] = useState(false)
+  const latestVersion = useLatestRelease()
+  const hasUpdate = isNewer(latestVersion, stats?.version)
+
+  const [updateDismissed, setUpdateDismissed] = useState(() => {
+    const stored = localStorage.getItem(UPDATE_DISMISSED_KEY)
+    return stored === latestVersion
+  })
+
+  // Re-check dismissal if latestVersion changes (e.g. on first load)
+  useEffect(() => {
+    const stored = localStorage.getItem(UPDATE_DISMISSED_KEY)
+    setUpdateDismissed(stored === latestVersion)
+  }, [latestVersion])
+
+  const dismissUpdate = (e) => {
+    e.stopPropagation()
+    localStorage.setItem(UPDATE_DISMISSED_KEY, latestVersion)
+    setUpdateDismissed(true)
+  }
+
+  const showUpdateBanner = hasUpdate && !updateDismissed
+
+  const anyStats = show_stat_systems || show_stat_books || show_stat_pages || show_stat_maps || show_stat_tokens || show_stat_size
+
   return (
     <div style={{
       width: 220, minWidth: 220, background: 'var(--bg-panel)',
@@ -68,7 +131,7 @@ export default function Sidebar({ stats, user, onLogout, uiSettings = {} }) {
       </nav>
 
       {/* Stats footer */}
-      {stats && (show_stat_systems || show_stat_books || show_stat_pages || show_stat_maps || show_stat_tokens || show_stat_size || show_stat_version) && (
+      {stats && anyStats && (
         <div style={{ padding: '16px 20px', borderTop: '1px solid var(--border)', fontSize: 14, color: 'var(--text-muted)' }}>
           {show_stat_systems && <div style={{ display: 'flex', justifyContent: 'space-between', marginBottom: 4 }}>
             <span>{t('stats.systems')}</span><span style={{ color: 'var(--text-dim)' }}>{stats.game_systems}</span>
@@ -85,12 +148,53 @@ export default function Sidebar({ stats, user, onLogout, uiSettings = {} }) {
           {show_stat_tokens && <div style={{ display: 'flex', justifyContent: 'space-between', marginBottom: 4 }}>
             <span>{t('stats.tokens')}</span><span style={{ color: 'var(--text-dim)' }}>{stats.tokens}</span>
           </div>}
-          {show_stat_size && <div style={{ display: 'flex', justifyContent: 'space-between', marginBottom: 4 }}>
+          {show_stat_size && <div style={{ display: 'flex', justifyContent: 'space-between' }}>
             <span>{t('stats.size')}</span><span style={{ color: 'var(--text-dim)' }}>{stats.total_size_mb >= 1024 ? t('common.sizeGB', { size: (stats.total_size_mb / 1024).toFixed(2) }) : t('common.sizeMB', { size: stats.total_size_mb })}</span>
           </div>}
-          {show_stat_version && <div style={{ display: 'flex', justifyContent: 'space-between' }}>
-            <span>{t('stats.version')}</span><span style={{ color: 'var(--text-dim)' }}>v{stats.version}</span>
-          </div>}
+        </div>
+      )}
+
+      {stats && (
+        <div style={{ borderTop: '1px solid var(--border)' }}>
+          <button
+            onClick={() => setShowAbout(true)}
+            title={t('about.openAbout')}
+            aria-label={t('about.openAbout')}
+            style={{
+              width: '100%', background: 'none', border: 'none', cursor: 'pointer',
+              padding: '10px 20px', display: 'flex', justifyContent: 'space-between', alignItems: 'center',
+              color: 'var(--text-muted)', fontSize: 12,
+            }}
+          >
+            <span style={{ textTransform: 'uppercase', letterSpacing: '0.08em' }}>{t('stats.version')}</span>
+            <span style={{ color: 'var(--text-dim)', fontFamily: 'monospace' }}>v{stats.version}</span>
+          </button>
+
+          {showUpdateBanner && (
+            <div style={{
+              padding: '8px 12px 8px 16px',
+              background: 'rgba(201,168,76,0.08)',
+              borderTop: '1px solid var(--border)',
+              display: 'flex', alignItems: 'center', justifyContent: 'space-between', gap: 8,
+            }}>
+              <div style={{ flex: 1, minWidth: 0 }}>
+                <div style={{ fontSize: 11, color: 'var(--gold)', fontWeight: 600, textTransform: 'uppercase', letterSpacing: '0.06em', marginBottom: 1 }}>
+                  {t('about.updateAvailable')}
+                </div>
+                <div style={{ fontSize: 12, color: 'var(--text-muted)' }}>
+                  v{latestVersion}
+                </div>
+              </div>
+              <button
+                onClick={dismissUpdate}
+                title={t('common.close')}
+                aria-label={t('common.close')}
+                style={{ background: 'none', border: 'none', cursor: 'pointer', color: 'var(--text-muted)', display: 'flex', padding: 2, flexShrink: 0 }}
+              >
+                <LuX size={13} />
+              </button>
+            </div>
+          )}
         </div>
       )}
 
@@ -133,6 +237,10 @@ export default function Sidebar({ stats, user, onLogout, uiSettings = {} }) {
             <LuLogOut size={14} />
           </button>
         </div>
+      )}
+
+      {showAbout && (
+        <AboutModal stats={stats} latestVersion={latestVersion} hasUpdate={hasUpdate} onClose={() => setShowAbout(false)} />
       )}
     </div>
   )

--- a/frontend/src/components/Sidebar.test.jsx
+++ b/frontend/src/components/Sidebar.test.jsx
@@ -1,62 +1,274 @@
-import { describe, it, expect, vi } from 'vitest'
-import { render, screen } from '@testing-library/react'
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
+import { render, screen, fireEvent, waitFor, act } from '@testing-library/react'
 import { MemoryRouter } from 'react-router-dom'
 import Sidebar from './Sidebar'
 
-function renderSidebar(user, uiSettings = {}) {
+// ---------------------------------------------------------------------------
+// Mocks
+// ---------------------------------------------------------------------------
+
+// Stub AboutModal so Sidebar tests don't need to worry about portal/modal internals
+vi.mock('./AboutModal', () => ({
+  default: ({ onClose }) => (
+    <div data-testid="about-modal">
+      <button onClick={onClose}>Close About</button>
+    </div>
+  ),
+}))
+
+const DISMISSED_KEY = 'grimoire_update_dismissed'
+
+const baseStats = {
+  version: '1.2.0',
+  commit_hash: 'abc123def456',
+  python_version: '3.12.0',
+  game_systems: 5,
+  books: 42,
+  total_pages: 10000,
+  maps: 8,
+  tokens: 30,
+  total_size_mb: 512,
+}
+
+const baseUser = { username: 'jdoe', display_name: 'Jane Doe', role: 'player' }
+
+function mockFetch(tagName = null, ok = true) {
+  global.fetch = vi.fn().mockResolvedValue({
+    ok,
+    json: () => Promise.resolve(tagName ? { tag_name: tagName } : {}),
+  })
+}
+
+function renderSidebar(props = {}) {
   return render(
     <MemoryRouter>
-      <Sidebar user={user} onLogout={vi.fn()} uiSettings={uiSettings} />
+      <Sidebar
+        user={baseUser}
+        onLogout={vi.fn()}
+        stats={baseStats}
+        uiSettings={{}}
+        {...props}
+      />
     </MemoryRouter>
   )
 }
 
+beforeEach(() => {
+  vi.resetAllMocks()
+  // Default: fetch returns a non-ok response so no update banner appears
+  mockFetch(null, false)
+})
+
+afterEach(() => {
+  vi.restoreAllMocks()
+})
+
+// ---------------------------------------------------------------------------
+// User display (existing)
+// ---------------------------------------------------------------------------
+
 describe('Sidebar user display', () => {
   it('shows display_name when set', () => {
-    renderSidebar({ username: 'jdoe', display_name: 'Jane Doe', role: 'player' })
+    renderSidebar()
     expect(screen.getByText('Jane Doe')).toBeTruthy()
     expect(screen.queryByText('jdoe')).toBeNull()
   })
 
   it('falls back to username when display_name is not set', () => {
-    renderSidebar({ username: 'jdoe', display_name: null, role: 'player' })
+    renderSidebar({ user: { username: 'jdoe', display_name: null, role: 'player' } })
     expect(screen.getByText('jdoe')).toBeTruthy()
   })
 
   it('falls back to username when display_name is empty string', () => {
-    renderSidebar({ username: 'jdoe', display_name: '', role: 'player' })
+    renderSidebar({ user: { username: 'jdoe', display_name: '', role: 'player' } })
     expect(screen.getByText('jdoe')).toBeTruthy()
   })
 
   it('shows user role', () => {
-    renderSidebar({ username: 'jdoe', display_name: null, role: 'admin' })
+    renderSidebar({ user: { username: 'jdoe', display_name: null, role: 'admin' } })
     expect(screen.getByText('admin')).toBeTruthy()
   })
 
   it('renders nothing in the user section when user is null', () => {
-    render(
-      <MemoryRouter>
-        <Sidebar user={null} onLogout={vi.fn()} />
-      </MemoryRouter>
-    )
-    // logout button only renders when user is present
+    renderSidebar({ user: null })
     expect(screen.queryByLabelText('Log out')).toBeNull()
   })
 })
 
+// ---------------------------------------------------------------------------
+// Navigation visibility (existing)
+// ---------------------------------------------------------------------------
+
 describe('Sidebar navigation visibility', () => {
   it('shows campaigns link by default', () => {
-    renderSidebar({ username: 'u', role: 'player' })
+    renderSidebar()
     expect(screen.getByText('Campaigns')).toBeTruthy()
   })
 
   it('hides campaigns link when hide_campaigns is true', () => {
-    renderSidebar({ username: 'u', role: 'player' }, { hide_campaigns: true })
+    renderSidebar({ uiSettings: { hide_campaigns: true } })
     expect(screen.queryByText('Campaigns')).toBeNull()
   })
 
   it('hides maps link when hide_maps is true', () => {
-    renderSidebar({ username: 'u', role: 'player' }, { hide_maps: true })
+    renderSidebar({ uiSettings: { hide_maps: true } })
     expect(screen.queryByText('Maps')).toBeNull()
+  })
+})
+
+// ---------------------------------------------------------------------------
+// Version row
+// ---------------------------------------------------------------------------
+
+describe('Sidebar version row', () => {
+  it('renders the version button when stats are provided', () => {
+    renderSidebar()
+    expect(screen.getByRole('button', { name: /about grimoire/i })).toBeInTheDocument()
+  })
+
+  it('displays the current version string', () => {
+    renderSidebar()
+    expect(screen.getByText('v1.2.0')).toBeInTheDocument()
+  })
+
+  it('does not render the version button when stats are null', () => {
+    renderSidebar({ stats: null })
+    expect(screen.queryByRole('button', { name: /about grimoire/i })).toBeNull()
+  })
+
+  it('opens the About modal when the version button is clicked', () => {
+    renderSidebar()
+    fireEvent.click(screen.getByRole('button', { name: /about grimoire/i }))
+    expect(screen.getByTestId('about-modal')).toBeInTheDocument()
+  })
+
+  it('closes the About modal when onClose is called', () => {
+    renderSidebar()
+    fireEvent.click(screen.getByRole('button', { name: /about grimoire/i }))
+    fireEvent.click(screen.getByRole('button', { name: /close about/i }))
+    expect(screen.queryByTestId('about-modal')).toBeNull()
+  })
+})
+
+// ---------------------------------------------------------------------------
+// Stats footer
+// ---------------------------------------------------------------------------
+
+describe('Sidebar stats footer', () => {
+  it('shows systems stat when show_stat_systems is true', () => {
+    renderSidebar({ uiSettings: { show_stat_systems: true } })
+    expect(screen.getByText('Systems')).toBeInTheDocument()
+  })
+
+  it('hides systems stat when show_stat_systems is false', () => {
+    renderSidebar({ uiSettings: { show_stat_systems: false, show_stat_pages: false, show_stat_size: false } })
+    expect(screen.queryByText('Systems')).toBeNull()
+  })
+
+  it('shows pages stat by default', () => {
+    renderSidebar()
+    expect(screen.getByText('Pages')).toBeInTheDocument()
+  })
+
+  it('version does not appear in the stats footer section', () => {
+    // Version is now always in its own row below, not a toggled stat
+    renderSidebar({ uiSettings: { show_stat_systems: false, show_stat_pages: false, show_stat_size: false } })
+    // Version button should still exist (it's always rendered when stats is set)
+    expect(screen.getByRole('button', { name: /about grimoire/i })).toBeInTheDocument()
+  })
+})
+
+// ---------------------------------------------------------------------------
+// Update banner — fetch success
+// ---------------------------------------------------------------------------
+
+describe('Sidebar update banner', () => {
+  it('shows update banner when a newer version is available', async () => {
+    mockFetch('v2.0.0')
+    renderSidebar()
+    await waitFor(() => {
+      expect(screen.getByText(/update available/i)).toBeInTheDocument()
+    })
+    expect(screen.getByText('v2.0.0')).toBeInTheDocument()
+  })
+
+  it('does not show update banner when already on the latest version', async () => {
+    mockFetch('v1.2.0') // same as baseStats.version
+    renderSidebar()
+    await waitFor(() => {
+      expect(global.fetch).toHaveBeenCalled()
+    })
+    expect(screen.queryByText(/update available/i)).toBeNull()
+  })
+
+  it('does not show update banner when current version is newer than remote', async () => {
+    mockFetch('v1.1.0')
+    renderSidebar()
+    await waitFor(() => {
+      expect(global.fetch).toHaveBeenCalled()
+    })
+    expect(screen.queryByText(/update available/i)).toBeNull()
+  })
+
+  it('does not show update banner when fetch fails', async () => {
+    global.fetch = vi.fn().mockRejectedValue(new Error('network error'))
+    renderSidebar()
+    // Give time for fetch to settle
+    await act(async () => { await new Promise(r => setTimeout(r, 50)) })
+    expect(screen.queryByText(/update available/i)).toBeNull()
+  })
+
+  it('does not show update banner when stats version is "dev"', async () => {
+    mockFetch('v2.0.0')
+    renderSidebar({ stats: { ...baseStats, version: 'dev' } })
+    await waitFor(() => {
+      expect(global.fetch).toHaveBeenCalled()
+    })
+    expect(screen.queryByText(/update available/i)).toBeNull()
+  })
+})
+
+// ---------------------------------------------------------------------------
+// Update banner — dismiss
+// ---------------------------------------------------------------------------
+
+describe('Sidebar update banner dismiss', () => {
+  it('hides the banner when X is clicked', async () => {
+    mockFetch('v2.0.0')
+    renderSidebar()
+    await waitFor(() => {
+      expect(screen.getByText(/update available/i)).toBeInTheDocument()
+    })
+    fireEvent.click(screen.getByRole('button', { name: /close/i }))
+    expect(screen.queryByText(/update available/i)).toBeNull()
+  })
+
+  it('saves the dismissed version to localStorage when X is clicked', async () => {
+    mockFetch('v2.0.0')
+    renderSidebar()
+    await waitFor(() => {
+      expect(screen.getByText(/update available/i)).toBeInTheDocument()
+    })
+    fireEvent.click(screen.getByRole('button', { name: /close/i }))
+    expect(localStorage.getItem(DISMISSED_KEY)).toBe('2.0.0')
+  })
+
+  it('does not show banner on mount when that version was already dismissed', async () => {
+    localStorage.setItem(DISMISSED_KEY, '2.0.0')
+    mockFetch('v2.0.0')
+    renderSidebar()
+    await waitFor(() => {
+      expect(global.fetch).toHaveBeenCalled()
+    })
+    expect(screen.queryByText(/update available/i)).toBeNull()
+  })
+
+  it('shows banner again when a newer version than the dismissed one is available', async () => {
+    localStorage.setItem(DISMISSED_KEY, '2.0.0')
+    mockFetch('v2.1.0')
+    renderSidebar()
+    await waitFor(() => {
+      expect(screen.getByText(/update available/i)).toBeInTheDocument()
+    })
   })
 })

--- a/frontend/src/components/settings/AppSettingsTab.jsx
+++ b/frontend/src/components/settings/AppSettingsTab.jsx
@@ -86,7 +86,6 @@ function StatsDisplaySection() {
     { key: 'show_stat_maps',    label: t('stats.maps')    },
     { key: 'show_stat_tokens',  label: t('stats.tokens')  },
     { key: 'show_stat_size',    label: t('stats.size')    },
-    { key: 'show_stat_version', label: t('stats.version') },
   ]
 
   useEffect(() => {

--- a/frontend/src/components/settings/AppSettingsTab.test.jsx
+++ b/frontend/src/components/settings/AppSettingsTab.test.jsx
@@ -1,0 +1,193 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { render, screen, fireEvent, waitFor } from '@testing-library/react'
+import AppSettingsTab from './AppSettingsTab'
+
+vi.mock('../../api', () => ({
+  settings: {
+    get: vi.fn(),
+    patch: vi.fn(),
+    generateApiKey: vi.fn(),
+    revokeApiKey: vi.fn(),
+  },
+}))
+
+import { settings as settingsApi } from '../../api'
+
+const defaultSettings = {
+  hide_maps: false,
+  hide_tokens: false,
+  hide_campaigns: false,
+  show_stat_systems: true,
+  show_stat_books: false,
+  show_stat_pages: true,
+  show_stat_maps: false,
+  show_stat_tokens: false,
+  show_stat_size: true,
+  stats_api_key: '',
+}
+
+beforeEach(() => {
+  vi.resetAllMocks()
+  settingsApi.get.mockResolvedValue(defaultSettings)
+  settingsApi.patch.mockResolvedValue({})
+})
+
+// ---------------------------------------------------------------------------
+// Stats Display section — toggle list
+// ---------------------------------------------------------------------------
+
+describe('AppSettingsTab — StatsDisplaySection', () => {
+  it('renders all six stat toggle labels', async () => {
+    render(<AppSettingsTab />)
+    await waitFor(() => {
+      expect(screen.getByLabelText('Systems')).toBeInTheDocument()
+    })
+    expect(screen.getByLabelText('Books')).toBeInTheDocument()
+    expect(screen.getByLabelText('Pages')).toBeInTheDocument()
+    expect(screen.getByLabelText('Maps')).toBeInTheDocument()
+    expect(screen.getByLabelText('Tokens')).toBeInTheDocument()
+    expect(screen.getByLabelText('Size')).toBeInTheDocument()
+  })
+
+  it('does not render a Version toggle', async () => {
+    render(<AppSettingsTab />)
+    await waitFor(() => {
+      expect(screen.getByLabelText('Systems')).toBeInTheDocument()
+    })
+    // Version is no longer a configurable stat; it is always shown in the sidebar
+    expect(screen.queryByLabelText('Version')).toBeNull()
+  })
+
+  it('reflects checked state from settings', async () => {
+    render(<AppSettingsTab />)
+    await waitFor(() => {
+      expect(screen.getByLabelText('Systems')).toBeChecked()
+    })
+    expect(screen.getByLabelText('Books')).not.toBeChecked()
+    expect(screen.getByLabelText('Pages')).toBeChecked()
+  })
+
+  it('calls settingsApi.patch with toggled value when checkbox is clicked', async () => {
+    render(<AppSettingsTab />)
+    await waitFor(() => {
+      expect(screen.getByLabelText('Books')).toBeInTheDocument()
+    })
+    fireEvent.click(screen.getByLabelText('Books'))
+    await waitFor(() => {
+      expect(settingsApi.patch).toHaveBeenCalledWith({ show_stat_books: true })
+    })
+  })
+
+  it('dispatches grimoire:settings-changed after a successful patch', async () => {
+    const handler = vi.fn()
+    window.addEventListener('grimoire:settings-changed', handler)
+
+    render(<AppSettingsTab />)
+    await waitFor(() => {
+      expect(screen.getByLabelText('Systems')).toBeInTheDocument()
+    })
+    fireEvent.click(screen.getByLabelText('Systems'))
+    await waitFor(() => {
+      expect(handler).toHaveBeenCalledOnce()
+    })
+
+    window.removeEventListener('grimoire:settings-changed', handler)
+  })
+})
+
+// ---------------------------------------------------------------------------
+// Sidebar Visibility section
+// ---------------------------------------------------------------------------
+
+describe('AppSettingsTab — SidebarVisibilitySection', () => {
+  it('renders Hide Maps, Hide Tokens, and Hide Campaigns checkboxes', async () => {
+    render(<AppSettingsTab />)
+    await waitFor(() => {
+      expect(screen.getByLabelText('Hide Maps')).toBeInTheDocument()
+    })
+    expect(screen.getByLabelText('Hide Tokens')).toBeInTheDocument()
+    expect(screen.getByLabelText('Hide Campaigns')).toBeInTheDocument()
+  })
+
+  it('reflects unchecked state when hide_maps is false', async () => {
+    render(<AppSettingsTab />)
+    await waitFor(() => {
+      expect(screen.getByLabelText('Hide Maps')).not.toBeChecked()
+    })
+  })
+
+  it('reflects checked state when hide_campaigns is true', async () => {
+    settingsApi.get.mockResolvedValue({ ...defaultSettings, hide_campaigns: true })
+    render(<AppSettingsTab />)
+    await waitFor(() => {
+      expect(screen.getByLabelText('Hide Campaigns')).toBeChecked()
+    })
+  })
+
+  it('calls patch with hide_maps: true when Hide Maps is toggled on', async () => {
+    render(<AppSettingsTab />)
+    await waitFor(() => {
+      expect(screen.getByLabelText('Hide Maps')).toBeInTheDocument()
+    })
+    fireEvent.click(screen.getByLabelText('Hide Maps'))
+    await waitFor(() => {
+      expect(settingsApi.patch).toHaveBeenCalledWith({ hide_maps: true })
+    })
+  })
+})
+
+// ---------------------------------------------------------------------------
+// API Key section
+// ---------------------------------------------------------------------------
+
+describe('AppSettingsTab — ApiKeySection', () => {
+  it('renders a Generate API Key button when no key exists', async () => {
+    render(<AppSettingsTab />)
+    await waitFor(() => {
+      expect(screen.getByRole('button', { name: /generate api key/i })).toBeInTheDocument()
+    })
+  })
+
+  it('shows the API key when one is present', async () => {
+    settingsApi.get.mockResolvedValue({ ...defaultSettings, stats_api_key: 'my-secret-key' })
+    render(<AppSettingsTab />)
+    await waitFor(() => {
+      expect(screen.getByText('my-secret-key')).toBeInTheDocument()
+    })
+  })
+
+  it('shows Regenerate and Revoke buttons when a key exists', async () => {
+    settingsApi.get.mockResolvedValue({ ...defaultSettings, stats_api_key: 'my-secret-key' })
+    render(<AppSettingsTab />)
+    await waitFor(() => {
+      expect(screen.getByRole('button', { name: /regenerate/i })).toBeInTheDocument()
+      expect(screen.getByRole('button', { name: /revoke/i })).toBeInTheDocument()
+    })
+  })
+
+  it('calls generateApiKey and shows the new key', async () => {
+    settingsApi.generateApiKey.mockResolvedValue({ stats_api_key: 'new-generated-key' })
+    render(<AppSettingsTab />)
+    await waitFor(() => {
+      expect(screen.getByRole('button', { name: /generate api key/i })).toBeInTheDocument()
+    })
+    fireEvent.click(screen.getByRole('button', { name: /generate api key/i }))
+    await waitFor(() => {
+      expect(screen.getByText('new-generated-key')).toBeInTheDocument()
+    })
+  })
+
+  it('calls revokeApiKey and hides the key', async () => {
+    settingsApi.get.mockResolvedValue({ ...defaultSettings, stats_api_key: 'my-secret-key' })
+    settingsApi.revokeApiKey.mockResolvedValue({})
+    render(<AppSettingsTab />)
+    await waitFor(() => {
+      expect(screen.getByRole('button', { name: /revoke/i })).toBeInTheDocument()
+    })
+    fireEvent.click(screen.getByRole('button', { name: /revoke/i }))
+    await waitFor(() => {
+      expect(screen.getByRole('button', { name: /generate api key/i })).toBeInTheDocument()
+    })
+    expect(screen.queryByText('my-secret-key')).toBeNull()
+  })
+})

--- a/frontend/src/components/settings/UserPreferenceSections.jsx
+++ b/frontend/src/components/settings/UserPreferenceSections.jsx
@@ -96,9 +96,9 @@ export function ReaderSection() {
 }
 
 export function LanguageSection() {
+  const { t } = useTranslation()
   const [lang, setLang] = useState(localStorage.getItem('grimoire:language') || 'en-US')
   const [saved, setSaved] = useState(false)
-
 
   const flash = () => { setSaved(true); setTimeout(() => setSaved(false), 2000) }
   const handleLang = (v) => {
@@ -111,11 +111,11 @@ export function LanguageSection() {
   return (
     <div>
       <h3 style={{ fontSize: 18, fontWeight: 600, marginBottom: 6, display: 'flex', alignItems: 'center', gap: 10 }}>
-        Language / Sprache
+        {t('userSettings.language.title')}
         {saved && <LuCircleCheck size={16} style={{ color: 'var(--green)' }} />}
       </h3>
       <p style={{ fontSize: 14, color: 'var(--text-dim)', marginBottom: 24, lineHeight: 1.6 }}>
-        Choose the display language for the interface.
+        {t('userSettings.language.description')}
       </p>
       <SegmentedControl options={AVAILABLE_LANGUAGES} value={lang} onChange={handleLang} />
     </div>

--- a/frontend/src/locales/de-DE.json
+++ b/frontend/src/locales/de-DE.json
@@ -24,6 +24,18 @@
     "size": "Größe",
     "version": "Version"
   },
+  "about": {
+    "title": "Über Grimoire",
+    "subtitle": "Selbst gehosteter TTRPG-Bibliotheksmanager",
+    "version": "Version",
+    "commitHash": "Commit-Hash",
+    "pythonVersion": "Python-Version",
+    "reactVersion": "React-Version",
+    "updateAvailable": "Update verfügbar",
+    "viewRelease": "Release ansehen",
+    "github": "GitHub-Repository",
+    "openAbout": "Über Grimoire"
+  },
   "common": {
     "save": "Speichern",
     "saving": "Speichern…",
@@ -306,6 +318,10 @@
       "cardSize": "Kartengröße",
       "comfortable": "Komfortabel",
       "compact": "Kompakt"
+    },
+    "language": {
+      "title": "Sprache",
+      "description": "Wählen Sie die Anzeigesprache der Benutzeroberfläche."
     },
     "opds": {
       "title": "OPDS-Feed",

--- a/frontend/src/locales/en-US.json
+++ b/frontend/src/locales/en-US.json
@@ -24,6 +24,18 @@
     "size": "Size",
     "version": "Version"
   },
+  "about": {
+    "title": "About Grimoire",
+    "subtitle": "Self-hosted TTRPG library manager",
+    "version": "Version",
+    "commitHash": "Commit Hash",
+    "pythonVersion": "Python Version",
+    "reactVersion": "React Version",
+    "updateAvailable": "Update Available",
+    "viewRelease": "View Release",
+    "github": "GitHub repository",
+    "openAbout": "About Grimoire"
+  },
   "common": {
     "save": "Save",
     "saving": "Saving…",
@@ -306,6 +318,10 @@
       "cardSize": "Card size",
       "comfortable": "Comfortable",
       "compact": "Compact"
+    },
+    "language": {
+      "title": "Language",
+      "description": "Choose the display language for the interface."
     },
     "opds": {
       "title": "OPDS Feed",

--- a/frontend/src/locales/fr-CA.json
+++ b/frontend/src/locales/fr-CA.json
@@ -24,6 +24,18 @@
     "size": "Taille",
     "version": "Version"
   },
+  "about": {
+    "title": "À propos de Grimoire",
+    "subtitle": "Gestionnaire de bibliothèque TTRPG auto-hébergé",
+    "version": "Version",
+    "commitHash": "Hash de commit",
+    "pythonVersion": "Version Python",
+    "reactVersion": "Version React",
+    "updateAvailable": "Mise à jour disponible",
+    "viewRelease": "Voir la version",
+    "github": "Dépôt GitHub",
+    "openAbout": "À propos de Grimoire"
+  },
   "common": {
     "save": "Enregistrer",
     "saving": "Enregistrement…",
@@ -306,6 +318,10 @@
       "cardSize": "Taille des vignettes",
       "comfortable": "Confortable",
       "compact": "Compact"
+    },
+    "language": {
+      "title": "Langue",
+      "description": "Choisissez la langue d'affichage de l'interface."
     },
     "opds": {
       "title": "Flux OPDS",

--- a/frontend/src/locales/fr-FR.json
+++ b/frontend/src/locales/fr-FR.json
@@ -1,5 +1,5 @@
 {
-  "_meta": { "nativeName": "Français" },
+  "_meta": { "nativeName": "Français (FR)" },
   "app": {
     "name": "GRIMOIRE",
     "subtitle": "Bibliothèque TTRPG"
@@ -23,6 +23,18 @@
     "tokens": "Pions",
     "size": "Taille",
     "version": "Version"
+  },
+  "about": {
+    "title": "À propos de Grimoire",
+    "subtitle": "Gestionnaire de bibliothèque TTRPG auto-hébergé",
+    "version": "Version",
+    "commitHash": "Hash de commit",
+    "pythonVersion": "Version Python",
+    "reactVersion": "Version React",
+    "updateAvailable": "Mise à jour disponible",
+    "viewRelease": "Voir la version",
+    "github": "Dépôt GitHub",
+    "openAbout": "À propos de Grimoire"
   },
   "common": {
     "save": "Enregistrer",
@@ -306,6 +318,10 @@
       "cardSize": "Taille des vignettes",
       "comfortable": "Confortable",
       "compact": "Compact"
+    },
+    "language": {
+      "title": "Langue",
+      "description": "Choisissez la langue d'affichage de l'interface."
     },
     "opds": {
       "title": "Flux OPDS",

--- a/frontend/vite.config.js
+++ b/frontend/vite.config.js
@@ -1,8 +1,15 @@
 import { defineConfig } from 'vite'
 import react from '@vitejs/plugin-react'
+import { createRequire } from 'module'
+
+const require = createRequire(import.meta.url)
+const reactVersion = require('react/package.json').version
 
 export default defineConfig({
   plugins: [react()],
+  define: {
+    __REACT_VERSION__: JSON.stringify(reactVersion),
+  },
   publicDir: 'static',
   server: {
     proxy: {


### PR DESCRIPTION
## Summary

Fetch the latest GitHub release on startup and show a dismissible "Update Available" banner in the sidebar when a newer version exists; dismissed version is persisted to localStorage. Clicking the version row opens an About modal with version, commit hash, Python version, and React version (injected at build time via Vite define). Version is no longer a togglable sidebar stat. Commit hash and Python version are exposed through the /api/stats endpoint, with COMMIT_HASH passed as a
Docker build arg from the release workflow. Adds translation keys for all new strings across en-US, fr-FR, fr-CA, and de-DE, including moving the hardcoded Language section strings into localization.

## Type of change

- [ ] Bug fix
- [x] New feature
- [ ] Refactor / cleanup
- [ ] Docs / configuration only

## Testing

<!-- How did you verify this works? Check all that apply. -->

- [x] Backend tests pass (`pytest -q`)
- [x] Frontend tests pass (`npm test`)
- [x] Tested manually in the browser


