### PR TITLE
Enhancement: Add tag export to Settings -> Maintenance

### DIFF
--- a/backend/main.py
+++ b/backend/main.py
@@ -26,6 +26,7 @@ from .routers import settings as settings_router
 from .routers import campaigns as campaigns_router
 from .routers import logs as logs_router
 from .routers import downloads as downloads_router
+from .routers import export as export_router
 from .routers.library import run_rescan_sync
 from .routers import opds as opds_router
 from . import scheduler
@@ -151,6 +152,7 @@ api.include_router(settings_router.router)
 api.include_router(campaigns_router.router)
 api.include_router(logs_router.router)
 api.include_router(downloads_router.router)
+api.include_router(export_router.router)
 app.include_router(api)
 
 

--- a/backend/routers/export.py
+++ b/backend/routers/export.py
@@ -1,0 +1,94 @@
+"""Export router — admin-only data export endpoints."""
+
+import json
+import datetime
+
+from fastapi import APIRouter, Depends
+from fastapi.responses import Response
+
+from ..config import SessionLocal
+from ..auth import require_admin, CurrentUser
+from ..models import GameSystem, Book, BookFolder, GenericMap, MapFolder, Token, TokenFolder
+
+router = APIRouter(prefix="/export", tags=["export"])
+
+
+@router.get("/tags", summary="Export all tag data as JSON")
+def export_tags(
+    include_library: bool = True,
+    include_maps: bool = True,
+    include_tokens: bool = True,
+    _: CurrentUser = Depends(require_admin),
+):
+    db = SessionLocal()
+    try:
+        exported_at = datetime.datetime.now(datetime.timezone.utc).strftime(
+            "%Y-%m-%dT%H:%M:%SZ"
+        )
+        payload: dict = {"exported_at": exported_at}
+
+        if include_library:
+            systems = [
+                {"slug": s.slug, "name": s.name, "tags": s.tags or []}
+                for s in db.query(GameSystem).order_by(GameSystem.name).all()
+            ]
+            books = [
+                {
+                    "id": b.id,
+                    "title": b.title,
+                    "filepath": b.relative_path,
+                    "tags": b.tags or [],
+                }
+                for b in db.query(Book).order_by(Book.title).all()
+            ]
+            book_folders = [
+                {"path": f.path, "tags": f.tags or []}
+                for f in db.query(BookFolder).order_by(BookFolder.path).all()
+            ]
+            payload["library"] = {
+                "systems": systems,
+                "books": books,
+                "book_folders": book_folders,
+            }
+
+        if include_maps:
+            maps = [
+                {
+                    "id": m.id,
+                    "name": m.filename,
+                    "folder": "/".join(m.relative_path.split("/")[:-1]),
+                    "tags": m.tags or [],
+                }
+                for m in db.query(GenericMap).order_by(GenericMap.filename).all()
+            ]
+            map_folders = [
+                {"path": f.path, "tags": f.tags or []}
+                for f in db.query(MapFolder).order_by(MapFolder.path).all()
+            ]
+            payload["maps"] = {"items": maps, "folders": map_folders}
+
+        if include_tokens:
+            tokens = [
+                {
+                    "id": t.id,
+                    "name": t.filename,
+                    "folder": "/".join(t.relative_path.split("/")[:-1]),
+                    "tags": t.tags or [],
+                }
+                for t in db.query(Token).order_by(Token.filename).all()
+            ]
+            token_folders = [
+                {"path": f.path, "tags": f.tags or []}
+                for f in db.query(TokenFolder).order_by(TokenFolder.path).all()
+            ]
+            payload["tokens"] = {"items": tokens, "folders": token_folders}
+
+        date_str = datetime.datetime.now(datetime.timezone.utc).strftime("%Y-%m-%d")
+        filename = f"grimoire-tags-{date_str}.json"
+        return Response(
+            content=json.dumps(payload, ensure_ascii=False, indent=2),
+            media_type="application/json",
+            headers={"Content-Disposition": f'attachment; filename="{filename}"'},
+        )
+    finally:
+        db.close()

--- a/frontend/src/components/settings/MaintenanceTab.jsx
+++ b/frontend/src/components/settings/MaintenanceTab.jsx
@@ -1,7 +1,7 @@
 import { useState, useEffect } from 'react'
 import { useTranslation } from 'react-i18next'
