### PR TITLE
Enhancement: Add scheduled Database Cleanup option to Scheduled Rescan

### DIFF
--- a/.github/workflows/beta.yml
+++ b/.github/workflows/beta.yml
@@ -1,17 +1,17 @@
-name: Canary
+name: Beta
 
 on:
   workflow_run:
     workflows: ["CI"]
-    branches: [main]
+    branches: ["release/v*"]
     types: [completed]
 
 env:
   IMAGE: ${{ secrets.DOCKERHUB_USERNAME }}/grimoire
 
 jobs:
-  canary:
-    name: Build and push canary
+  beta:
+    name: Build and push beta
     runs-on: ubuntu-latest
     if: ${{ github.event.workflow_run.conclusion == 'success' }}
 
@@ -19,6 +19,14 @@ jobs:
       - uses: actions/checkout@v4
         with:
           ref: ${{ github.event.workflow_run.head_sha }}
+
+      # Extract version from branch name: release/v1.9.2 → 1.9.2
+      - name: Parse version from branch
+        id: ver
+        run: |
+          BRANCH="${{ github.event.workflow_run.head_branch }}"
+          VERSION="${BRANCH#release/v}"
+          echo "version=$VERSION" >> "$GITHUB_OUTPUT"
 
       - name: Log in to DockerHub
         uses: docker/login-action@v3
@@ -29,11 +37,16 @@ jobs:
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3
 
-      - name: Build and push canary
+      - name: Build and push beta
         uses: docker/build-push-action@v6
         with:
           context: .
           push: true
-          tags: ${{ env.IMAGE }}:canary
+          build-args: |
+            APP_VERSION=${{ steps.ver.outputs.version }}-beta
+            COMMIT_HASH=${{ github.event.workflow_run.head_sha }}
+          tags: |
+            ${{ env.IMAGE }}:${{ steps.ver.outputs.version }}-beta
+            ${{ env.IMAGE }}:edge
           cache-from: type=gha
           cache-to: type=gha,mode=max

--- a/backend/routers/maintenance.py
+++ b/backend/routers/maintenance.py
@@ -7,38 +7,60 @@ from sqlalchemy import text
 
 from ..config import SessionLocal, logger
 from ..auth import require_admin, CurrentUser
-from ..models import Book, GenericMap, Token
+from ..models import Book, Bookmark, GenericMap, Token
 
 router = APIRouter(prefix="/maintenance", tags=["maintenance"])
+
+
+def _do_cleanup(db) -> dict:
+    """Delete DB records whose files no longer exist on disk. Caller commits."""
+    removed = {"books": 0, "maps": 0, "tokens": 0}
+
+    for book in db.query(Book).all():
+        if not os.path.exists(book.filepath):
+            logger.info(f"Cleanup: removing missing book '{book.title}' ({book.filepath})")
+            db.execute(text("DELETE FROM book_search WHERE book_id = :id"), {"id": book.id})
+            db.query(Bookmark).filter_by(book_id=book.id).delete()
+            db.delete(book)
+            removed["books"] += 1
+
+    for m in db.query(GenericMap).all():
+        if not os.path.exists(m.filepath):
+            logger.info(f"Cleanup: removing missing map '{m.filename}' ({m.filepath})")
+            db.delete(m)
+            removed["maps"] += 1
+
+    for t in db.query(Token).all():
+        if not os.path.exists(t.filepath):
+            logger.info(f"Cleanup: removing missing token '{t.filename}' ({t.filepath})")
+            db.delete(t)
+            removed["tokens"] += 1
+
+    return removed
 
 
 @router.post("/cleanup-missing", summary="Remove DB entries for missing files")
 def cleanup_missing(_: CurrentUser = Depends(require_admin)):
     db = SessionLocal()
-    removed = {"books": 0, "maps": 0, "tokens": 0}
     try:
-        for book in db.query(Book).all():
-            if not os.path.exists(book.filepath):
-                logger.info(f"Cleanup: removing missing book '{book.title}' ({book.filepath})")
-                db.execute(text("DELETE FROM book_search WHERE book_id = :id"), {"id": book.id})
-                db.delete(book)
-                removed["books"] += 1
-
-        for m in db.query(GenericMap).all():
-            if not os.path.exists(m.filepath):
-                logger.info(f"Cleanup: removing missing map '{m.filename}' ({m.filepath})")
-                db.delete(m)
-                removed["maps"] += 1
-
-        for t in db.query(Token).all():
-            if not os.path.exists(t.filepath):
-                logger.info(f"Cleanup: removing missing token '{t.filename}' ({t.filepath})")
-                db.delete(t)
-                removed["tokens"] += 1
-
+        removed = _do_cleanup(db)
         db.commit()
         logger.info(f"Cleanup complete: {removed}")
         return {"removed": removed}
