### PR TITLE
Fix: Use navigator.language as fallback and dropdown for language selection

### DIFF
--- a/frontend/src/components/settings/UserPreferenceSections.jsx
+++ b/frontend/src/components/settings/UserPreferenceSections.jsx
@@ -101,7 +101,8 @@ export function LanguageSection() {
   const [saved, setSaved] = useState(false)
 
   const flash = () => { setSaved(true); setTimeout(() => setSaved(false), 2000) }
-  const handleLang = (v) => {
+  const handleLang = (e) => {
+    const v = e.target.value
     setLang(v)
     localStorage.setItem('grimoire:language', v)
     i18n.changeLanguage(v)
@@ -117,7 +118,19 @@ export function LanguageSection() {
       <p style={{ fontSize: 14, color: 'var(--text-dim)', marginBottom: 24, lineHeight: 1.6 }}>
         {t('userSettings.language.description')}
       </p>
-      <SegmentedControl options={AVAILABLE_LANGUAGES} value={lang} onChange={handleLang} />
+      <select
+        value={lang}
+        onChange={handleLang}
+        style={{
+          background: 'var(--bg-card)', border: '1px solid var(--border)', borderRadius: 6,
+          color: 'var(--text)', fontSize: 14, padding: '7px 12px', cursor: 'pointer',
+          minWidth: 180,
+        }}
+      >
+        {AVAILABLE_LANGUAGES.map(({ value, label }) => (
+          <option key={value} value={value}>{label}</option>
+        ))}
+      </select>
     </div>
   )
 }

--- a/frontend/src/components/settings/UserPreferenceSections.test.jsx
+++ b/frontend/src/components/settings/UserPreferenceSections.test.jsx
@@ -1,0 +1,86 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { render, screen, fireEvent } from '@testing-library/react'
+import { LanguageSection } from './UserPreferenceSections'
+import i18n from '../../i18n'
+
+// ---------------------------------------------------------------------------
+// Mocks
+// ---------------------------------------------------------------------------
+
+vi.mock('../../i18n', async (importOriginal) => {
+  const actual = await importOriginal()
+  return {
+    ...actual,
+    default: { ...actual.default, changeLanguage: vi.fn() },
+  }
+})
+
+beforeEach(() => {
+  vi.clearAllMocks()
+})
+
+// ---------------------------------------------------------------------------
+// LanguageSection — rendering
+// ---------------------------------------------------------------------------
+
+describe('LanguageSection — rendering', () => {
+  it('renders the section heading', () => {
+    render(<LanguageSection />)
+    expect(screen.getByRole('heading', { level: 3 })).toBeInTheDocument()
+  })
+
+  it('renders a <select> element', () => {
+    render(<LanguageSection />)
+    expect(screen.getByRole('combobox')).toBeInTheDocument()
+  })
+
+  it('renders at least the English option', () => {
+    render(<LanguageSection />)
+    expect(screen.getByRole('option', { name: /english/i })).toBeInTheDocument()
+  })
+
+  it('defaults to en-US when localStorage has no saved language', () => {
+    render(<LanguageSection />)
+    const select = screen.getByRole('combobox')
+    expect(select.value).toBe('en-US')
+  })
+
+  it('defaults to the saved language from localStorage', () => {
+    localStorage.setItem('grimoire:language', 'de-DE')
+    render(<LanguageSection />)
+    const select = screen.getByRole('combobox')
+    expect(select.value).toBe('de-DE')
+  })
+})
+
+// ---------------------------------------------------------------------------
+// LanguageSection — language change
+// ---------------------------------------------------------------------------
+
+describe('LanguageSection — language change', () => {
+  it('updates the select value when a new language is chosen', () => {
+    render(<LanguageSection />)
+    const select = screen.getByRole('combobox')
+    fireEvent.change(select, { target: { value: 'fr-CA' } })
+    expect(select.value).toBe('fr-CA')
+  })
+
+  it('saves the chosen language to localStorage', () => {
+    render(<LanguageSection />)
+    fireEvent.change(screen.getByRole('combobox'), { target: { value: 'de-DE' } })
+    expect(localStorage.getItem('grimoire:language')).toBe('de-DE')
+  })
+
+  it('calls i18n.changeLanguage with the selected locale', () => {
+    render(<LanguageSection />)
+    fireEvent.change(screen.getByRole('combobox'), { target: { value: 'fr-CA' } })
+    expect(i18n.changeLanguage).toHaveBeenCalledWith('fr-CA')
+  })
+
+  it('shows the saved indicator after a change', () => {
+    render(<LanguageSection />)
+    fireEvent.change(screen.getByRole('combobox'), { target: { value: 'fr-CA' } })
+    // The LuCircleCheck is rendered as an svg icon; the save flash is visible
+    expect(document.querySelector('svg')).toBeInTheDocument()
+  })
+})

--- a/frontend/src/i18n.js
+++ b/frontend/src/i18n.js
@@ -15,11 +15,25 @@ for (const path in modules) {
 
 AVAILABLE_LANGUAGES.sort((a, b) => a.label.localeCompare(b.label))
 
+function detectLanguage() {
+  if (typeof localStorage !== 'undefined') {
+    const saved = localStorage.getItem?.('grimoire:language')
+    if (saved) return saved
+  }
+  const available = Object.keys(resources)
+  for (const lang of (typeof navigator !== 'undefined' ? (navigator.languages ?? [navigator.language]) : [])) {
+    const exact  = available.find(a => a === lang)
+    const prefix = available.find(a => a.startsWith(lang.split('-')[0]))
+    if (exact || prefix) return exact ?? prefix
+  }
+  return 'en-US'
+}
+
 i18n
   .use(initReactI18next)
   .init({
     resources,
-    lng: (typeof localStorage !== 'undefined' && localStorage.getItem?.('grimoire:language')) || 'en-US',
+    lng: detectLanguage(),
     fallbackLng: 'en-US',
     interpolation: {
       escapeValue: false,

--- a/frontend/src/i18n.test.js
+++ b/frontend/src/i18n.test.js
@@ -1,0 +1,100 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest'
+
+// We test the language-detection behaviour indirectly via i18n.language,
+// but to do that we need to reload the module with different env state.
+// Since the module is initialized once, we test detectLanguage by checking
+// the exported AVAILABLE_LANGUAGES array and that the module loads without
+// error, then test the priority rules through manual invocation of an
+// equivalent function.
+
+// ---------------------------------------------------------------------------
+// AVAILABLE_LANGUAGES
+// ---------------------------------------------------------------------------
+
+describe('i18n — AVAILABLE_LANGUAGES', () => {
+  it('is a non-empty array', async () => {
+    const { AVAILABLE_LANGUAGES } = await import('./i18n')
+    expect(Array.isArray(AVAILABLE_LANGUAGES)).toBe(true)
+    expect(AVAILABLE_LANGUAGES.length).toBeGreaterThan(0)
+  })
+
+  it('each entry has value and label properties', async () => {
+    const { AVAILABLE_LANGUAGES } = await import('./i18n')
+    for (const entry of AVAILABLE_LANGUAGES) {
+      expect(entry).toHaveProperty('value')
+      expect(entry).toHaveProperty('label')
+    }
+  })
+
+  it('includes en-US', async () => {
+    const { AVAILABLE_LANGUAGES } = await import('./i18n')
+    expect(AVAILABLE_LANGUAGES.some(l => l.value === 'en-US')).toBe(true)
+  })
+
+  it('is sorted by label', async () => {
+    const { AVAILABLE_LANGUAGES } = await import('./i18n')
+    const labels = AVAILABLE_LANGUAGES.map(l => l.label)
+    const sorted = [...labels].sort((a, b) => a.localeCompare(b))
+    expect(labels).toEqual(sorted)
+  })
+})
+
+// ---------------------------------------------------------------------------
+// detectLanguage priority rules (tested via an equivalent inline function)
+// ---------------------------------------------------------------------------
+
+// These tests replicate the detectLanguage() logic directly so we can
+// exercise every branch without reloading the module.
+
+function makeDetect(availableLocales) {
+  return function detectLanguage(localStorageValue, navigatorLanguages) {
+    if (localStorageValue) return localStorageValue
+
+    for (const lang of (navigatorLanguages ?? [])) {
+      const exact  = availableLocales.find(a => a === lang)
+      const prefix = availableLocales.find(a => a.startsWith(lang.split('-')[0]))
+      if (exact || prefix) return exact ?? prefix
+    }
+    return 'en-US'
+  }
+}
+
+const LOCALES = ['en-US', 'fr-CA', 'fr-FR', 'de-DE']
+const detect  = makeDetect(LOCALES)
+
+describe('detectLanguage — priority', () => {
+  it('returns localStorage value when present, regardless of navigator', () => {
+    expect(detect('de-DE', ['en-US'])).toBe('de-DE')
+  })
+
+  it('ignores localStorage when the value is an empty string', () => {
+    // empty string is falsy, so navigator is tried next
+    expect(detect('', ['fr-CA'])).toBe('fr-CA')
+  })
+
+  it('exact-matches a navigator language', () => {
+    expect(detect(null, ['fr-CA'])).toBe('fr-CA')
+  })
+
+  it('prefix-matches when an exact locale is not available', () => {
+    // navigator says 'fr-BE', which is not in LOCALES; prefix 'fr' matches fr-CA
+    expect(detect(null, ['fr-BE'])).toBe('fr-CA')
+  })
+
+  it('tries navigator languages in order, picks first match', () => {
+    // zh-CN (no match), then de-DE (exact match)
+    expect(detect(null, ['zh-CN', 'de-DE'])).toBe('de-DE')
+  })
+
+  it('falls back to en-US when no navigator language matches', () => {
+    expect(detect(null, ['ja-JP', 'ko-KR'])).toBe('en-US')
+  })
+
+  it('falls back to en-US when navigator languages list is empty', () => {
+    expect(detect(null, [])).toBe('en-US')
+  })
+
+  it('falls back to en-US when navigator languages is null', () => {
+    expect(detect(null, null)).toBe('en-US')
+  })
+})


### PR DESCRIPTION
## Summary

Add detectLanguage() to i18n.js that checks localStorage first, then navigator.languages/navigator.language, then falls back to en-US
Replace SegmentedControl with a <select> dropdown in LanguageSection for better scalability as more locales are added

## Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / cleanup
- [ ] Docs / configuration only

## Testing


- [x] Backend tests pass (`pytest -q`)
- [x] Frontend tests pass (`npm test`)
- [x] Tested manually in the browser

