### PR TITLE
Fix: image files within books are now viewable

### DIFF
--- a/backend/indexer.py
+++ b/backend/indexer.py
@@ -362,6 +362,8 @@ def scan_library(library_path: str, data_path: str, session: Session, on_progres
                             continue
                         needs_thumbnail = not existing.has_thumbnail
                         needs_page_count = ext == ".pdf" and existing.page_count == 0 and not existing.index_error
+                        if ext in IMAGE_EXTS and existing.page_count == 0:
+                            existing.page_count = 1
                         if not needs_thumbnail and not needs_page_count:
                             logger.debug(f"Already registered, skipping: {filename}")
                             continue
@@ -408,6 +410,8 @@ def scan_library(library_path: str, data_path: str, session: Session, on_progres
                             continue
                         needs_thumbnail = True
                         needs_page_count = ext == ".pdf"
+                        if ext in IMAGE_EXTS:
+                            book.page_count = 1
 
                     thumb_path = os.path.join(
                         thumb_dir,

--- a/backend/routers/books/pages.py
+++ b/backend/routers/books/pages.py
@@ -2,6 +2,7 @@
 import hashlib
 import io
 import os
+from pathlib import Path
 
 from fastapi import HTTPException, Query
 from fastapi.responses import FileResponse, StreamingResponse
@@ -52,9 +53,29 @@ def get_book_toc(book_id: str):
 
 def serve_book_page(book_id: str, page_num: int, width: int = Query(1200, le=3000)):
     book_info = _cached_book_info(book_id)
-    if not book_info or book_info[1] != "application/pdf":
+    if not book_info:
         raise HTTPException(404)
-    filepath = book_info[0]
+    filepath, mime_type = book_info[0], book_info[1]
+
+    if mime_type.startswith("image/"):
+        if page_num != 1:
+            raise HTTPException(400, "Image files have only one page")
+        if not os.path.exists(filepath):
+            db = SessionLocal()
+            try:
+                book = db.query(Book).filter_by(id=book_id).first()
+                if book and not book.is_missing:
+                    book.is_missing = True
+                    db.commit()
+            finally:
+                db.close()
+            raise HTTPException(404, "File not found on disk")
+        ext = Path(filepath).suffix.lower().lstrip(".")
+        media_type = f"image/{ext}" if ext not in ("jpg",) else "image/jpeg"
+        return FileResponse(filepath, media_type=media_type, headers=_PAGE_CACHE_HEADERS)
+
+    if mime_type != "application/pdf":
+        raise HTTPException(404)
 
     valkey_key = f"page:{book_id}:{page_num}:{width}"
 
@@ -121,7 +142,7 @@ def serve_book_page(book_id: str, page_num: int, width: int = Query(1200, le=300
 
 def get_page_text(book_id: str, page_num: int):
     book_info = _cached_book_info(book_id)
-    if not book_info or book_info[1] != "application/pdf":
+    if not book_info or not book_info[1].startswith("application/"):
         raise HTTPException(404)
 
     db = SessionLocal()
@@ -148,7 +169,7 @@ def get_page_text(book_id: str, page_num: int):
 
 def get_page_words(book_id: str, page_num: int):
     book_info = _cached_book_info(book_id)
-    if not book_info or book_info[1] != "application/pdf":
+    if not book_info or not book_info[1].startswith("application/"):
         return {"width": 0, "height": 0, "words": []}
 
     filepath = book_info[0]

--- a/backend/tests/test_books.py
+++ b/backend/tests/test_books.py
@@ -3,6 +3,8 @@
 PDF rendering and page endpoints are not tested here since they require
 actual PDF files on disk. Those are better suited for integration tests.
 """
+import os
+import tempfile
 import pytest
 from backend.tests.conftest import make_game_system, make_book
 
@@ -150,4 +152,86 @@ class TestUpdateBook:
             },
             headers=admin_headers,
         )
+        assert resp.status_code == 404
+
+
+class TestImageBookPage:
+    IMAGE_TYPES = [
+        ("png", "image/png", b"\x89PNG\r\n\x1a\n" + b"\x00" * 8),
+        ("jpg", "image/jpeg", b"\xff\xd8\xff\xe0" + b"\x00" * 12),
+        ("jpeg", "image/jpeg", b"\xff\xd8\xff\xe0" + b"\x00" * 12),
+        ("webp", "image/webp", b"RIFF\x00\x00\x00\x00WEBP"),
+        ("gif", "image/gif", b"GIF89a" + b"\x00" * 10),
+        ("bmp", "image/bmp", b"BM" + b"\x00" * 10),
+    ]
+
+    def _make_image_book(self, system_id, ext, mime_type, content):
+        with tempfile.NamedTemporaryFile(suffix=f".{ext}", delete=False) as f:
+            f.write(content)
+            fpath = f.name
+        book = make_book(
+            system_id=system_id,
+            title=f"Image Book ({ext})",
+            filename=f"image.{ext}",
+            filepath=fpath,
+            mime_type=mime_type,
+            page_count=1,
+        )
+        return book, fpath
+
+    @pytest.fixture(scope="module")
+    def sys(self):
+        return make_game_system()
+
+    def test_image_book_page1_returns_file(self, client, admin_headers, sys):
+        ext, mime_type, content = self.IMAGE_TYPES[0]
+        book, fpath = self._make_image_book(sys.id, ext, mime_type, content)
+        try:
+            resp = client.get(f"/api/books/{book.id}/page/1", headers=admin_headers)
+            assert resp.status_code == 200
+            assert resp.headers["content-type"].startswith("image/")
+        finally:
+            os.unlink(fpath)
+
+    def test_image_book_page_beyond_1_is_400(self, client, admin_headers, sys):
+        ext, mime_type, content = self.IMAGE_TYPES[0]
+        book, fpath = self._make_image_book(sys.id, ext, mime_type, content)
+        try:
+            resp = client.get(f"/api/books/{book.id}/page/2", headers=admin_headers)
+            assert resp.status_code == 400
+        finally:
+            os.unlink(fpath)
+
+    def test_all_image_mime_types_served(self, client, admin_headers, sys):
+        for ext, mime_type, content in self.IMAGE_TYPES:
+            book, fpath = self._make_image_book(sys.id, ext, mime_type, content)
+            try:
+                resp = client.get(f"/api/books/{book.id}/page/1", headers=admin_headers)
+                assert resp.status_code == 200, f"Failed for {ext}: {resp.status_code}"
+                assert resp.headers["content-type"].startswith("image/"), f"Wrong content-type for {ext}"
+            finally:
+                os.unlink(fpath)
+
+    def test_image_book_missing_file_returns_404(self, client, admin_headers, sys):
+        book = make_book(
+            system_id=sys.id,
+            title="Missing Image Book",
+            filename="missing.png",
+            filepath="/nonexistent/path/missing.png",
+            mime_type="image/png",
+            page_count=1,
+        )
+        resp = client.get(f"/api/books/{book.id}/page/1", headers=admin_headers)
+        assert resp.status_code == 404
+
+    def test_pdf_book_page_still_404_without_file(self, client, admin_headers, sys):
+        book = make_book(
+            system_id=sys.id,
+            title="Missing PDF",
+            filename="missing.pdf",
+            filepath="/nonexistent/path/missing.pdf",
+            mime_type="application/pdf",
+            page_count=10,
+        )
+        resp = client.get(f"/api/books/{book.id}/page/1", headers=admin_headers)
         assert resp.status_code == 404

--- a/frontend/src/views/ReaderView.jsx
+++ b/frontend/src/views/ReaderView.jsx
@@ -315,6 +315,10 @@ export default function ReaderView() {
       </div>
     )
 
+  if (book.mime_type?.startsWith('image/')) {
+    return <ImageBookViewer book={book} bookId={bookId} />
+  }
+
   const rightPage = currentPage + 1
   const hasRight = currentPage !== 1 && rightPage <= totalPages
 
@@ -911,6 +915,114 @@ function SinglePage({
           }}
         />
       )}
+    </div>
+  )
+}
+
+function ImageBookViewer({ book, bookId }) {
+  const { t } = useTranslation()
+  const navigate = useNavigate()
+  const { isFavorite, toggleFavorite } = useFavorites()
+
+  return (
+    <div className="fade-in" style={{ display: 'flex', flexDirection: 'column', height: '100%' }}>
+      <div
+        style={{
+          display: 'flex',
+          alignItems: 'center',
+          gap: 12,
+          padding: '10px 20px',
+          background: 'var(--bg-panel)',
+          borderBottom: '1px solid var(--border)',
+          flexWrap: 'wrap',
+        }}
+      >
+        <button
+          onClick={() => navigate(-1)}
+          aria-label={t('reader.back')}
+          style={{
+            background: 'none',
+            color: 'var(--text-dim)',
+            fontSize: 15,
+            display: 'flex',
+            alignItems: 'center',
+            gap: 5,
+            border: 'none',
+            cursor: 'pointer',
+          }}
+        >
+          <LuArrowLeft size={15} /> {t('reader.back')}
+        </button>
+        <div style={{ width: 1, height: 20, background: 'var(--border)' }} />
+        <span
+          style={{
+            fontSize: 16,
+            fontWeight: 500,
+            color: 'var(--text)',
+            flex: 1,
+            overflow: 'hidden',
+            textOverflow: 'ellipsis',
+            whiteSpace: 'nowrap',
+          }}
+        >
+          {book.title}
+        </span>
+        <button
+          onClick={() => toggleFavorite('book', bookId)}
+          title={
+            isFavorite('book', bookId) ? t('reader.removeFromFavorites') : t('reader.addToFavorites')
+          }
+          style={{
+            ...btnStyle,
+            color: isFavorite('book', bookId) ? 'var(--gold)' : 'var(--text-muted)',
+          }}
+        >
+          <LuHeart size={14} fill={isFavorite('book', bookId) ? 'var(--gold)' : 'none'} />
+        </button>
+        <AddToCampaignButton resourceType="book" resourceId={bookId} />
+        <a
+          href={mediaUrl(`/books/${bookId}/file`)}
+          download
+          title={t('reader.downloadFile')}
+          style={{
+            background: 'var(--bg-card)',
+            border: '1px solid var(--border)',
+            color: 'var(--text-dim)',
+            borderRadius: 4,
+            padding: '4px 12px',
+            fontSize: 14,
+            display: 'inline-flex',
+            alignItems: 'center',
+            gap: 5,
+          }}
+        >
+          <LuDownload size={13} />
+        </a>
+      </div>
+      <div
+        style={{
+          flex: 1,
+          minHeight: 0,
+          overflow: 'auto',
+          display: 'flex',
+          alignItems: 'center',
+          justifyContent: 'center',
+          background: 'var(--bg-deep)',
+          padding: 20,
+        }}
+      >
+        <img
+          src={mediaUrl(`/books/${bookId}/file`)}
+          alt={book.title}
+          style={{
+            maxHeight: '100%',
+            maxWidth: '100%',
+            width: 'auto',
+            borderRadius: 4,
+            boxShadow: '0 4px 20px rgba(0,0,0,0.4)',
+          }}
+        />
+      </div>
     </div>
   )
 }


### PR DESCRIPTION
## Summary

Enables images in books directory

## Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / cleanup
- [ ] Docs / configuration only

## Testing

- [x] Backend tests pass (`pytest -q`)
- [x] Frontend tests pass (`npm test`)
- [x] Tested manually in the browser