### PR TITLE
Fix: guard cleanup against hung mounts, block during active scan, and cascade bookmark deletion

### DIFF
--- a/.github/workflows/beta.yml
+++ b/.github/workflows/beta.yml
@@ -3,7 +3,6 @@ name: Beta
 on:
   workflow_run:
     workflows: ["CI"]
-    branches: ["release/v*"]
     types: [completed]
 
 env:
@@ -13,7 +12,9 @@ jobs:
   beta:
     name: Build and push beta
     runs-on: ubuntu-latest
-    if: ${{ github.event.workflow_run.conclusion == 'success' }}
+    if: |
+      github.event.workflow_run.conclusion == 'success' &&
+      startsWith(github.event.workflow_run.head_branch, 'release/v')
 
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,6 +2,9 @@ name: CI
 
 on:
   push:
+    branches:
+      - main
+      - "release/v*"
   pull_request:
 
 jobs:

--- a/backend/routers/maintenance.py
+++ b/backend/routers/maintenance.py
@@ -1,8 +1,9 @@
 """Maintenance router — admin-only housekeeping tasks."""
 
 import os
+import threading
 
-from fastapi import APIRouter, Depends
+from fastapi import APIRouter, Depends, HTTPException
 from sqlalchemy import text
 
 from ..config import SessionLocal, logger
@@ -11,40 +12,97 @@ from ..models import Book, Bookmark, GenericMap, Token
 
 router = APIRouter(prefix="/maintenance", tags=["maintenance"])
 
+_FS_TIMEOUT = 5  # seconds before an os.path.exists() call is treated as hung
+
+
+def _path_exists(filepath: str) -> bool:
+    """Return whether filepath exists, with a timeout guard against hung mounts."""
+    result = [None]
+
+    def _check():
+        try:
+            result[0] = os.path.exists(filepath)
+        except Exception:
+            result[0] = False
+
+    t = threading.Thread(target=_check, daemon=True)
+    t.start()
+    t.join(_FS_TIMEOUT)
+    if t.is_alive():
+        # Thread is stuck — treat the path as present to avoid false deletion
+        logger.warning(f"Cleanup: filesystem check timed out for '{filepath}' — skipping")
+        return True
+    return result[0]
+
 
 def _do_cleanup(db) -> dict:
-    """Delete DB records whose files no longer exist on disk. Caller commits."""
+    """Delete DB records whose files no longer exist on disk.
+
+    Commits after each deleted record so the write lock is released between
+    rows and doesn't block concurrent scanner sessions.
+    """
     removed = {"books": 0, "maps": 0, "tokens": 0}
 
-    for book in db.query(Book).all():
-        if not os.path.exists(book.filepath):
+    books = db.query(Book).all()
+    logger.debug(f"Cleanup: checking {len(books)} book(s)")
+    for book in books:
+        logger.debug(f"Cleanup: checking book '{book.title}' ({book.filepath})")
+        if not _path_exists(book.filepath):
             logger.info(f"Cleanup: removing missing book '{book.title}' ({book.filepath})")
+            logger.debug(f"Cleanup: deleting FTS index for book id={book.id}")
             db.execute(text("DELETE FROM book_search WHERE book_id = :id"), {"id": book.id})
+            bookmark_count = db.query(Bookmark).filter_by(book_id=book.id).count()
+            logger.debug(f"Cleanup: deleting {bookmark_count} bookmark(s) for book id={book.id}")
             db.query(Bookmark).filter_by(book_id=book.id).delete()
             db.delete(book)
+            db.commit()
+            logger.debug(f"Cleanup: committed removal of book id={book.id}")
             removed["books"] += 1
+        else:
+            logger.debug(f"Cleanup: book '{book.title}' present — skipping")
 
-    for m in db.query(GenericMap).all():
-        if not os.path.exists(m.filepath):
+    maps = db.query(GenericMap).all()
+    logger.debug(f"Cleanup: checking {len(maps)} map(s)")
+    for m in maps:
+        logger.debug(f"Cleanup: checking map '{m.filename}' ({m.filepath})")
+        if not _path_exists(m.filepath):
             logger.info(f"Cleanup: removing missing map '{m.filename}' ({m.filepath})")
             db.delete(m)
+            db.commit()
+            logger.debug(f"Cleanup: committed removal of map id={m.id}")
             removed["maps"] += 1
