### PR TITLE
Fix: ungrouped items display above grouped folder sections

### DIFF
--- a/frontend/src/views/SystemDetailView.jsx
+++ b/frontend/src/views/SystemDetailView.jsx
@@ -708,8 +708,8 @@ export default function SystemDetailView() {
                     }
 
                     const sortedFolderKeys = Object.keys(folderMap).sort((a, b) => {
-                      if (a === '') return 1
-                      if (b === '') return -1
+                      if (a === '') return -1
+                      if (b === '') return 1
                       return a.localeCompare(b)
                     })
                     return (


### PR DESCRIPTION
## Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / cleanup
- [ ] Docs / configuration only

## Testing

<!-- How did you verify this works? Check all that apply. -->

- [x] Backend tests pass (`pytest -q`)
- [x] Frontend tests pass (`npm test`)
- [x] Tested manually in the browser