-import { LuTrash2, LuCircleCheck, LuRefreshCw, LuSquare } from 'react-icons/lu'
-import api, { settings as settingsApi } from '../../api'
+import { LuTrash2, LuCircleCheck, LuRefreshCw, LuSquare, LuDownload } from 'react-icons/lu'
+import api, { settings as settingsApi, mediaUrl } from '../../api'
 import Spinner from '../Spinner'
 
 // ---------------------------------------------------------------------------
@@ -625,6 +625,105 @@ function DatabaseCleanupSection() {
 }
 
 // ---------------------------------------------------------------------------
+// Export Tags section
+// ---------------------------------------------------------------------------
+
+function ExportTagsSection() {
+  const { t } = useTranslation()
+  const [exporting, setExporting] = useState(false)
+  const [includeLibrary, setIncludeLibrary] = useState(true)
+  const [includeMaps, setIncludeMaps] = useState(true)
+  const [includeTokens, setIncludeTokens] = useState(true)
+
+  const handleExport = () => {
+    setExporting(true)
+    const params = {
+      include_library: includeLibrary,
+      include_maps: includeMaps,
+      include_tokens: includeTokens,
+    }
+    const url = mediaUrl('/export/tags', params)
+    const a = document.createElement('a')
+    a.href = url
+    a.download = ''
+    document.body.appendChild(a)
+    a.click()
+    document.body.removeChild(a)
+    setTimeout(() => setExporting(false), 800)
+  }
+
+  const checkboxStyle = {
+    display: 'flex',
+    alignItems: 'center',
+    gap: 8,
+    fontSize: 14,
+    color: 'var(--text-dim)',
+    cursor: 'pointer',
+    userSelect: 'none',
+  }
+
+  return (
+    <div style={{ marginBottom: 40 }}>
+      <h3 style={{ fontSize: 18, fontWeight: 600, marginBottom: 6 }}>
+        {t('maintenance.tagExport.title')}
+      </h3>
+      <p style={{ fontSize: 14, color: 'var(--text-dim)', marginBottom: 20, lineHeight: 1.6 }}>
+        {t('maintenance.tagExport.description')}
+      </p>
+
+      <div style={{ display: 'flex', gap: 20, marginBottom: 16, flexWrap: 'wrap' }}>
+        <label style={checkboxStyle}>
+          <input
+            type="checkbox"
+            checked={includeLibrary}
+            onChange={(e) => setIncludeLibrary(e.target.checked)}
+          />
+          {t('maintenance.tagExport.library')}
+        </label>
+        <label style={checkboxStyle}>
+          <input
+            type="checkbox"
+            checked={includeMaps}
+            onChange={(e) => setIncludeMaps(e.target.checked)}
+          />
+          {t('maintenance.tagExport.maps')}
+        </label>
+        <label style={checkboxStyle}>
+          <input
+            type="checkbox"
+            checked={includeTokens}
+            onChange={(e) => setIncludeTokens(e.target.checked)}
+          />
+          {t('maintenance.tagExport.tokens')}
+        </label>
+      </div>
+
+      <button
+        onClick={handleExport}
+        disabled={exporting || (!includeLibrary && !includeMaps && !includeTokens)}
+        style={{
+          display: 'inline-flex',
+          alignItems: 'center',
+          gap: 8,
+          padding: '8px 18px',
+          borderRadius: 6,
+          fontSize: 14,
+          fontWeight: 500,
+          background: 'var(--bg-card)',
+          border: '1px solid var(--border)',
+          color: exporting ? 'var(--gold)' : 'var(--text-dim)',
+          cursor: exporting || (!includeLibrary && !includeMaps && !includeTokens) ? 'default' : 'pointer',
+          opacity: (!includeLibrary && !includeMaps && !includeTokens) ? 0.5 : 1,
+        }}
+      >
+        {exporting ? <Spinner size={13} /> : <LuDownload size={13} />}
+        {exporting ? t('maintenance.tagExport.exporting') : t('maintenance.tagExport.button')}
+      </button>
+    </div>
+  )
+}
+
+// ---------------------------------------------------------------------------
 // Tab root
 // ---------------------------------------------------------------------------
 