+        else:
+            logger.debug(f"Cleanup: map '{m.filename}' present — skipping")
 
-    for t in db.query(Token).all():
-        if not os.path.exists(t.filepath):
+    tokens = db.query(Token).all()
+    logger.debug(f"Cleanup: checking {len(tokens)} token(s)")
+    for t in tokens:
+        logger.debug(f"Cleanup: checking token '{t.filename}' ({t.filepath})")
+        if not _path_exists(t.filepath):
             logger.info(f"Cleanup: removing missing token '{t.filename}' ({t.filepath})")
             db.delete(t)
+            db.commit()
+            logger.debug(f"Cleanup: committed removal of token id={t.id}")
             removed["tokens"] += 1
+        else:
+            logger.debug(f"Cleanup: token '{t.filename}' present — skipping")
 
     return removed
 
 
 @router.post("/cleanup-missing", summary="Remove DB entries for missing files")
 def cleanup_missing(_: CurrentUser = Depends(require_admin)):
+    from .library import _helpers as _lib
+
+    logger.debug("Cleanup: manual trigger received")
+    if _lib._get_status()["running"]:
+        logger.debug("Cleanup: blocked — library scan is currently running")
+        raise HTTPException(status_code=409, detail="A library scan is already running; retry after it completes.")
+
+    logger.debug("Cleanup: no scan running, proceeding")
     db = SessionLocal()
     try:
         removed = _do_cleanup(db)
-        db.commit()
         logger.info(f"Cleanup complete: {removed}")
         return {"removed": removed}
     except Exception:
@@ -56,10 +114,10 @@ def cleanup_missing(_: CurrentUser = Depends(require_admin)):
 
 def run_cleanup_sync() -> None:
     """Synchronous wrapper used by the scheduler."""
+    logger.debug("Cleanup: scheduled run starting")
     db = SessionLocal()
     try:
         removed = _do_cleanup(db)
-        db.commit()
         logger.info(f"Cleanup complete: {removed}")
     except Exception:
         db.rollback()

--- a/tests/test_settings_maintenance.py
+++ b/tests/test_settings_maintenance.py
@@ -8,7 +8,7 @@ import pytest
 
 from tests.conftest import make_book, make_game_system, make_map, make_token
 from backend.config import SessionLocal
-from backend.models import AppSetting
+from backend.models import AppSetting, Bookmark
 
 
 # ---------------------------------------------------------------------------
@@ -291,6 +291,41 @@ class TestCleanupMissingBehavior:
         assert data["removed"]["books"] == 0
         assert data["removed"]["maps"] == 0
         assert data["removed"]["tokens"] == 0
+
+    def test_removes_bookmarks_with_missing_book(self, client, admin_headers, admin_id):
+        sys = make_game_system()
+        book = make_book(
+            system_id=sys.id,
+            filepath="/tmp/nonexistent-bm-book-" + uuid.uuid4().hex + ".pdf",
+        )
+        db = SessionLocal()
+        bm = Bookmark(user_id=admin_id, book_id=book.id, page_number=1, label="test")
+        db.add(bm)
+        db.commit()
+        bm_id = bm.id
+        db.close()
+
+        client.post("/api/maintenance/cleanup-missing", headers=admin_headers)
+
+        db = SessionLocal()
+        assert db.query(Bookmark).filter_by(id=bm_id).first() is None
+        db.close()
+
+    def test_returns_409_when_scan_running(self, client, admin_headers):
+        with patch(
+            "backend.routers.library._helpers._get_status",
+            return_value={"running": True},
+        ):
+            resp = client.post("/api/maintenance/cleanup-missing", headers=admin_headers)
+        assert resp.status_code == 409
+
+    def test_proceeds_when_scan_not_running(self, client, admin_headers):
+        with patch(
+            "backend.routers.library._helpers._get_status",
+            return_value={"running": False},
+        ):
+            resp = client.post("/api/maintenance/cleanup-missing", headers=admin_headers)
+        assert resp.status_code == 200
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / cleanup
- [ ] Docs / configuration only

## Testing

<!-- How did you verify this works? Check all that apply. -->

- [x] Backend tests pass (`pytest -q`)
- [x] Frontend tests pass (`npm test`)
- [x] Tested manually in the browser

## Notes for reviewer

<!-- Anything that needs extra context, known limitations, or follow-up work. Delete if not needed. -->
