### PR TITLE
Fix: image-only PDFs no longer marked as index failed

### DIFF
--- a/backend/indexer.py
+++ b/backend/indexer.py
@@ -800,16 +800,17 @@ def index_book_text(book: Book, data_path: str, session: Session, should_stop=No
     logger.info(f"Indexing: extracting text from '{book.filepath}'")
     pages = extract_text_from_pdf(book.filepath, should_stop=should_stop)
     if not pages:
-        logger.warning(f"No text extracted from '{book.filename}', marking as failed")
-        book.index_error = "No text extracted"
-        book.index_failed = True
-        logger.debug(f"DB: committing index_failed for '{book.filename}'")
+        logger.info(f"No text extracted from '{book.filename}' — image-only PDF, marking as indexed")
+        book.index_error = "image-only"
+        book.indexed = True
+        book.index_failed = False
+        logger.debug(f"DB: committing image-only indexed for '{book.filename}'")
         try:
-            _run_with_timeout(session.commit, _DB_TIMEOUT, f"commit index_failed '{book.filepath}'")
+            _run_with_timeout(session.commit, _DB_TIMEOUT, f"commit image-only indexed '{book.filepath}'")
         except TimeoutError as e:
-            logger.error(f"DB hang: {e} — rolling back index_failed for '{book.filename}'")
+            logger.error(f"DB hang: {e} — rolling back image-only indexed for '{book.filename}'")
             session.rollback()
-        return False
+        return True
 
     logger.info(f"Indexing: inserting {len(pages)} pages for '{book.filename}' into search index")
     for page_data in pages:

--- a/backend/tests/test_indexer_resilience.py
+++ b/backend/tests/test_indexer_resilience.py
@@ -124,8 +124,8 @@ class TestIndexBookTextIndexFailed:
 
         assert result is False
 
-    def test_sets_index_failed_when_no_text_extracted(self):
-        """When extract_text_from_pdf returns empty, book is marked index_failed (not indexed)."""
+    def test_image_only_pdf_marked_indexed(self):
+        """When extract_text_from_pdf returns empty, image-only PDF is marked indexed=True with index_error='image-only'."""
         uid = str(uuid.uuid4())[:8]
         db = SessionLocal()
         try:
@@ -146,10 +146,10 @@ class TestIndexBookTextIndexFailed:
                 result = index_book_text(book, "/tmp", db)
 
             db.refresh(book)
-            assert result is False
-            assert book.indexed is False
-            assert book.index_failed is True
-            assert "No text extracted" in book.index_error
+            assert result is True
+            assert book.indexed is True
+            assert book.index_failed is False
+            assert book.index_error == "image-only"
         finally:
             db.close()
 

--- a/frontend/src/components/system/BookRow.jsx
+++ b/frontend/src/components/system/BookRow.jsx
@@ -148,7 +148,7 @@ export default function BookRow({ book, onOpen, onEdit, editing }) {
             </span>
           ) : (
             <>
-              {book.indexed && (
+              {book.indexed && book.index_error !== 'image-only' && (
                 <span
                   title={t('bookRow.indexedTitle')}
                   style={{
@@ -160,6 +160,21 @@ export default function BookRow({ book, onOpen, onEdit, editing }) {
                   }}
                 >
                   {t('bookRow.indexed')}
+                </span>
+              )}
+              {book.indexed && book.index_error === 'image-only' && (
+                <span
+                  title={t('bookRow.imageOnlyTitle')}
+                  style={{
+                    fontSize: 11,
+                    color: 'var(--muted, #888)',
+                    background: 'rgba(128,128,128,0.1)',
+                    padding: '1px 6px',
+                    borderRadius: 8,
+                    border: '1px solid rgba(128,128,128,0.25)',
+                  }}
+                >
+                  {t('bookRow.imageOnly')}
                 </span>
               )}
               {book.index_failed && (

--- a/frontend/src/components/system/BookRow.test.jsx
+++ b/frontend/src/components/system/BookRow.test.jsx
@@ -65,6 +65,29 @@ describe('BookRow', () => {
     expect(screen.queryByText('Indexed')).not.toBeInTheDocument()
   })
 
+  it('does not show "Indexed" badge for image-only PDFs', () => {
+    render(<BookRow book={makeBook({ indexed: true, index_error: 'image-only' })} onOpen={() => {}} />)
+    expect(screen.queryByText('Indexed')).not.toBeInTheDocument()
+  })
+
+  // --- image-only badge ---
+
+  it('shows "Image Only" badge when indexed and index_error is image-only', () => {
+    render(<BookRow book={makeBook({ indexed: true, index_error: 'image-only' })} onOpen={() => {}} />)
+    expect(screen.getByText('Image Only')).toBeInTheDocument()
+  })
+
+  it('does not show "Image Only" badge for normally indexed books', () => {
+    render(<BookRow book={makeBook({ indexed: true, index_error: '' })} onOpen={() => {}} />)
+    expect(screen.queryByText('Image Only')).not.toBeInTheDocument()
+  })
+
+  it('"Image Only" badge has the correct tooltip', () => {
+    render(<BookRow book={makeBook({ indexed: true, index_error: 'image-only' })} onOpen={() => {}} />)
+    const badge = screen.getByText('Image Only')
+    expect(badge.title).toBe('This PDF contains only scanned images — no text layer to search')
+  })
+
   // --- index_failed badge ---
 
   it('shows "Index Failed" badge when index_failed is true', () => {

--- a/frontend/src/locales/de-DE.json
+++ b/frontend/src/locales/de-DE.json
@@ -828,6 +828,8 @@
     "editBook": "Metadaten bearbeiten",
     "indexed": "Indiziert",
     "indexedTitle": "Volltext indiziert",
+    "imageOnly": null,
+    "imageOnlyTitle": null,
     "indexFailed": "Indizierung fehlgeschlagen",
     "indexFailedTitle": "Indizierung fehlgeschlagen",
     "indexFailedWithError": "Indizierung fehlgeschlagen: {{error}}",

--- a/frontend/src/locales/en-US.json
+++ b/frontend/src/locales/en-US.json
@@ -894,6 +894,8 @@
     "editBook": "Edit metadata",
     "indexed": "Indexed",
     "indexedTitle": "Full-text indexed",
+    "imageOnly": "Image Only",
+    "imageOnlyTitle": "This PDF contains only scanned images — no text layer to search",
     "indexFailed": "Index Failed",
     "indexFailedTitle": "Index failed",
     "indexFailedWithError": "Index failed: {{error}}",

--- a/frontend/src/locales/fr-CA.json
+++ b/frontend/src/locales/fr-CA.json
@@ -894,6 +894,8 @@
     "editBook": "Modifier les métadonnées",
     "indexed": "Indexé",
     "indexedTitle": "Indexé en texte intégral",
+    "imageOnly": "Images uniquement",
+    "imageOnlyTitle": "Ce PDF ne contient que des images numérisées — aucune couche de texte consultable",
     "indexFailed": "Échec d'indexation",
     "indexFailedTitle": "Échec de l'indexation",
     "indexFailedWithError": "Échec de l'indexation : {{error}}",

--- a/frontend/src/locales/fr-FR.json
+++ b/frontend/src/locales/fr-FR.json
@@ -894,6 +894,8 @@
     "editBook": "Modifier les métadonnées",
     "indexed": "Indexé",
     "indexedTitle": "Indexé en texte intégral",
+    "imageOnly": "Images uniquement",
+    "imageOnlyTitle": "Ce PDF ne contient que des images numérisées — aucune couche de texte consultable",
     "indexFailed": "Échec d'indexation",
     "indexFailedTitle": "Échec de l'indexation",
     "indexFailedWithError": "Échec de l'indexation : {{error}}",


### PR DESCRIPTION
## Summary

PDFs with no embedded text layer (scanned image-only files) were being marked as `index_failed` with "No text extracted", showing a red "Index Failed" badge in the UI despite being perfectly valid files.

These are now marked `indexed=True` with `index_error="image-only"`. The UI shows a neutral grey "Image Only" badge with a tooltip explaining there is no text layer to search, and suppresses the green "Indexed" badge for these books.

## Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / cleanup
- [ ] Docs / configuration only

## Testing

<!-- How did you verify this works? Check all that apply. -->

- [x] Backend tests pass (`pytest -q`)
- [x] Frontend tests pass (`npm test`)
- [x] Tested manually in the browser