@@ -634,6 +733,8 @@ export default function MaintenanceTab() {
       <RescanSection />
       <div style={{ borderTop: '1px solid var(--border)', marginBottom: 40 }} />
       <ScheduledRescanSection />
+      <div style={{ borderTop: '1px solid var(--border)', marginBottom: 40 }} />
+      <ExportTagsSection />
       <div style={{ borderTop: '1px solid var(--border)', marginBottom: 40 }} />
       <DatabaseCleanupSection />
     </div>

--- a/frontend/src/components/settings/MaintenanceTab.test.jsx
+++ b/frontend/src/components/settings/MaintenanceTab.test.jsx
@@ -11,9 +11,13 @@ vi.mock('../../api', () => ({
     get: vi.fn(),
     patch: vi.fn(),
   },
+  mediaUrl: vi.fn((path, params = {}) => {
+    const qs = new URLSearchParams({ ...params, token: 'test-token' }).toString()
+    return `/api${path}?${qs}`
+  }),
 }))
 
-import api, { settings as settingsApi } from '../../api'
+import api, { settings as settingsApi, mediaUrl } from '../../api'
 
 const idleStatus = {
   running: false,
@@ -122,5 +126,105 @@ describe('MaintenanceTab — RescanSection', () => {
     await waitFor(() => {
       expect(api.post).toHaveBeenCalledWith('/rescan')
     })
+  })
+})
+
+describe('MaintenanceTab — ExportTagsSection', () => {
+  let appendedAnchors
+  let origAppendChild
+  let origRemoveChild
+
+  beforeEach(() => {
+    appendedAnchors = []
+    origAppendChild = document.body.appendChild.bind(document.body)
+    origRemoveChild = document.body.removeChild.bind(document.body)
+
+    vi.spyOn(document.body, 'appendChild').mockImplementation((el) => {
+      if (el && el.tagName === 'A') {
+        appendedAnchors.push(el)
+        el.click = vi.fn()
+        return el
+      }
+      return origAppendChild(el)
+    })
+    vi.spyOn(document.body, 'removeChild').mockImplementation((el) => {
+      if (el && el.tagName === 'A') return el
+      return origRemoveChild(el)
+    })
+  })
+
+  afterEach(() => {
+    vi.restoreAllMocks()
+  })
+
+  it('renders the Export Tags button', () => {
+    render(<MaintenanceTab />)
+    expect(screen.getByRole('button', { name: /export tags/i })).toBeInTheDocument()
+  })
+
+  it('renders all three section checkboxes checked by default', () => {
+    render(<MaintenanceTab />)
+    const checkboxes = screen.getAllByRole('checkbox')
+    expect(checkboxes).toHaveLength(3)
+    checkboxes.forEach((cb) => expect(cb).toBeChecked())
+  })
+
+  it('calls mediaUrl with all sections enabled by default on click', () => {
+    render(<MaintenanceTab />)
+    fireEvent.click(screen.getByRole('button', { name: /export tags/i }))
+    expect(mediaUrl).toHaveBeenCalledWith('/export/tags', {
+      include_library: true,
+      include_maps: true,
+      include_tokens: true,
+    })
+  })
+
+  it('triggers a programmatic anchor click to download the file', () => {
+    render(<MaintenanceTab />)
+    fireEvent.click(screen.getByRole('button', { name: /export tags/i }))
+    expect(appendedAnchors).toHaveLength(1)
+    expect(appendedAnchors[0].click).toHaveBeenCalled()
+  })
+
+  it('passes include_library=false when Library checkbox is unchecked', () => {
+    render(<MaintenanceTab />)
+    const [libraryCheckbox] = screen.getAllByRole('checkbox')
+    fireEvent.click(libraryCheckbox)
+    fireEvent.click(screen.getByRole('button', { name: /export tags/i }))
+    expect(mediaUrl).toHaveBeenCalledWith('/export/tags', {
+      include_library: false,
+      include_maps: true,
+      include_tokens: true,
+    })
+  })
+
+  it('passes include_maps=false when Maps checkbox is unchecked', () => {
+    render(<MaintenanceTab />)
+    const [, mapsCheckbox] = screen.getAllByRole('checkbox')
+    fireEvent.click(mapsCheckbox)
+    fireEvent.click(screen.getByRole('button', { name: /export tags/i }))
+    expect(mediaUrl).toHaveBeenCalledWith('/export/tags', {
+      include_library: true,
+      include_maps: false,
+      include_tokens: true,
+    })
+  })
+
+  it('passes include_tokens=false when Tokens checkbox is unchecked', () => {
+    render(<MaintenanceTab />)
+    const [, , tokensCheckbox] = screen.getAllByRole('checkbox')
+    fireEvent.click(tokensCheckbox)
+    fireEvent.click(screen.getByRole('button', { name: /export tags/i }))
+    expect(mediaUrl).toHaveBeenCalledWith('/export/tags', {
+      include_library: true,
+      include_maps: true,
+      include_tokens: false,
+    })
+  })
+
+  it('disables the button when all checkboxes are unchecked', () => {
+    render(<MaintenanceTab />)
+    screen.getAllByRole('checkbox').forEach((cb) => fireEvent.click(cb))
+    expect(screen.getByRole('button', { name: /export tags/i })).toBeDisabled()
   })
 })