+    except Exception:
+        db.rollback()
+        raise
+    finally:
+        db.close()
+
+
+def run_cleanup_sync() -> None:
+    """Synchronous wrapper used by the scheduler."""
+    db = SessionLocal()
+    try:
+        removed = _do_cleanup(db)
+        db.commit()
+        logger.info(f"Cleanup complete: {removed}")
     except Exception:
         db.rollback()
         raise

--- a/backend/routers/settings/_helpers.py
+++ b/backend/routers/settings/_helpers.py
@@ -11,6 +11,7 @@ _DEFAULTS = {
     "rescan_schedule_hour": "2",
     "rescan_schedule_minute": "0",
     "rescan_schedule_weekday": "0",  # 0=Mon … 6=Sun
+    "cleanup_on_rescan": "false",
     "stats_api_key": "",
     "hide_maps": "false",
     "hide_tokens": "false",
@@ -46,6 +47,7 @@ def _to_typed(raw: dict) -> dict:
         "rescan_schedule_hour": int(raw.get("rescan_schedule_hour", "2")),
         "rescan_schedule_minute": int(raw.get("rescan_schedule_minute", "0")),
         "rescan_schedule_weekday": int(raw.get("rescan_schedule_weekday", "0")),
+        "cleanup_on_rescan": raw.get("cleanup_on_rescan", "false") == "true",
         "stats_api_key": raw["stats_api_key"],
         "hide_maps": raw["hide_maps"] == "true",
         "hide_tokens": raw["hide_tokens"] == "true",

--- a/backend/routers/settings/_schemas.py
+++ b/backend/routers/settings/_schemas.py
@@ -9,6 +9,7 @@ class SettingsPatch(BaseModel):
     rescan_schedule_hour: Optional[int] = None
     rescan_schedule_minute: Optional[int] = None
     rescan_schedule_weekday: Optional[int] = None
+    cleanup_on_rescan: Optional[bool] = None
     stats_api_key: Optional[str] = None  # set to "" to clear
     hide_maps: Optional[bool] = None
     hide_tokens: Optional[bool] = None

--- a/backend/routers/settings/core.py
+++ b/backend/routers/settings/core.py
@@ -41,6 +41,8 @@ def update_settings(data: SettingsPatch, _: CurrentUser = Depends(require_admin)
             _set(db, "rescan_schedule_minute", str(max(0, min(59, data.rescan_schedule_minute))))
         if data.rescan_schedule_weekday is not None:
             _set(db, "rescan_schedule_weekday", str(max(0, min(6, data.rescan_schedule_weekday))))
+        if data.cleanup_on_rescan is not None:
+            _set(db, "cleanup_on_rescan", "true" if data.cleanup_on_rescan else "false")
         if data.stats_api_key is not None:
             _set(db, "stats_api_key", data.stats_api_key)
         if data.hide_maps is not None:

--- a/backend/scheduler.py
+++ b/backend/scheduler.py
@@ -35,7 +35,14 @@ def _seconds_until_next(hour: int, minute: int, weekday: Optional[int]) -> float
     return max(1.0, (target - now).total_seconds())
 
 
-def _run(interval: str, hour: int, minute: int, weekday: Optional[int], rescan_fn) -> None:
+def _run(
+    interval: str,
+    hour: int,
+    minute: int,
+    weekday: Optional[int],
+    rescan_fn,
+    cleanup_fn=None,
+) -> None:
     while True:
         if interval == "hourly":
             secs = 3600.0
@@ -51,8 +58,15 @@ def _run(interval: str, hour: int, minute: int, weekday: Optional[int], rescan_f
         except Exception as e:
             logger.error(f"Scheduled rescan error: {e}")
 
+        if cleanup_fn is not None:
+            logger.info("Scheduled database cleanup starting…")
+            try:
+                cleanup_fn()
+            except Exception as e:
+                logger.error(f"Scheduled database cleanup error: {e}")
 
-def start(interval: str, hour: int, minute: int, weekday: int, rescan_fn) -> None:
+
+def start(interval: str, hour: int, minute: int, weekday: int, rescan_fn, cleanup_fn=None) -> None:
     """Start (or restart) the background rescan thread."""
     global _thread
     stop()
@@ -60,7 +74,7 @@ def start(interval: str, hour: int, minute: int, weekday: int, rescan_fn) -> Non
     _wd = weekday if interval == "weekly" else None
     _thread = threading.Thread(
         target=_run,
-        args=(interval, hour, minute, _wd, rescan_fn),
+        args=(interval, hour, minute, _wd, rescan_fn, cleanup_fn),
         daemon=True,
         name="grimoire-scheduler",
     )
@@ -93,6 +107,7 @@ def apply(db) -> None:
     """
     from .models import AppSetting
     from .routers.library import run_rescan_sync
+    from .routers.maintenance import run_cleanup_sync
 
     rows = {r.key: r.value for r in db.query(AppSetting).all()}
     enabled = rows.get("rescan_schedule_enabled", "false") == "true"
@@ -100,8 +115,10 @@ def apply(db) -> None:
     hour = int(rows.get("rescan_schedule_hour", "2"))
     minute = int(rows.get("rescan_schedule_minute", "0"))
     weekday = int(rows.get("rescan_schedule_weekday", "0"))
+    cleanup_on_rescan = rows.get("cleanup_on_rescan", "false") == "true"
 
     if enabled:
-        start(interval, hour, minute, weekday, run_rescan_sync)
+        cleanup_fn = run_cleanup_sync if cleanup_on_rescan else None
+        start(interval, hour, minute, weekday, run_rescan_sync, cleanup_fn)
     else:
         stop()

--- a/frontend/src/components/settings/MaintenanceTab.jsx
+++ b/frontend/src/components/settings/MaintenanceTab.jsx
@@ -318,6 +318,7 @@ function ScheduledRescanSection() {
   const [schedule, setSchedule] = useState('off')
   const [localTime, setLocalTime] = useState('02:00')
   const [weekday, setWeekday] = useState(0)
+  const [cleanupOnRescan, setCleanupOnRescan] = useState(false)
   const [loading, setLoading] = useState(true)
   const [saving, setSaving] = useState(false)
   const [saved, setSaved] = useState(false)
@@ -348,6 +349,7 @@ function ScheduledRescanSection() {
           utcToLocalTime(data.rescan_schedule_hour ?? 2, data.rescan_schedule_minute ?? 0)
         )
         setWeekday(data.rescan_schedule_weekday ?? 0)
+        setCleanupOnRescan(data.cleanup_on_rescan ?? false)
       })
       .finally(() => setLoading(false))
   }, [])
@@ -363,10 +365,12 @@ function ScheduledRescanSection() {
         rescan_schedule_hour: hour,
         rescan_schedule_minute: minute,
         rescan_schedule_weekday: weekday,
+        cleanup_on_rescan: cleanupOnRescan,
       })
       setSchedule(data.rescan_schedule_enabled ? data.rescan_schedule_interval : 'off')
       setLocalTime(utcToLocalTime(data.rescan_schedule_hour, data.rescan_schedule_minute))
       setWeekday(data.rescan_schedule_weekday)
+      setCleanupOnRescan(data.cleanup_on_rescan ?? false)
       setSaved(true)
       setTimeout(() => setSaved(false), 3000)
     } finally {
@@ -473,6 +477,29 @@ function ScheduledRescanSection() {
                 {t('maintenance.scheduledRescan.localTime')}
               </span>
             </div>
+          )}
+
+          {/* Also run database cleanup toggle */}
+          {schedule !== 'off' && (
+            <label
+              style={{
+                display: 'flex',
+                alignItems: 'center',
+                gap: 10,
+                cursor: 'pointer',
+                fontSize: 14,
+                color: 'var(--text)',
+                userSelect: 'none',
+              }}
+            >
+              <input
+                type="checkbox"
+                checked={cleanupOnRescan}
+                onChange={(e) => setCleanupOnRescan(e.target.checked)}
+                style={{ width: 15, height: 15, cursor: 'pointer', accentColor: 'var(--gold)' }}
+              />
+              {t('maintenance.scheduledRescan.alsoRunCleanup')}
+            </label>
           )}
 
           <div style={{ display: 'flex', alignItems: 'center', gap: 12 }}>

--- a/frontend/src/components/settings/MaintenanceTab.test.jsx
+++ b/frontend/src/components/settings/MaintenanceTab.test.jsx
@@ -61,6 +61,15 @@ beforeEach(() => {
     rescan_schedule_hour: 2,
     rescan_schedule_minute: 0,
     rescan_schedule_weekday: 0,
+    cleanup_on_rescan: false,
+  })
+  settingsApi.patch.mockResolvedValue({
+    rescan_schedule_enabled: false,
+    rescan_schedule_interval: 'daily',
+    rescan_schedule_hour: 2,
+    rescan_schedule_minute: 0,
+    rescan_schedule_weekday: 0,
+    cleanup_on_rescan: false,
   })
 })
 
@@ -125,6 +134,109 @@ describe('MaintenanceTab — RescanSection', () => {
     fireEvent.click(screen.getByRole('button', { name: /rescan library/i }))
     await waitFor(() => {
       expect(api.post).toHaveBeenCalledWith('/rescan')
+    })
+  })
+})
+
+describe('MaintenanceTab — ScheduledRescanSection', () => {
+  it('does not show the cleanup checkbox when schedule is Off', async () => {
+    settingsApi.get.mockResolvedValue({
+      rescan_schedule_enabled: false,
+      rescan_schedule_interval: 'daily',
+      rescan_schedule_hour: 2,
+      rescan_schedule_minute: 0,
+      rescan_schedule_weekday: 0,
+      cleanup_on_rescan: false,
+    })
+    render(<MaintenanceTab />)
+    await waitFor(() => expect(settingsApi.get).toHaveBeenCalled())
+    expect(screen.queryByLabelText(/also run database cleanup/i)).not.toBeInTheDocument()
+  })
+
+  it('shows the cleanup checkbox when a schedule is active', async () => {
+    settingsApi.get.mockResolvedValue({
+      rescan_schedule_enabled: true,
+      rescan_schedule_interval: 'daily',
+      rescan_schedule_hour: 2,
+      rescan_schedule_minute: 0,
+      rescan_schedule_weekday: 0,
+      cleanup_on_rescan: false,
+    })
+    render(<MaintenanceTab />)
+    await waitFor(() =>
+      expect(screen.getByText(/also run database cleanup/i)).toBeInTheDocument()
+    )
+  })
+
+  it('loads cleanup_on_rescan=true from settings as checked', async () => {
+    settingsApi.get.mockResolvedValue({
+      rescan_schedule_enabled: true,
+      rescan_schedule_interval: 'daily',
+      rescan_schedule_hour: 2,
+      rescan_schedule_minute: 0,
+      rescan_schedule_weekday: 0,
+      cleanup_on_rescan: true,
+    })
+    render(<MaintenanceTab />)
+    await waitFor(() => {
+      const cb = screen.getByRole('checkbox', { name: /also run database cleanup/i })
+      expect(cb).toBeChecked()
+    })
+  })
+
+  it('includes cleanup_on_rescan=true in patch when checkbox is checked and saved', async () => {
+    settingsApi.get.mockResolvedValue({
+      rescan_schedule_enabled: true,
+      rescan_schedule_interval: 'daily',
+      rescan_schedule_hour: 2,
+      rescan_schedule_minute: 0,
+      rescan_schedule_weekday: 0,
+      cleanup_on_rescan: false,
+    })
+    settingsApi.patch.mockResolvedValue({
+      rescan_schedule_enabled: true,
+      rescan_schedule_interval: 'daily',
+      rescan_schedule_hour: 2,
+      rescan_schedule_minute: 0,
+      rescan_schedule_weekday: 0,
+      cleanup_on_rescan: true,
+    })
+    render(<MaintenanceTab />)
+    const cb = await screen.findByRole('checkbox', { name: /also run database cleanup/i })
+    fireEvent.click(cb)
+    fireEvent.click(screen.getByRole('button', { name: /save schedule/i }))
+    await waitFor(() => {
+      expect(settingsApi.patch).toHaveBeenCalledWith(
+        expect.objectContaining({ cleanup_on_rescan: true }),
+      )
+    })
+  })
+
+  it('includes cleanup_on_rescan=false in patch when checkbox is unchecked and saved', async () => {
+    settingsApi.get.mockResolvedValue({
+      rescan_schedule_enabled: true,
+      rescan_schedule_interval: 'daily',
+      rescan_schedule_hour: 2,
+      rescan_schedule_minute: 0,
+      rescan_schedule_weekday: 0,
+      cleanup_on_rescan: true,
+    })
+    settingsApi.patch.mockResolvedValue({
+      rescan_schedule_enabled: true,
+      rescan_schedule_interval: 'daily',
+      rescan_schedule_hour: 2,
+      rescan_schedule_minute: 0,
+      rescan_schedule_weekday: 0,
+      cleanup_on_rescan: false,
+    })
+    render(<MaintenanceTab />)
+    const cb = await screen.findByRole('checkbox', { name: /also run database cleanup/i })
+    fireEvent.click(cb) // uncheck
+    fireEvent.click(screen.getByRole('button', { name: /save schedule/i }))
+    await waitFor(() => {
+      expect(settingsApi.patch).toHaveBeenCalledWith(
+        expect.objectContaining({ cleanup_on_rescan: false }),
+      )
     })
   })
 })

--- a/frontend/src/i18n.js
+++ b/frontend/src/i18n.js
@@ -38,6 +38,7 @@ i18n.use(initReactI18next).init({
   interpolation: {
     escapeValue: false,
   },
+  returnNull: false,
 })
 
 export default i18n

--- a/frontend/src/locales/de-DE.json
+++ b/frontend/src/locales/de-DE.json
@@ -195,7 +195,6 @@
     "downloadAllInFolder": "Alle Karten in {{folder}} herunterladen",
     "downloadInSubfolder": "Karten in {{folder}} herunterladen",
     "editTags": "Bearbeiten",
-    "addTags": "Tags hinzufügen",
     "editTagsFull": "Tags bearbeiten",
     "download": "Herunterladen",
     "missing": "Fehlend",
@@ -244,7 +243,6 @@
     "downloadAllInFolder": "Alle Tokens in {{folder}} herunterladen",
     "downloadInSubfolder": "Tokens in {{folder}} herunterladen",
     "editTags": "Bearbeiten",
-    "addTags": "Tags hinzufügen",
     "editTagsFull": "Tags bearbeiten",
     "download": "Herunterladen",
     "missing": "Fehlend",
@@ -446,6 +444,7 @@
       "saveSchedule": "Zeitplan speichern",
       "saving": "Speichern…",
       "saved": "Gespeichert",
+      "alsoRunCleanup": null,
       "weekdays": {
         "mon": "Mo",
         "tue": "Di",
@@ -455,6 +454,15 @@
         "sat": "Sa",
         "sun": "So"
       }
+    },
+    "tagExport": {
+      "title": null,
+      "description": null,
+      "button": null,
+      "exporting": null,
+      "library": null,
+      "maps": null,
+      "tokens": null
     },
     "cleanup": {
       "title": "Datenbankbereinigung",

--- a/frontend/src/locales/en-US.json
+++ b/frontend/src/locales/en-US.json
@@ -195,7 +195,6 @@
     "downloadAllInFolder": "Download all maps in {{folder}}",
     "downloadInSubfolder": "Download maps in {{folder}}",
     "editTags": "Edit",
-    "addTags": "Add tags",
     "editTagsFull": "Edit tags",
     "download": "Download",
     "missing": "Missing",
@@ -244,7 +243,6 @@
     "downloadAllInFolder": "Download all tokens in {{folder}}",
     "downloadInSubfolder": "Download tokens in {{folder}}",
     "editTags": "Edit",
-    "addTags": "Add tags",
     "editTagsFull": "Edit tags",
     "download": "Download",
     "missing": "Missing",
@@ -446,6 +444,7 @@
       "saveSchedule": "Save Schedule",
       "saving": "Saving…",
       "saved": "Saved",
+      "alsoRunCleanup": "Also run Database Cleanup after each rescan",
       "weekdays": {
         "mon": "Mon",
         "tue": "Tue",

--- a/frontend/src/locales/fr-CA.json
+++ b/frontend/src/locales/fr-CA.json
@@ -195,7 +195,6 @@
     "downloadAllInFolder": "Télécharger toutes les cartes de {{folder}}",
     "downloadInSubfolder": "Télécharger les cartes de {{folder}}",
     "editTags": "Modifier",
-    "addTags": "Ajouter des étiquettes",
     "editTagsFull": "Modifier les étiquettes",
     "download": "Télécharger",
     "missing": "Manquant",
@@ -244,7 +243,6 @@
     "downloadAllInFolder": "Télécharger tous les pions de {{folder}}",
     "downloadInSubfolder": "Télécharger les pions de {{folder}}",
     "editTags": "Modifier",
-    "addTags": "Ajouter des étiquettes",
     "editTagsFull": "Modifier les étiquettes",
     "download": "Télécharger",
     "missing": "Manquant",
@@ -446,6 +444,7 @@
       "saveSchedule": "Enregistrer l'horaire",
       "saving": "Enregistrement…",
       "saved": "Enregistré",
+      "alsoRunCleanup": "Effectuer aussi un nettoyage de la base de données après chaque réanalyse",
       "weekdays": {
         "mon": "Lun",
         "tue": "Mar",

--- a/frontend/src/locales/fr-FR.json
+++ b/frontend/src/locales/fr-FR.json
@@ -195,7 +195,6 @@
     "downloadAllInFolder": "Télécharger toutes les cartes de {{folder}}",
     "downloadInSubfolder": "Télécharger les cartes de {{folder}}",
     "editTags": "Modifier",
-    "addTags": "Ajouter des étiquettes",
     "editTagsFull": "Modifier les étiquettes",
     "download": "Télécharger",
     "missing": "Manquant",
@@ -244,7 +243,6 @@
     "downloadAllInFolder": "Télécharger tous les pions de {{folder}}",
     "downloadInSubfolder": "Télécharger les pions de {{folder}}",
     "editTags": "Modifier",
-    "addTags": "Ajouter des étiquettes",
     "editTagsFull": "Modifier les étiquettes",
     "download": "Télécharger",
     "missing": "Manquant",
@@ -446,6 +444,7 @@
       "saveSchedule": "Enregistrer le planning",
       "saving": "Enregistrement…",
       "saved": "Enregistré",
+      "alsoRunCleanup": "Effectuer aussi un nettoyage de la base de données après chaque réanalyse",
       "weekdays": {
         "mon": "Lun",
         "tue": "Mar",

--- a/tests/test_settings_maintenance.py
+++ b/tests/test_settings_maintenance.py
@@ -1,0 +1,323 @@
+"""Tests for settings API and maintenance/cleanup endpoint."""
+import os
+import uuid
+from typing import Optional
+from unittest.mock import patch
+
+import pytest
+
+from tests.conftest import make_book, make_game_system, make_map, make_token
+from backend.config import SessionLocal
+from backend.models import AppSetting
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _set_setting(key: str, value: str) -> None:
+    db = SessionLocal()
+    row = db.query(AppSetting).filter_by(key=key).first()
+    if row:
+        row.value = value
+    else:
+        db.add(AppSetting(key=key, value=value))
+    db.commit()
+    db.close()
+
+
+def _get_setting(key: str) -> Optional[str]:
+    db = SessionLocal()
+    row = db.query(AppSetting).filter_by(key=key).first()
+    db.close()
+    return row.value if row else None
+
+
+# ---------------------------------------------------------------------------
+# GET /api/settings — authentication
+# ---------------------------------------------------------------------------
+
+
+class TestGetSettingsAuth:
+    def test_unauthenticated_rejected(self, client):
+        assert client.get("/api/settings").status_code == 401
+
+    def test_player_forbidden(self, client, player_headers):
+        assert client.get("/api/settings", headers=player_headers).status_code == 403
+
+    def test_gm_forbidden(self, client, gm_headers):
+        assert client.get("/api/settings", headers=gm_headers).status_code == 403
+
+    def test_admin_allowed(self, client, admin_headers):
+        assert client.get("/api/settings", headers=admin_headers).status_code == 200
+
+
+# ---------------------------------------------------------------------------
+# GET /api/settings — response shape
+# ---------------------------------------------------------------------------
+
+
+class TestGetSettingsShape:
+    def test_rescan_schedule_fields_present(self, client, admin_headers):
+        data = client.get("/api/settings", headers=admin_headers).json()
+        assert "rescan_schedule_enabled" in data
+        assert "rescan_schedule_interval" in data
+        assert "rescan_schedule_hour" in data
+        assert "rescan_schedule_minute" in data
+        assert "rescan_schedule_weekday" in data
+
+    def test_cleanup_on_rescan_field_present(self, client, admin_headers):
+        data = client.get("/api/settings", headers=admin_headers).json()
+        assert "cleanup_on_rescan" in data
+
+    def test_cleanup_on_rescan_is_bool(self, client, admin_headers):
+        data = client.get("/api/settings", headers=admin_headers).json()
+        assert isinstance(data["cleanup_on_rescan"], bool)
+
+    def test_cleanup_on_rescan_defaults_false(self, client, admin_headers):
+        data = client.get("/api/settings", headers=admin_headers).json()
+        assert data["cleanup_on_rescan"] is False
+
+
+# ---------------------------------------------------------------------------
+# PATCH /api/settings — cleanup_on_rescan
+# ---------------------------------------------------------------------------
+
+
+class TestPatchCleanupOnRescan:
+    def test_enable_cleanup_on_rescan(self, client, admin_headers):
+        resp = client.patch(
+            "/api/settings",
+            json={"cleanup_on_rescan": True},
+            headers=admin_headers,
+        )
+        assert resp.status_code == 200
+        assert resp.json()["cleanup_on_rescan"] is True
+
+    def test_disable_cleanup_on_rescan(self, client, admin_headers):
+        client.patch(
+            "/api/settings",
+            json={"cleanup_on_rescan": True},
+            headers=admin_headers,
+        )
+        resp = client.patch(
+            "/api/settings",
+            json={"cleanup_on_rescan": False},
+            headers=admin_headers,
+        )
+        assert resp.status_code == 200
+        assert resp.json()["cleanup_on_rescan"] is False
+
+    def test_persisted_to_db(self, client, admin_headers):
+        client.patch(
+            "/api/settings",
+            json={"cleanup_on_rescan": True},
+            headers=admin_headers,
+        )
+        assert _get_setting("cleanup_on_rescan") == "true"
+        client.patch(
+            "/api/settings",
+            json={"cleanup_on_rescan": False},
+            headers=admin_headers,
+        )
+        assert _get_setting("cleanup_on_rescan") == "false"
+
+    def test_other_fields_unaffected(self, client, admin_headers):
+        before = client.get("/api/settings", headers=admin_headers).json()
+        client.patch(
+            "/api/settings",
+            json={"cleanup_on_rescan": True},
+            headers=admin_headers,
+        )
+        after = client.get("/api/settings", headers=admin_headers).json()
+        for key in ("rescan_schedule_interval", "rescan_schedule_hour", "rescan_schedule_minute"):
+            assert before[key] == after[key]
+
+    def test_unauthenticated_rejected(self, client):
+        assert (
+            client.patch("/api/settings", json={"cleanup_on_rescan": True}).status_code == 401
+        )
+
+
+# ---------------------------------------------------------------------------
+# Scheduler applies cleanup_fn when cleanup_on_rescan is enabled
+# ---------------------------------------------------------------------------
+
+
+class TestSchedulerApplyCleanup:
+    def test_cleanup_fn_passed_when_enabled(self, client, admin_headers):
+        with patch("backend.scheduler.start") as mock_start:
+            client.patch(
+                "/api/settings",
+                json={
+                    "rescan_schedule_enabled": True,
+                    "rescan_schedule_interval": "daily",
+                    "cleanup_on_rescan": True,
+                },
+                headers=admin_headers,
+            )
+            assert mock_start.called
+            _, _, cleanup_fn = (
+                mock_start.call_args.args[0],
+                mock_start.call_args.args[4],
+                mock_start.call_args.args[5]
+                if len(mock_start.call_args.args) > 5
+                else mock_start.call_args.kwargs.get("cleanup_fn"),
+            )
+            assert cleanup_fn is not None
+
+    def test_cleanup_fn_none_when_disabled(self, client, admin_headers):
+        with patch("backend.scheduler.start") as mock_start:
+            client.patch(
+                "/api/settings",
+                json={
+                    "rescan_schedule_enabled": True,
+                    "rescan_schedule_interval": "daily",
+                    "cleanup_on_rescan": False,
+                },
+                headers=admin_headers,
+            )
+            assert mock_start.called
+            call_args = mock_start.call_args
+            cleanup_fn = (
+                call_args.args[5]
+                if len(call_args.args) > 5
+                else call_args.kwargs.get("cleanup_fn")
+            )
+            assert cleanup_fn is None
+
+
+# ---------------------------------------------------------------------------
+# POST /api/maintenance/cleanup-missing — authentication
+# ---------------------------------------------------------------------------
+
+
+class TestCleanupMissingAuth:
+    def test_unauthenticated_rejected(self, client):
+        assert client.post("/api/maintenance/cleanup-missing").status_code == 401
+
+    def test_player_forbidden(self, client, player_headers):
+        assert (
+            client.post("/api/maintenance/cleanup-missing", headers=player_headers).status_code
+            == 403
+        )
+
+    def test_gm_forbidden(self, client, gm_headers):
+        assert (
+            client.post("/api/maintenance/cleanup-missing", headers=gm_headers).status_code == 403
+        )
+
+    def test_admin_allowed(self, client, admin_headers):
+        assert (
+            client.post("/api/maintenance/cleanup-missing", headers=admin_headers).status_code
+            == 200
+        )
+
+
+# ---------------------------------------------------------------------------
+# POST /api/maintenance/cleanup-missing — response shape
+# ---------------------------------------------------------------------------
+
+
+class TestCleanupMissingShape:
+    def test_removed_key_present(self, client, admin_headers):
+        data = client.post("/api/maintenance/cleanup-missing", headers=admin_headers).json()
+        assert "removed" in data
+
+    def test_removed_has_books_maps_tokens(self, client, admin_headers):
+        data = client.post("/api/maintenance/cleanup-missing", headers=admin_headers).json()
+        assert "books" in data["removed"]
+        assert "maps" in data["removed"]
+        assert "tokens" in data["removed"]
+
+    def test_removed_counts_are_ints(self, client, admin_headers):
+        data = client.post("/api/maintenance/cleanup-missing", headers=admin_headers).json()
+        assert isinstance(data["removed"]["books"], int)
+        assert isinstance(data["removed"]["maps"], int)
+        assert isinstance(data["removed"]["tokens"], int)
+
+
+# ---------------------------------------------------------------------------
+# POST /api/maintenance/cleanup-missing — removes missing records
+# ---------------------------------------------------------------------------
+
+
+class TestCleanupMissingBehavior:
+    def test_removes_book_with_missing_file(self, client, admin_headers):
+        sys = make_game_system()
+        book = make_book(
+            system_id=sys.id,
+            filepath="/tmp/nonexistent-book-" + uuid.uuid4().hex + ".pdf",
+        )
+        book_id = book.id
+        data = client.post("/api/maintenance/cleanup-missing", headers=admin_headers).json()
+        assert data["removed"]["books"] >= 1
+        resp = client.get(f"/api/books/{book_id}", headers=admin_headers)
+        assert resp.status_code == 404
+
+    def test_keeps_book_with_existing_file(self, client, admin_headers, tmp_path):
+        pdf = tmp_path / "real.pdf"
+        pdf.write_bytes(b"%PDF-1.4")
+        sys = make_game_system()
+        book = make_book(system_id=sys.id, filepath=str(pdf))
+        book_id = book.id
+        client.post("/api/maintenance/cleanup-missing", headers=admin_headers)
+        resp = client.get(f"/api/books/{book_id}", headers=admin_headers)
+        assert resp.status_code == 200
+
+    def test_removes_map_with_missing_file(self, client, admin_headers):
+        m = make_map(filepath="/tmp/nonexistent-map-" + uuid.uuid4().hex + ".png")
+        map_id = m.id
+        data = client.post("/api/maintenance/cleanup-missing", headers=admin_headers).json()
+        assert data["removed"]["maps"] >= 1
+        resp = client.get(f"/api/maps/{map_id}", headers=admin_headers)
+        assert resp.status_code == 404
+
+    def test_removes_token_with_missing_file(self, client, admin_headers):
+        t = make_token(filepath="/tmp/nonexistent-token-" + uuid.uuid4().hex + ".png")
+        token_id = t.id
+        data = client.post("/api/maintenance/cleanup-missing", headers=admin_headers).json()
+        assert data["removed"]["tokens"] >= 1
+        resp = client.get(f"/api/tokens/{token_id}", headers=admin_headers)
+        assert resp.status_code == 404
+
+    def test_nothing_removed_when_all_present(self, client, admin_headers, tmp_path):
+        pdf = tmp_path / "exists.pdf"
+        pdf.write_bytes(b"%PDF-1.4")
+        sys = make_game_system()
+        make_book(system_id=sys.id, filepath=str(pdf))
+        data = client.post("/api/maintenance/cleanup-missing", headers=admin_headers).json()
+        assert data["removed"]["books"] == 0
+        assert data["removed"]["maps"] == 0
+        assert data["removed"]["tokens"] == 0
+
+
+# ---------------------------------------------------------------------------
+# run_cleanup_sync — scheduler callable
+# ---------------------------------------------------------------------------
+
+
+class TestRunCleanupSync:
+    def test_callable_without_http_context(self):
+        from backend.routers.maintenance import run_cleanup_sync
+
+        run_cleanup_sync()  # must not raise
+
+    def test_removes_missing_records(self, tmp_path):
+        from backend.routers.maintenance import run_cleanup_sync
+
+        sys = make_game_system()
+        missing_book = make_book(
+            system_id=sys.id,
+            filepath="/tmp/sync-missing-" + uuid.uuid4().hex + ".pdf",
+        )
+        book_id = missing_book.id
+
+        run_cleanup_sync()
+
+        db = SessionLocal()
+        from backend.models import Book
+
+        assert db.query(Book).filter_by(id=book_id).first() is None
+        db.close()


### PR DESCRIPTION
## Summary

Adds a "Also run Database Cleanup after each rescan" toggle to the Scheduled Rescan settings section. When enabled, the scheduler runs cleanup automatically after each rescan without manual intervention.

## Type of change

- [ ] Bug fix
- [x] New feature
- [ ] Refactor / cleanup
- [ ] Docs / configuration only

## Testing

<!-- How did you verify this works? Check all that apply. -->

- [x] Backend tests pass (`pytest -q`)
- [x] Frontend tests pass (`npm test`)
- [x] Tested manually in the browser