### PR TITLE
Fix: request configured groups and permissions claim names as OIDC scopes

### DIFF
--- a/backend/routers/oidc/core.py
+++ b/backend/routers/oidc/core.py
@@ -98,9 +98,13 @@ def oidc_login(return_to: Optional[str] = Query(None)):
 
     scopes = ["openid", "email", "profile"]
     if eff["oidc_groups_claim"]:
-        # Some IdPs (Keycloak, Authentik) expose groups via a dedicated scope;
-        # asking for it is harmless if unsupported.
+        # Request both the generic "groups" scope and the configured claim name
+        # as a scope — IdPs like Authentik map claims to scopes by name.
         scopes.append("groups")
+        if eff["oidc_groups_claim"] not in scopes:
+            scopes.append(eff["oidc_groups_claim"])
+    if eff["oidc_permissions_claim"] and eff["oidc_permissions_claim"] not in scopes:
+        scopes.append(eff["oidc_permissions_claim"])
 
     params = {
         "response_type": "code",


### PR DESCRIPTION
## Summary

IdPs like Authentik map claims to scopes by name, so requesting only the generic "groups" scope would omit custom claims like "grimoire-groups". Now the configured groups and permissions claim names are also requested as scopes at authorization time.

## Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / cleanup
- [ ] Docs / configuration only

## Testing

<!-- How did you verify this works? Check all that apply. -->

- [x] Backend tests pass (`pytest -q`)
- [x] Frontend tests pass (`npm test`)
- [x] Tested manually in the browser

