### PR TITLE
Fix: back button exits reader in one click and restore search state on back navigation

### DIFF
--- a/frontend/src/components/campaigns/ResourcesPanel.jsx
+++ b/frontend/src/components/campaigns/ResourcesPanel.jsx
@@ -42,7 +42,9 @@ function ResourceRow({ resource, isOwner, isGmCampaign, onRemove, onToggleShare 
     : null
 
   const handleNav = () =>
-    navigate(RESOURCE_NAV[resource.resource_type]?.(resource.resource_id) ?? '/')
+    navigate(RESOURCE_NAV[resource.resource_type]?.(resource.resource_id) ?? '/', {
+      state: { from: window.location.pathname },
+    })
 
   return (
     <div

--- a/frontend/src/views/FavoritesView.jsx
+++ b/frontend/src/views/FavoritesView.jsx
@@ -12,7 +12,7 @@ function BookFavorite({ item }) {
   const CatIcon = CATEGORY_ICONS[item.category] || LuFileText
   return (
     <div
-      onClick={() => navigate(`/library/book/${item.item_id}`)}
+      onClick={() => navigate(`/library/book/${item.item_id}`, { state: { from: window.location.pathname } })}
       style={{
         display: 'flex',
         alignItems: 'center',

--- a/frontend/src/views/LibraryView.jsx
+++ b/frontend/src/views/LibraryView.jsx
@@ -262,7 +262,7 @@ export default function LibraryView() {
               return (
                 <div
                   key={book.id}
-                  onClick={() => navigate(`/library/book/${book.id}?page=${lastPage}`)}
+                  onClick={() => navigate(`/library/book/${book.id}?page=${lastPage}`, { state: { from: window.location.pathname } })}
                   style={{
                     display: 'flex',
                     alignItems: 'center',

--- a/frontend/src/views/ReaderView.jsx
+++ b/frontend/src/views/ReaderView.jsx
@@ -1,5 +1,5 @@
 import { useState, useEffect, useCallback, useRef } from 'react'
-import { useParams, useNavigate, useSearchParams } from 'react-router-dom'
+import { useParams, useNavigate, useSearchParams, useLocation } from 'react-router-dom'
 import { useTranslation } from 'react-i18next'
 import {
   LuArrowLeft,
@@ -51,7 +51,11 @@ export default function ReaderView() {
   const { t } = useTranslation()
   const { bookId } = useParams()
   const navigate = useNavigate()
+  const location = useLocation()
   const [searchParams, setSearchParams] = useSearchParams()
+  // Capture the referring path on mount so the back button always exits the reader in one click,
+  // regardless of how many jump-navigation history entries were pushed (ToC, bookmarks, search).
+  const backPathRef = useRef(location.state?.from ?? null)
 
   const MODES = [
     { key: 'page', Icon: LuFileText, label: t('reader.page') },
@@ -316,7 +320,7 @@ export default function ReaderView() {
     )
 
   if (book.mime_type?.startsWith('image/')) {
-    return <ImageBookViewer book={book} bookId={bookId} />
+    return <ImageBookViewer book={book} bookId={bookId} backPath={backPathRef.current} />
   }
 
   const rightPage = currentPage + 1
@@ -342,7 +346,7 @@ export default function ReaderView() {
         }}
       >
         <button
-          onClick={() => navigate(-1)}
+          onClick={() => (backPathRef.current ? navigate(backPathRef.current) : navigate(-1))}
           aria-label={t('reader.back')}
           style={{
             background: 'none',
@@ -920,7 +924,7 @@ function SinglePage({
   )
 }
 
-function ImageBookViewer({ book, bookId }) {
+function ImageBookViewer({ book, bookId, backPath }) {
   const { t } = useTranslation()
   const navigate = useNavigate()
   const { isFavorite, toggleFavorite } = useFavorites()
@@ -939,7 +943,7 @@ function ImageBookViewer({ book, bookId }) {
         }}
       >
         <button
-          onClick={() => navigate(-1)}
+          onClick={() => (backPath ? navigate(backPath) : navigate(-1))}
           aria-label={t('reader.back')}
           style={{
             background: 'none',

--- a/frontend/src/views/ReaderView.test.jsx
+++ b/frontend/src/views/ReaderView.test.jsx
@@ -24,13 +24,15 @@ vi.mock('../components/campaigns/AddToCampaignButton', () => ({
   default: () => null,
 }))
 
-// Capture setSearchParams calls so we can assert replace vs push behaviour.
+// Capture setSearchParams and navigate calls so we can assert behaviour.
 const mockSetSearchParams = vi.fn()
+const mockNavigate = vi.fn()
 vi.mock('react-router-dom', async (importOriginal) => {
   const actual = await importOriginal()
   return {
     ...actual,
     useSearchParams: () => [new URLSearchParams(), mockSetSearchParams],
+    useNavigate: () => mockNavigate,
   }
 })
 
@@ -66,9 +68,12 @@ function setupApiMocks() {
   })
 }
 
-function renderReader(bookId = 'book-1') {
+function renderReader(bookId = 'book-1', { locationState } = {}) {
+  const entry = locationState
+    ? { pathname: `/library/book/${bookId}`, state: locationState }
+    : `/library/book/${bookId}`
   return render(
-    <MemoryRouter initialEntries={[`/library/book/${bookId}`]}>
+    <MemoryRouter initialEntries={[entry]}>
       <Routes>
         <Route path="/library/book/:bookId" element={<ReaderView key={bookId} />} />
       </Routes>
@@ -189,5 +194,33 @@ describe('ReaderView — jump navigation history behaviour', () => {
     await userEvent.click(screen.getByLabelText('Next page'))
     await waitFor(() => expect(mockSetSearchParams).toHaveBeenCalled())
     expect(lastReplaceOption()).toBe(true)
+  })
+})
+
+describe('ReaderView — back button navigation', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    setupApiMocks()
+    vi.stubGlobal('requestAnimationFrame', (cb) => { cb(); return 0 })
+    vi.stubGlobal('cancelAnimationFrame', () => {})
+  })
+
+  it('navigates to location.state.from when present', async () => {
+    renderReader('book-1', { locationState: { from: '/library/system/system-1' } })
+    await waitFor(() => screen.getByText('Test Book'))
+
+    await userEvent.click(screen.getByLabelText('Back'))
+
+    expect(mockNavigate).toHaveBeenCalledWith('/library/system/system-1')
+    expect(mockNavigate).not.toHaveBeenCalledWith(-1)
+  })
+
+  it('falls back to navigate(-1) when no location.state.from', async () => {
+    renderReader('book-1')
+    await waitFor(() => screen.getByText('Test Book'))
+
+    await userEvent.click(screen.getByLabelText('Back'))
+
+    expect(mockNavigate).toHaveBeenCalledWith(-1)
   })
 })

--- a/frontend/src/views/SearchView.jsx
+++ b/frontend/src/views/SearchView.jsx
@@ -1,5 +1,5 @@
-import { useState, useCallback, useRef, useMemo } from 'react'
-import { useNavigate } from 'react-router-dom'
+import { useState, useCallback, useRef, useMemo, useEffect } from 'react'
+import { useNavigate, useSearchParams } from 'react-router-dom'
 import { useTranslation } from 'react-i18next'
 import { LuSearch, LuMap, LuUser, LuBookOpen, LuChevronDown, LuChevronRight } from 'react-icons/lu'
 import api from '../api'
@@ -8,7 +8,8 @@ import Spinner from '../components/Spinner'
 export default function SearchView() {
   const { t } = useTranslation()
   const navigate = useNavigate()
-  const [query, setQuery] = useState('')
+  const [searchParams, setSearchParams] = useSearchParams()
+  const [query, setQuery] = useState(() => searchParams.get('q') ?? '')
   const [results, setResults] = useState(null)
   const [searching, setSearching] = useState(false)
   const [collapsed, setCollapsed] = useState({})
@@ -34,9 +35,16 @@ export default function SearchView() {
       .catch(() => setSearching(false))
   }, [])
 
+  // Run the search immediately on mount if the URL already has a query (e.g. back navigation).
+  useEffect(() => {
+    const initial = searchParams.get('q')
+    if (initial && initial.length >= 2) doSearch(initial)
+  }, []) // eslint-disable-line react-hooks/exhaustive-deps
+
   const handleInput = (e) => {
     const v = e.target.value
     setQuery(v)
+    setSearchParams(v ? { q: v } : {}, { replace: true })
     clearTimeout(timerRef.current)
     timerRef.current = setTimeout(() => doSearch(v), 350)
   }
@@ -198,7 +206,7 @@ export default function SearchView() {
                       group={group}
                       collapsed={collapsed}
                       onToggle={toggleSection}
-                      onNavigate={(page) => navigate(`/library/book/${group.id}?page=${page}`)}
+                      onNavigate={(page) => navigate(`/library/book/${group.id}?page=${page}`, { state: { from: window.location.pathname + window.location.search } })}
                       t={t}
                     />
                   ))}

--- a/frontend/src/views/SearchView.test.jsx
+++ b/frontend/src/views/SearchView.test.jsx
@@ -216,3 +216,41 @@ describe('SearchView', () => {
     expect(api.get).not.toHaveBeenCalled()
   })
 })
+
+describe('SearchView — URL query param persistence', () => {
+  beforeEach(() => vi.clearAllMocks())
+
+  it('pre-fills the input from ?q= on mount', () => {
+    render(
+      <MemoryRouter initialEntries={['/search?q=fireball']}>
+        <SearchView />
+      </MemoryRouter>
+    )
+    expect(screen.getByRole('textbox').value).toBe('fireball')
+  })
+
+  it('runs the search immediately on mount when ?q= is present', async () => {
+    api.get.mockResolvedValue(makeResponse([makeBookResult({ title: 'Spell Guide' })]))
+    render(
+      <MemoryRouter initialEntries={['/search?q=fireball']}>
+        <SearchView />
+      </MemoryRouter>
+    )
+    await waitFor(() => expect(screen.getByText('Spell Guide')).toBeInTheDocument())
+    expect(api.get).toHaveBeenCalledWith(expect.stringContaining('q=fireball'))
+  })
+
+  it('does not run a search on mount when ?q= is absent', () => {
+    renderView()
+    expect(api.get).not.toHaveBeenCalled()
+  })
+
+  it('does not run a search on mount when ?q= is a single character', () => {
+    render(
+      <MemoryRouter initialEntries={['/search?q=x']}>
+        <SearchView />
+      </MemoryRouter>
+    )
+    expect(api.get).not.toHaveBeenCalled()
+  })
+})

--- a/frontend/src/views/SystemDetailView.jsx
+++ b/frontend/src/views/SystemDetailView.jsx
@@ -60,7 +60,7 @@ export default function SystemDetailView() {
   const [showAllTags, setShowAllTags] = useState(false)
   const [bookSort, setBookSort] = useState('title')
   const [favOnly, setFavOnly] = useState(false)
-  const [searchQuery, setSearchQuery] = useState('')
+  const [searchQuery, setSearchQuery] = useSessionState(`grimoire:system:${systemId}:search-query`, '')
   const [searchResults, setSearchResults] = useState(null)
   const [searching, setSearching] = useState(false)
   const searchTimer = useRef(null)
@@ -87,6 +87,11 @@ export default function SystemDetailView() {
     },
     [systemId]
   )
+
+  // Re-run the search on mount if a query was persisted from a previous visit.
+  useEffect(() => {
+    if (searchQuery && searchQuery.length >= 2) doSearch(searchQuery)
+  }, []) // eslint-disable-line react-hooks/exhaustive-deps
 
   const handleSearchInput = (e) => {
     const v = e.target.value
@@ -551,7 +556,7 @@ export default function SystemDetailView() {
           {searchResults.results.map((r, i) => (
             <div
               key={i}
-              onClick={() => navigate(`/library/book/${r.id}?page=${r.page_number}`)}
+              onClick={() => navigate(`/library/book/${r.id}?page=${r.page_number}`, { state: { from: window.location.pathname } })}
               style={{
                 background: 'var(--bg-card)',
                 border: '1px solid var(--border)',
@@ -711,7 +716,7 @@ export default function SystemDetailView() {
                             <div key={book.id}>
                               <BookRow
                                 book={book}
-                                onOpen={() => navigate(`/library/book/${book.id}`)}
+                                onOpen={() => navigate(`/library/book/${book.id}`, { state: { from: window.location.pathname } })}
                                 onEdit={
                                   isEditor
                                     ? () =>
@@ -760,7 +765,7 @@ export default function SystemDetailView() {
                                 <div key={book.id}>
                                   <BookRow
                                     book={book}
-                                    onOpen={() => navigate(`/library/book/${book.id}`)}
+                                    onOpen={() => navigate(`/library/book/${book.id}`, { state: { from: window.location.pathname } })}
                                     onEdit={
                                       isEditor
                                         ? () =>
@@ -796,7 +801,7 @@ export default function SystemDetailView() {
                               onToggle={toggleSubfolder}
                               editingBookId={editingBookId}
                               setEditingBookId={setEditingBookId}
-                              onOpenBook={(book) => navigate(`/library/book/${book.id}`)}
+                              onOpenBook={(book) => navigate(`/library/book/${book.id}`, { state: { from: window.location.pathname } })}
                               isEditor={isEditor}
                               onSaveBook={saveBook}
                               onDownload={setDownloadModal}

--- a/frontend/src/views/SystemDetailView.test.jsx
+++ b/frontend/src/views/SystemDetailView.test.jsx
@@ -304,3 +304,77 @@ describe('SystemDetailView — subfolder grouping', () => {
     })
   })
 })
+
+describe('SystemDetailView — in-system search persistence', () => {
+  const SESSION_KEY = 'grimoire:system:system-1:search-query'
+
+  function setupSearchMock(resultTitle = 'Spell Compendium') {
+    api.get.mockImplementation((url) => {
+      if (url.includes('/search')) {
+        return Promise.resolve({
+          query: 'fireball',
+          total: 1,
+          results: [
+            {
+              id: 'b1',
+              title: resultTitle,
+              game_system: 'Test System',
+              category: 'core',
+              page_number: 7,
+              snippet: 'A <mark>fireball</mark> spell.',
+            },
+          ],
+          maps: [],
+          tokens: [],
+        })
+      }
+      return Promise.resolve(makeSystem([makeBook({ title: 'PHB' })]))
+    })
+  }
+
+  beforeEach(() => {
+    vi.clearAllMocks()
+    mockIsFavorite.mockReturnValue(false)
+    sessionStorage.clear()
+  })
+
+  it('persists the search query to sessionStorage as the user types', async () => {
+    setupSearchMock()
+    renderView()
+    await waitFor(() => screen.getByLabelText(/search within/i))
+
+    await userEvent.type(screen.getByLabelText(/search within/i), 'fi')
+
+    await waitFor(() =>
+      expect(sessionStorage.getItem(SESSION_KEY)).toBe(JSON.stringify('fi'))
+    )
+  })
+
+  it('re-runs the search on mount when a query is stored in sessionStorage', async () => {
+    sessionStorage.setItem(SESSION_KEY, JSON.stringify('fireball'))
+    setupSearchMock('Spell Compendium')
+    renderView()
+
+    await waitFor(() => expect(screen.getByText('Spell Compendium')).toBeInTheDocument())
+    expect(api.get).toHaveBeenCalledWith(expect.stringContaining('q=fireball'))
+  })
+
+  it('pre-fills the search input from sessionStorage on mount', async () => {
+    sessionStorage.setItem(SESSION_KEY, JSON.stringify('fireball'))
+    setupSearchMock()
+    renderView()
+
+    await waitFor(() => screen.getByLabelText(/search within/i))
+    expect(screen.getByLabelText(/search within/i).value).toBe('fireball')
+  })
+
+  it('does not run a search on mount when the stored query is too short', async () => {
+    sessionStorage.setItem(SESSION_KEY, JSON.stringify('x'))
+    api.get.mockResolvedValue(makeSystem([makeBook({ title: 'PHB' })]))
+    renderView()
+
+    await waitFor(() => screen.getByText('PHB'))
+    const searchCalls = api.get.mock.calls.filter(([url]) => url.includes('/search'))
+    expect(searchCalls).toHaveLength(0)
+  })
+})


### PR DESCRIPTION
## Summary

The reader's back button previously used navigate(-1), which required multiple clicks after  ToC/bookmark/search jumps that pushed history entries. It now navigates directly to location.state.from (set by all call sites), falling back to navigate(-1) for direct URL access.

Global search and in-system search now restore their query and results on back navigation: SearchView syncs the query to ?q= so returning to the URL replays the search, and SystemDetailView persists the query in sessionStorage.

Closes #98

## Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / cleanup
- [ ] Docs / configuration only

## Testing

<!-- How did you verify this works? Check all that apply. -->

- [x] Backend tests pass (`pytest -q`)
- [x] Frontend tests pass (`npm test`)
- [x] Tested manually in the browser

## Notes for reviewer

<!-- Anything that needs extra context, known limitations, or follow-up work. Delete if not needed. -->
