### PR TITLE
feat(dhi): add docker hardened image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -7,7 +7,7 @@ COPY frontend/ ./
 RUN npm run build
 
 # Stage 2: Python app
-FROM python:3.12-slim
+FROM python:3.12-slim AS backend-builder
 
 RUN apt-get update && apt-get install -y --no-install-recommends \
     libmupdf-dev \
@@ -17,10 +17,24 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
     && rm -rf /var/lib/apt/lists/*
 
 WORKDIR /app
-
 COPY backend/requirements.txt .
-RUN pip install --no-cache-dir -r requirements.txt
 
+# Install into a relocatable prefix so we can copy it into the final image
+RUN pip install --no-cache-dir --prefix=/install -r requirements.txt
+
+# Stage 3: Runtime (hardened)
+FROM dhi.io/python:3.12
+
+WORKDIR /app
+
+# Python deps
+COPY --from=backend-builder /install /usr/local
+
+# MuPDF runtime bits
+COPY --from=backend-builder /usr/bin/mutool /usr/bin/mutool
+COPY --from=backend-builder /usr/bin/mupdf* /usr/bin/
+
+# App code + built frontend
 COPY backend/ ./backend/
 COPY --from=frontend-builder /app/frontend/dist ./frontend/dist
 


### PR DESCRIPTION
## Summary

Swaps the base image to Docker Hardened. In the process, it removes 1,245 vulns.

<img width="1092" height="189" alt="image" src="https://github.com/user-attachments/assets/d1e2c9df-e7d8-4f6d-94c3-cb1bb8472e68" />


## Type of change

- [ ] Bug fix
- [ ] New feature
- [x] Refactor / cleanup
- [ ] Docs / configuration only

## Testing

- [ ] Backend tests pass (`pytest -q`)
- [ ] Frontend tests pass (`npm test`)
- [ ] Tested manually in the browser

Launched the container.

## Notes for reviewer

Note: because of the reduced startup time, there is now a concurrency issue with 2 workers connecting to the same sqlite DB. This can be resolved by changing the workers to 1, by using threading instead of processes, or by swapping to a DB which is intended to support multiple remote workers at once (such as postgres).