--- a/frontend/src/locales/en-US.json
+++ b/frontend/src/locales/en-US.json
@@ -456,6 +456,15 @@
         "sun": "Sun"
       }
     },
+    "tagExport": {
+      "title": "Export Tags",
+      "description": "Download all tags assigned to books, maps, tokens, systems, and folders as a JSON file.",
+      "button": "Export Tags",
+      "exporting": "Exporting…",
+      "library": "Library",
+      "maps": "Maps",
+      "tokens": "Tokens"
+    },
     "cleanup": {
       "title": "Database Cleanup",
       "description": "Scans the database for books, maps, and tokens whose files no longer exist on disk and removes their records. This cannot be undone — re-scanning the library will only re-add files that are present on disk.",

--- a/frontend/src/locales/fr-CA.json
+++ b/frontend/src/locales/fr-CA.json
@@ -456,6 +456,15 @@
         "sun": "Dim"
       }
     },
+    "tagExport": {
+      "title": "Exporter les étiquettes",
+      "description": "Télécharger toutes les étiquettes attribuées aux livres, cartes, pions, systèmes et dossiers dans un fichier JSON.",
+      "button": "Exporter les étiquettes",
+      "exporting": "Exportation…",
+      "library": "Bibliothèque",
+      "maps": "Cartes",
+      "tokens": "Pions"
+    },
     "cleanup": {
       "title": "Nettoyage de la base de données",
       "description": "Analyse la base de données à la recherche de livres, cartes et pions dont les fichiers n'existent plus sur le disque et supprime leurs enregistrements. Cette action est irréversible — réanalyser la bibliothèque ne rajoutera que les fichiers présents sur le disque.",

--- a/frontend/src/locales/fr-FR.json
+++ b/frontend/src/locales/fr-FR.json
@@ -456,6 +456,15 @@
         "sun": "Dim"
       }
     },
