### PR TITLE
Fix: normalize tags to lowercase across all write paths and existing …

### DIFF
--- a/backend/indexer.py
+++ b/backend/indexer.py
@@ -695,7 +695,14 @@ def _load_tags_json(folder_path: str) -> dict:
         result = {}
         for key, val in raw.items():
             if isinstance(val, list):
-                result[key] = [str(t).strip() for t in val if str(t).strip()]
+                seen: set[str] = set()
+                normalized = []
+                for t in val:
+                    lowered = str(t).strip().lower()
+                    if lowered and lowered not in seen:
+                        seen.add(lowered)
+                        normalized.append(lowered)
+                result[key] = normalized
         return result
     except Exception as exc:
         logger.warning(f"tags.json at {folder_path} could not be parsed: {exc}")

--- a/backend/models.py
+++ b/backend/models.py
@@ -1,5 +1,6 @@
 """Database models for Grimoire."""
 
+import json
 import uuid
 import datetime
 from sqlalchemy import (
@@ -369,6 +370,41 @@ class Favorite(Base):
     __table_args__ = (UniqueConstraint("user_id", "item_type", "item_id"),)
 
 
+def _normalize_tags_in_db(conn) -> None:
+    """Lower-case and deduplicate tags in all tag-bearing tables."""
+    tables = [
+        "game_systems",
+        "books",
+        "book_folders",
+        "generic_maps",
+        "map_folders",
+        "tokens",
+        "token_folders",
+    ]
+    for table in tables:
+        rows = conn.execute(text(f"SELECT rowid, tags FROM {table} WHERE tags IS NOT NULL")).fetchall()
+        for rowid, raw in rows:
+            try:
+                tags = json.loads(raw) if isinstance(raw, str) else raw
+                if not isinstance(tags, list):
+                    continue
+                seen: set[str] = set()
+                normalized = []
+                for t in tags:
+                    lowered = str(t).strip().lower()
+                    if lowered and lowered not in seen:
+                        seen.add(lowered)
+                        normalized.append(lowered)
+                if normalized != tags:
+                    conn.execute(
+                        text(f"UPDATE {table} SET tags = :tags WHERE rowid = :rowid"),
+                        {"tags": json.dumps(normalized), "rowid": rowid},
+                    )
+            except Exception:
+                pass
+    conn.commit()
+
+
 def init_db(db_path: str):
     """Initialize database and return engine + session factory."""
     engine = create_engine(
@@ -414,6 +450,9 @@ def init_db(db_path: str):
             conn.commit()
         except Exception:
             pass  # Column already exists
+
+        # Normalize all stored tags to lowercase, deduplicating within each row.
+        _normalize_tags_in_db(conn)
 
         conn.execute(
             text(

--- a/backend/routers/maps/_schemas.py
+++ b/backend/routers/maps/_schemas.py
@@ -1,6 +1,17 @@
 """Pydantic schemas for the maps API."""
 from typing import Optional
-from pydantic import BaseModel
+from pydantic import BaseModel, field_validator
+
+
+def _normalize_tags(tags: list[str]) -> list[str]:
+    seen = set()
+    result = []
+    for t in tags:
+        lowered = t.strip().lower()
+        if lowered and lowered not in seen:
+            seen.add(lowered)
+            result.append(lowered)
+    return result
 
 
 class MapUpdate(BaseModel):
@@ -9,7 +20,17 @@ class MapUpdate(BaseModel):
     map_type: Optional[str] = None
     grid_size: Optional[str] = None
 
+    @field_validator("tags", mode="before")
+    @classmethod
+    def lowercase_tags(cls, v):
+        return _normalize_tags(v) if v is not None else v
+
 
 class FolderTagsUpdate(BaseModel):
     path: str
     tags: list[str]
+
+    @field_validator("tags", mode="before")
+    @classmethod
+    def lowercase_tags(cls, v):
+        return _normalize_tags(v)

--- a/backend/routers/systems.py
+++ b/backend/routers/systems.py
@@ -3,11 +3,22 @@
 from typing import Optional
 
 from fastapi import APIRouter, HTTPException, Depends
-from pydantic import BaseModel
+from pydantic import BaseModel, field_validator
 
 from ..config import SessionLocal
 from ..models import GameSystem, Book, BookFolder, User
 from ..auth import require_gm_or_admin, get_current_user, CurrentUser
+
+
+def _normalize_tags(tags: list[str]) -> list[str]:
+    seen = set()
+    result = []
+    for t in tags:
+        lowered = t.strip().lower()
+        if lowered and lowered not in seen:
+            seen.add(lowered)
+            result.append(lowered)
+    return result
 
 
 class PublisherEntry(BaseModel):
@@ -19,6 +30,11 @@ class BookFolderUpdate(BaseModel):
     path: str
     tags: list[str]
 
+    @field_validator("tags", mode="before")
+    @classmethod
+    def lowercase_tags(cls, v):
+        return _normalize_tags(v)
+
 
 class GameSystemUpdate(BaseModel):
     name: Optional[str] = None
@@ -29,6 +45,11 @@ class GameSystemUpdate(BaseModel):
     genre: Optional[str] = None
     cover_book_id: Optional[str] = None
     is_explicit: Optional[bool] = None
+
+    @field_validator("tags", mode="before")
+    @classmethod
+    def lowercase_tags(cls, v):
+        return _normalize_tags(v) if v is not None else v
 
 
 router = APIRouter(prefix="/systems", tags=["systems"])

--- a/backend/routers/tokens/_schemas.py
+++ b/backend/routers/tokens/_schemas.py
@@ -1,6 +1,17 @@
 """Pydantic schemas for the tokens API."""
 from typing import Optional
-from pydantic import BaseModel
+from pydantic import BaseModel, field_validator
+
+
+def _normalize_tags(tags: list[str]) -> list[str]:
+    seen = set()
+    result = []
+    for t in tags:
+        lowered = t.strip().lower()
+        if lowered and lowered not in seen:
+            seen.add(lowered)
+            result.append(lowered)
+    return result
 
 
 class TokenUpdate(BaseModel):
@@ -8,7 +19,17 @@ class TokenUpdate(BaseModel):
     tags: Optional[list[str]] = None
     is_explicit: Optional[bool] = None
 
+    @field_validator("tags", mode="before")
+    @classmethod
+    def lowercase_tags(cls, v):
+        return _normalize_tags(v) if v is not None else v
+
 
 class FolderTagsUpdate(BaseModel):
     path: str
     tags: list[str]
+
+    @field_validator("tags", mode="before")
+    @classmethod
+    def lowercase_tags(cls, v):
+        return _normalize_tags(v)

--- a/frontend/src/views/MapsView.jsx
+++ b/frontend/src/views/MapsView.jsx
@@ -170,7 +170,9 @@ export default function MapsView() {
 
   const allTags = [
     ...new Set(
-      maps.maps.flatMap((m) => [...(m.tags || []), ...(folderTags[getFolderPath(m)] || [])])
+      maps.maps.flatMap((m) =>
+        [...(m.tags || []), ...(folderTags[getFolderPath(m)] || [])].map((t) => t.toLowerCase())
+      )
     ),
   ].sort()
 
@@ -193,8 +195,10 @@ export default function MapsView() {
     const tagMatch =
       selectedTags.size === 0 ||
       (() => {
-        const mapTagSet = new Set(m.tags || [])
-        const folderTagSet = new Set(folderTags[getFolderPath(m)] || [])
+        const mapTagSet = new Set((m.tags || []).map((t) => t.toLowerCase()))
+        const folderTagSet = new Set(
+          (folderTags[getFolderPath(m)] || []).map((t) => t.toLowerCase())
+        )
         return [...selectedTags].some((tag) => mapTagSet.has(tag) || folderTagSet.has(tag))
       })()
     return textMatch && tagMatch

--- a/tests/test_maps.py
+++ b/tests/test_maps.py
@@ -79,6 +79,28 @@ class TestUpdateMap:
         assert resp.status_code == 200
         assert resp.json() == {"status": "ok"}
 
+    def test_tags_are_lowercased_on_map_update(self, client, gm_headers):
+        m = make_map()
+        resp = client.patch(
+            f"/api/maps/{m.id}",
+            json={"tags": ["Draw Steel", "DUNGEON", "city"]},
+            headers=gm_headers,
+        )
+        assert resp.status_code == 200
+        detail = client.get(f"/api/maps/{m.id}", headers=gm_headers).json()
+        assert detail["tags"] == ["draw steel", "dungeon", "city"]
+
+    def test_duplicate_tags_deduplicated_on_map_update(self, client, gm_headers):
+        m = make_map()
+        resp = client.patch(
+            f"/api/maps/{m.id}",
+            json={"tags": ["draw steel", "Draw Steel", "DRAW STEEL"]},
+            headers=gm_headers,
+        )
+        assert resp.status_code == 200
+        detail = client.get(f"/api/maps/{m.id}", headers=gm_headers).json()
+        assert detail["tags"] == ["draw steel"]
+
     def test_player_cannot_update_map(self, client, player_headers, map_entry):
         resp = client.patch(
             f"/api/maps/{map_entry.id}",
@@ -125,6 +147,25 @@ class TestMapFolders:
             headers=gm_headers,
         )
         assert resp.status_code == 200
+
+    def test_folder_tags_are_lowercased(self, client, gm_headers):
+        resp = client.patch(
+            "/api/map-folders",
+            json={"path": "maps/case-test", "tags": ["Draw Steel", "DUNGEON"]},
+            headers=gm_headers,
+        )
+        assert resp.status_code == 200
+        body = resp.json()
+        assert body["tags"] == ["draw steel", "dungeon"]
+
+    def test_folder_tags_deduplicated_after_lowercase(self, client, gm_headers):
+        resp = client.patch(
+            "/api/map-folders",
+            json={"path": "maps/dedup-test", "tags": ["draw steel", "Draw Steel"]},
+            headers=gm_headers,
+        )
+        assert resp.status_code == 200
+        assert resp.json()["tags"] == ["draw steel"]
 
     def test_player_cannot_update_folder_tags(self, client, player_headers):
         resp = client.patch(

--- a/tests/test_systems.py
+++ b/tests/test_systems.py
@@ -171,6 +171,26 @@ class TestBookFolders:
         )
         assert resp.status_code == 200
 
+    def test_book_folder_tags_lowercased(self, client, admin_headers, folder_system):
+        path = f"{folder_system.id}/case-folder"
+        resp = client.patch(
+            f"/api/systems/{folder_system.id}/book-folders",
+            json={"path": path, "tags": ["Draw Steel", "PATHFINDER"]},
+            headers=admin_headers,
+        )
+        assert resp.status_code == 200
+        assert resp.json()["tags"] == ["draw steel", "pathfinder"]
+
+    def test_book_folder_tags_deduplicated(self, client, admin_headers, folder_system):
+        path = f"{folder_system.id}/dedup-folder"
+        resp = client.patch(
+            f"/api/systems/{folder_system.id}/book-folders",
+            json={"path": path, "tags": ["draw steel", "Draw Steel"]},
+            headers=admin_headers,
+        )
+        assert resp.status_code == 200
+        assert resp.json()["tags"] == ["draw steel"]
+
     def test_book_folders_nonexistent_system_returns_404(self, client, admin_headers):
         resp = client.get("/api/systems/no-such-id/book-folders", headers=admin_headers)
         assert resp.status_code == 404
@@ -200,6 +220,26 @@ class TestUpdateSystem:
         )
         assert resp.status_code == 200
         assert resp.json() == {"status": "ok"}
+
+    def test_system_tags_lowercased_on_update(self, client, admin_headers, system):
+        resp = client.patch(
+            f"/api/systems/{system.id}",
+            json={"tags": ["Draw Steel", "FANTASY"]},
+            headers=admin_headers,
+        )
+        assert resp.status_code == 200
+        detail = client.get(f"/api/systems/{system.id}", headers=admin_headers).json()
+        assert detail["tags"] == ["draw steel", "fantasy"]
+
+    def test_system_tags_deduplicated_after_lowercase(self, client, admin_headers, system):
+        resp = client.patch(
+            f"/api/systems/{system.id}",
+            json={"tags": ["draw steel", "Draw Steel"]},
+            headers=admin_headers,
+        )
+        assert resp.status_code == 200
+        detail = client.get(f"/api/systems/{system.id}", headers=admin_headers).json()
+        assert detail["tags"] == ["draw steel"]
 
     def test_player_cannot_update(self, client, player_headers, system):
         resp = client.patch(

--- a/tests/test_tags_json.py
+++ b/tests/test_tags_json.py
@@ -181,6 +181,20 @@ def test_load_tags_json_strips_empty_strings_from_tags():
     assert result["."] == ["dungeon"]
 
 
+def test_load_tags_json_lowercases_tags():
+    tmp = tempfile.mkdtemp()
+    _write_json(Path(tmp) / "tags.json", {".": ["Draw Steel", "FANTASY", "dungeon"]})
+    result = _load_tags_json(tmp)
+    assert result["."] == ["draw steel", "fantasy", "dungeon"]
+
+
+def test_load_tags_json_deduplicates_after_lowercasing():
+    tmp = tempfile.mkdtemp()
+    _write_json(Path(tmp) / "tags.json", {".": ["Draw Steel", "draw steel", "DRAW STEEL"]})
+    result = _load_tags_json(tmp)
+    assert result["."] == ["draw steel"]
+
+
 # ---------------------------------------------------------------------------
 # _apply_tags_from_library — maps
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
…data

## Summary

* Add startup DB migration that lowercases and deduplicates tags in all seven tag-bearing tables, resolving collisions like "Draw Steel" vs "draw steel" in existing databases
* Add Pydantic field validators to MapUpdate, FolderTagsUpdate (maps & tokens), BookFolderUpdate, and GameSystemUpdate to enforce lowercase and deduplication on every API write
* Normalize tags read from tags.json in the indexer before storing
* Fix MapsView tag filter to build sets from lowercased values so clicking a filter pill matches maps regardless of stored casing

## Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / cleanup
- [ ] Docs / configuration only

## Testing

<!-- How did you verify this works? Check all that apply. -->

- [x] Backend tests pass (`pytest -q`)
- [x] Frontend tests pass (`npm test`)
- [x] Tested manually in the browser

## Notes for reviewer

<!-- Anything that needs extra context, known limitations, or follow-up work. Delete if not needed. -->
