### PR TITLE
Fix: admin user deletion blocked by foreign key constraints

### DIFF
--- a/backend/routers/users/core.py
+++ b/backend/routers/users/core.py
@@ -1,9 +1,10 @@
 """Admin user management endpoints."""
 from fastapi import APIRouter, Depends, HTTPException
+from sqlalchemy import text
 
 from ...config import SessionLocal
-from ...models import User
-from ...auth import require_admin, get_current_user, CurrentUser, hash_password
+from ...models import User, Campaign
+from ...auth import require_admin, CurrentUser, hash_password
 from ._schemas import UserCreate, UserUpdate
 
 router = APIRouter()
@@ -92,6 +93,14 @@ def delete_user(user_id: str, current_user: CurrentUser = Depends(require_admin)
             if admin_count <= 1:
                 raise HTTPException(400, "Cannot delete the last admin")
 
+        uid = user.id
+        for campaign in db.query(Campaign).filter_by(owner_id=uid).all():
+            db.delete(campaign)
+        db.execute(text("DELETE FROM campaign_members WHERE user_id = :uid"), {"uid": uid})
+        db.execute(text("DELETE FROM player_session_notes WHERE user_id = :uid"), {"uid": uid})
+        db.execute(text("DELETE FROM session_availability WHERE user_id = :uid"), {"uid": uid})
+        db.execute(text("DELETE FROM bookmarks WHERE user_id = :uid"), {"uid": uid})
+        db.execute(text("DELETE FROM favorites WHERE user_id = :uid"), {"uid": uid})
         db.delete(user)
         db.commit()
     finally:

--- a/backend/routers/users/me.py
+++ b/backend/routers/users/me.py
@@ -5,7 +5,7 @@ from fastapi import APIRouter, Depends, HTTPException
 from sqlalchemy import text
 
 from ...config import SessionLocal, OPDS_ENABLED, BASE_URL
-from ...models import User
+from ...models import User, Campaign
 from ...auth import get_current_user, CurrentUser, hash_password, verify_password
 from ._schemas import PasswordChange, PreferencesUpdate
 
@@ -57,8 +57,14 @@ def delete_own_account(current_user: CurrentUser = Depends(get_current_user)):
             raise HTTPException(404, "User not found")
         if user.role == "admin":
             raise HTTPException(400, "Admin accounts cannot be self-deleted")
-        db.execute(text("DELETE FROM bookmarks WHERE user_id = :uid"), {"uid": user.id})
-        db.execute(text("DELETE FROM favorites WHERE user_id = :uid"), {"uid": user.id})
+        uid = user.id
+        for campaign in db.query(Campaign).filter_by(owner_id=uid).all():
+            db.delete(campaign)
+        db.execute(text("DELETE FROM campaign_members WHERE user_id = :uid"), {"uid": uid})
+        db.execute(text("DELETE FROM player_session_notes WHERE user_id = :uid"), {"uid": uid})
+        db.execute(text("DELETE FROM session_availability WHERE user_id = :uid"), {"uid": uid})
+        db.execute(text("DELETE FROM bookmarks WHERE user_id = :uid"), {"uid": uid})
+        db.execute(text("DELETE FROM favorites WHERE user_id = :uid"), {"uid": uid})
         db.delete(user)
         db.commit()
     finally:

--- a/tests/test_users.py
+++ b/tests/test_users.py
@@ -285,3 +285,35 @@ class TestDeleteUser:
         user_id = deletable_user["id"]
         resp = client.delete(f"/api/users/{user_id}", headers=gm_headers)
         assert resp.status_code == 403
+
+    def test_delete_user_with_data(self, client, admin_headers):
+        """Deleting a user with bookmarks and favorites must not raise FK errors."""
+        from tests.conftest import make_game_system, make_book
+        from backend.config import SessionLocal
+        from backend.models import Bookmark, Favorite
+
+        username = unique_user()
+        create = client.post(
+            "/api/users",
+            json={"username": username, "password": "testpass123", "role": "player"},
+            headers=admin_headers,
+        )
+        assert create.status_code == 201
+        user_id = create.json()["id"]
+
+        db = SessionLocal()
+        try:
+            system = make_game_system()
+            db.add(system)
+            db.flush()
+            book = make_book(system.id)
+            db.add(book)
+            db.flush()
+            db.add(Bookmark(user_id=user_id, book_id=book.id, page_number=1))
+            db.add(Favorite(user_id=user_id, item_type="book", item_id=book.id))
+            db.commit()
+        finally:
+            db.close()
+
+        resp = client.delete(f"/api/users/{user_id}", headers=admin_headers)
+        assert resp.status_code == 204


### PR DESCRIPTION
## Summary

Deleting a user failed with a SQLite FK constraint error because PRAGMA foreign_keys=ON is active and six tables reference users.id with no cascade delete. The delete_user endpoint was calling db.delete(user) directly without first removing dependent rows. The fix cleans up owned campaigns (which cascade to their members, resources, session notes, schedules, and availability via existing SQLAlchemy cascade config), then raw-SQL-deletes remaining campaign_members, player_session_notes, session_availability, bookmarks, and favorites rows before deleting the user. The same gap in delete_own_account  was fixed as well.

## Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / cleanup
- [ ] Docs / configuration only

## Testing

- [x] Backend tests pass (`pytest -q`)
- [x] Frontend tests pass (`npm test`)
- [x] Tested manually in the browser