+    "tagExport": {
+      "title": "Exporter les étiquettes",
+      "description": "Télécharger toutes les étiquettes attribuées aux livres, cartes, pions, systèmes et dossiers dans un fichier JSON.",
+      "button": "Exporter les étiquettes",
+      "exporting": "Exportation…",
+      "library": "Bibliothèque",
+      "maps": "Cartes",
+      "tokens": "Pions"
+    },
     "cleanup": {
       "title": "Nettoyage de la base de données",
       "description": "Analyse la base de données à la recherche de livres, cartes et pions dont les fichiers n'existent plus sur le disque et supprime leurs enregistrements. Cette action est irréversible — réanalyser la bibliothèque ne rajoutera que les fichiers présents sur le disque.",

--- a/tests/test_export.py
+++ b/tests/test_export.py
@@ -1,0 +1,349 @@
+"""Tests for the tag export endpoint (GET /api/export/tags)."""
+import json
+import uuid
+
+import pytest
+
+from tests.conftest import make_game_system, make_book, make_map, make_token
+from backend.config import SessionLocal
+from backend.models import BookFolder, MapFolder, TokenFolder
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _make_book_folder(path: str, tags: list) -> BookFolder:
+    db = SessionLocal()
+    row = BookFolder(path=path, tags=tags)
+    db.add(row)
+    db.commit()
+    db.refresh(row)
+    db.close()
+    return row
+
+
+def _make_map_folder(path: str, tags: list) -> MapFolder:
+    db = SessionLocal()
+    row = MapFolder(path=path, tags=tags)
+    db.add(row)
+    db.commit()
+    db.refresh(row)
+    db.close()
+    return row
+
+
+def _make_token_folder(path: str, tags: list) -> TokenFolder:
+    db = SessionLocal()
+    row = TokenFolder(path=path, tags=tags)
+    db.add(row)
+    db.commit()
+    db.refresh(row)
+    db.close()
+    return row
+
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture(scope="module")
+def export_system():
+    uid = uuid.uuid4().hex[:6]
+    return make_game_system(
+        name=f"ExportSystem-{uid}",
+        slug=f"export-system-{uid}",
+        tags=["fantasy", "official"],
+    )
+
+
+@pytest.fixture(scope="module")
+def export_book(export_system):
+    uid = uuid.uuid4().hex[:6]
+    return make_book(
+        system_id=export_system.id,
+        title=f"Export Book {uid}",
+        filename=f"export-book-{uid}.pdf",
+        filepath=f"/tmp/export-book-{uid}.pdf",
+        relative_path=f"books/core/export-book-{uid}.pdf",
+        tags=["core", "phb"],
+    )
+
+
+@pytest.fixture(scope="module")
+def export_book_folder():
+    uid = uuid.uuid4().hex[:6]
+    return _make_book_folder(f"dnd-5e/adventures-{uid}", ["adventure", "al-legal"])
+
+
+@pytest.fixture(scope="module")
+def export_map():
+    uid = uuid.uuid4().hex[:6]
+    return make_map(
+        filename=f"dungeon-{uid}.png",
+        filepath=f"/tmp/dungeon-{uid}.png",
+        relative_path=f"maps/dungeons/dungeon-{uid}.png",
+        tags=["dungeon", "outdoor"],
+    )
+
+
+@pytest.fixture(scope="module")
+def export_map_folder():
+    uid = uuid.uuid4().hex[:6]
+    return _make_map_folder(f"dungeons-{uid}", ["dungeon"])
+
+
+@pytest.fixture(scope="module")
+def export_token():
+    uid = uuid.uuid4().hex[:6]
+    return make_token(
+        filename=f"goblin-{uid}.png",
+        filepath=f"/tmp/goblin-{uid}.png",
+        relative_path=f"tokens/monsters/goblin-{uid}.png",
+        tags=["monster", "cr5"],
+    )
+
+
+@pytest.fixture(scope="module")
+def export_token_folder():
+    uid = uuid.uuid4().hex[:6]
+    return _make_token_folder(f"monsters-{uid}", ["creature"])
+
+
+# ---------------------------------------------------------------------------
+# Authentication
+# ---------------------------------------------------------------------------
+
+
+class TestExportTagsAuth:
+    def test_unauthenticated_rejected(self, client):
+        resp = client.get("/api/export/tags")
+        assert resp.status_code == 401
+
+    def test_player_forbidden(self, client, player_headers):
+        resp = client.get("/api/export/tags", headers=player_headers)
+        assert resp.status_code == 403
+
+    def test_gm_forbidden(self, client, gm_headers):
+        resp = client.get("/api/export/tags", headers=gm_headers)
+        assert resp.status_code == 403
+
+    def test_admin_allowed(self, client, admin_headers):
+        resp = client.get("/api/export/tags", headers=admin_headers)
+        assert resp.status_code == 200
+
+
+# ---------------------------------------------------------------------------
+# Response format
+# ---------------------------------------------------------------------------
+
+
+class TestExportTagsFormat:
+    def test_content_type_is_json(self, client, admin_headers):
+        resp = client.get("/api/export/tags", headers=admin_headers)
+        assert "application/json" in resp.headers["content-type"]
+
+    def test_content_disposition_attachment(self, client, admin_headers):
+        resp = client.get("/api/export/tags", headers=admin_headers)
+        cd = resp.headers["content-disposition"]
+        assert "attachment" in cd
+        assert "grimoire-tags-" in cd
+        assert ".json" in cd
+
+    def test_exported_at_field_present(self, client, admin_headers):
+        data = client.get("/api/export/tags", headers=admin_headers).json()
+        assert "exported_at" in data
+
+    def test_all_top_level_sections_present_by_default(self, client, admin_headers):
+        data = client.get("/api/export/tags", headers=admin_headers).json()
+        assert "library" in data
+        assert "maps" in data
+        assert "tokens" in data
+
+    def test_library_has_expected_keys(self, client, admin_headers):
+        data = client.get("/api/export/tags", headers=admin_headers).json()
+        lib = data["library"]
+        assert "systems" in lib
+        assert "books" in lib
+        assert "book_folders" in lib
+
+    def test_maps_has_expected_keys(self, client, admin_headers):
+        data = client.get("/api/export/tags", headers=admin_headers).json()
+        assert "items" in data["maps"]
+        assert "folders" in data["maps"]
+
+    def test_tokens_has_expected_keys(self, client, admin_headers):
+        data = client.get("/api/export/tags", headers=admin_headers).json()
+        assert "items" in data["tokens"]
+        assert "folders" in data["tokens"]
+
+
+# ---------------------------------------------------------------------------
+# Data integrity
+# ---------------------------------------------------------------------------
+
+
+class TestExportTagsData:
+    def test_system_tags_included(self, client, admin_headers, export_system):
+        data = client.get("/api/export/tags", headers=admin_headers).json()
+        systems = data["library"]["systems"]
+        match = next((s for s in systems if s["slug"] == export_system.slug), None)
+        assert match is not None
+        assert match["tags"] == export_system.tags
+
+    def test_system_entry_shape(self, client, admin_headers, export_system):
+        data = client.get("/api/export/tags", headers=admin_headers).json()
+        match = next(
+            (s for s in data["library"]["systems"] if s["slug"] == export_system.slug), None
+        )
+        assert "slug" in match
+        assert "name" in match
+        assert "tags" in match
+
+    def test_book_tags_included(self, client, admin_headers, export_book):
+        data = client.get("/api/export/tags", headers=admin_headers).json()
+        books = data["library"]["books"]
+        match = next((b for b in books if b["id"] == export_book.id), None)
+        assert match is not None
+        assert match["tags"] == export_book.tags
+
+    def test_book_entry_shape(self, client, admin_headers, export_book):
+        data = client.get("/api/export/tags", headers=admin_headers).json()
+        match = next((b for b in data["library"]["books"] if b["id"] == export_book.id), None)
+        assert "id" in match
+        assert "title" in match
+        assert "filepath" in match
+        assert "tags" in match
+
+    def test_book_folder_tags_included(self, client, admin_headers, export_book_folder):
+        data = client.get("/api/export/tags", headers=admin_headers).json()
+        folders = data["library"]["book_folders"]
+        match = next((f for f in folders if f["path"] == export_book_folder.path), None)
+        assert match is not None
+        assert match["tags"] == export_book_folder.tags
+
+    def test_map_tags_included(self, client, admin_headers, export_map):
+        data = client.get("/api/export/tags", headers=admin_headers).json()
+        maps = data["maps"]["items"]
+        match = next((m for m in maps if m["id"] == export_map.id), None)
+        assert match is not None
+        assert match["tags"] == export_map.tags
+
+    def test_map_entry_shape(self, client, admin_headers, export_map):
+        data = client.get("/api/export/tags", headers=admin_headers).json()
+        match = next((m for m in data["maps"]["items"] if m["id"] == export_map.id), None)
+        assert "id" in match
+        assert "name" in match
+        assert "folder" in match
+        assert "tags" in match
+
+    def test_map_folder_derived_from_relative_path(self, client, admin_headers, export_map):
+        data = client.get("/api/export/tags", headers=admin_headers).json()
+        match = next((m for m in data["maps"]["items"] if m["id"] == export_map.id), None)
+        assert match["folder"] == "maps/dungeons"
+
+    def test_map_folder_tags_included(self, client, admin_headers, export_map_folder):
+        data = client.get("/api/export/tags", headers=admin_headers).json()
+        folders = data["maps"]["folders"]
+        match = next((f for f in folders if f["path"] == export_map_folder.path), None)
+        assert match is not None
+        assert match["tags"] == export_map_folder.tags
+
+    def test_token_tags_included(self, client, admin_headers, export_token):
+        data = client.get("/api/export/tags", headers=admin_headers).json()
+        tokens = data["tokens"]["items"]
+        match = next((t for t in tokens if t["id"] == export_token.id), None)
+        assert match is not None
+        assert match["tags"] == export_token.tags
+
+    def test_token_entry_shape(self, client, admin_headers, export_token):
+        data = client.get("/api/export/tags", headers=admin_headers).json()
+        match = next((t for t in data["tokens"]["items"] if t["id"] == export_token.id), None)
+        assert "id" in match
+        assert "name" in match
+        assert "folder" in match
+        assert "tags" in match
+
+    def test_token_folder_tags_included(self, client, admin_headers, export_token_folder):
+        data = client.get("/api/export/tags", headers=admin_headers).json()
+        folders = data["tokens"]["folders"]
+        match = next((f for f in folders if f["path"] == export_token_folder.path), None)
+        assert match is not None
+        assert match["tags"] == export_token_folder.tags
+
+    def test_empty_tags_included_not_omitted(self, client, admin_headers):
+        uid = uuid.uuid4().hex[:6]
+        sys = make_game_system(
+            name=f"NoTagSystem-{uid}",
+            slug=f"no-tag-system-{uid}",
+            tags=[],
+        )
+        data = client.get("/api/export/tags", headers=admin_headers).json()
+        match = next((s for s in data["library"]["systems"] if s["slug"] == sys.slug), None)
+        assert match is not None
+        assert match["tags"] == []
+
+    def test_valid_json_payload(self, client, admin_headers):
+        resp = client.get("/api/export/tags", headers=admin_headers)
+        parsed = json.loads(resp.content)
+        assert isinstance(parsed, dict)
+
+
+# ---------------------------------------------------------------------------
+# Section toggles
+# ---------------------------------------------------------------------------
+
+
+class TestExportTagsToggles:
+    def test_exclude_library(self, client, admin_headers):
+        data = client.get(
+            "/api/export/tags",
+            headers=admin_headers,
+            params={"include_library": False},
+        ).json()
+        assert "library" not in data
+        assert "maps" in data
+        assert "tokens" in data
+
+    def test_exclude_maps(self, client, admin_headers):
+        data = client.get(
+            "/api/export/tags",
+            headers=admin_headers,
+            params={"include_maps": False},
+        ).json()
+        assert "library" in data
+        assert "maps" not in data
+        assert "tokens" in data
+
+    def test_exclude_tokens(self, client, admin_headers):
+        data = client.get(
+            "/api/export/tags",
+            headers=admin_headers,
+            params={"include_tokens": False},
+        ).json()
+        assert "library" in data
+        assert "maps" in data
+        assert "tokens" not in data
+
+    def test_exclude_all_sections(self, client, admin_headers):
+        data = client.get(
+            "/api/export/tags",
+            headers=admin_headers,
+            params={"include_library": False, "include_maps": False, "include_tokens": False},
+        ).json()
+        assert "library" not in data
+        assert "maps" not in data
+        assert "tokens" not in data
+        assert "exported_at" in data
+
+    def test_library_only(self, client, admin_headers):
+        data = client.get(
+            "/api/export/tags",
+            headers=admin_headers,
+            params={"include_maps": False, "include_tokens": False},
+        ).json()
+        assert "library" in data
+        assert "maps" not in data
+        assert "tokens" not in data


### PR DESCRIPTION
## Summary

Adds a GET /api/export/tags endpoint (admin-only) that returns all tag data for library systems, books, book-folders, maps, map-folders, tokens, and token-folders as a downloadable JSON file. Query params include_library / include_maps / include_tokens (all default true) allow per-section filtering.

## Type of change

- [ ] Bug fix
- [x] New feature
- [ ] Refactor / cleanup
- [ ] Docs / configuration only

## Testing

<!-- How did you verify this works? Check all that apply. -->

- [x] Backend tests pass (`pytest -q`)
- [x] Frontend tests pass (`npm test`)
- [x] Tested manually in the browser

## Notes for reviewer

<!-- Anything that needs extra context, known limitations, or follow-up work. Delete if not needed. -->
