### PR TITLE
Enhancement: spread offset toggle and extract ReaderToolbar component

### DIFF
--- a/frontend/src/components/reader/ReaderToolbar.jsx
+++ b/frontend/src/components/reader/ReaderToolbar.jsx
@@ -1,0 +1,362 @@
+import { useTranslation } from 'react-i18next'
+import {
+  LuArrowLeft,
+  LuChevronLeft,
+  LuChevronRight,
+  LuDownload,
+  LuFileText,
+  LuColumns2,
+  LuFile,
+  LuSearch,
+  LuList,
+  LuBookmark,
+  LuBookmarkPlus,
+  LuHeart,
+  LuKeyboard,
+  LuPanelLeft,
+} from 'react-icons/lu'
+import { mediaUrl } from '../../api'
+import AddToCampaignButton from '../campaigns/AddToCampaignButton'
+
+export const MODES = [
+  { key: 'page', Icon: LuFileText },
+  { key: 'spread', Icon: LuColumns2 },
+  { key: 'pdf', Icon: LuFile },
+]
+
+const btnStyle = {
+  background: 'var(--bg-card)',
+  border: '1px solid var(--border)',
+  color: 'var(--text)',
+  borderRadius: 4,
+  padding: '4px 8px',
+  display: 'flex',
+  alignItems: 'center',
+  cursor: 'pointer',
+}
+
+export default function ReaderToolbar({
+  book,
+  bookId,
+  mode,
+  onModeChange,
+  spreadOffset,
+  onSpreadOffsetChange,
+  currentPage,
+  totalPages,
+  step,
+  hasRight,
+  rightPage,
+  pageInput,
+  onPageInputChange,
+  onPageInputCommit,
+  panel,
+  onTogglePanel,
+  isMobilePhone,
+  showShortcuts,
+  onToggleShortcuts,
+  onBack,
+  isFavorite,
+  onToggleFavorite,
+  onBookmarkPage,
+}) {
+  const { t } = useTranslation()
+
+  const panels = [
+    book.mime_type === 'application/pdf' && mode !== 'pdf'
+      ? { key: 'toc', Icon: LuList, label: t('reader.contents') }
+      : null,
+    mode !== 'pdf' ? { key: 'bookmarks', Icon: LuBookmark, label: t('reader.bookmarks') } : null,
+    book.indexed ? { key: 'search', Icon: LuSearch, label: t('common.search') } : null,
+  ].filter(Boolean)
+
+  return (
+    <>
+      <div
+        style={{
+          display: 'flex',
+          alignItems: 'center',
+          gap: 12,
+          padding: '10px 20px',
+          background: 'var(--bg-panel)',
+          borderBottom: '1px solid var(--border)',
+          flexWrap: 'wrap',
+        }}
+      >
+        <button
+          onClick={onBack}
+          aria-label={t('reader.back')}
+          style={{
+            background: 'none',
+            color: 'var(--text-dim)',
+            fontSize: 15,
+            display: 'flex',
+            alignItems: 'center',
+            gap: 5,
+            border: 'none',
+            cursor: 'pointer',
+          }}
+        >
+          <LuArrowLeft size={15} /> {t('reader.back')}
+        </button>
+
+        <div style={{ width: 1, height: 20, background: 'var(--border)' }} />
+
+        <span
+          style={{
+            fontSize: 16,
+            fontWeight: 500,
+            color: 'var(--text)',
+            flex: 1,
+            overflow: 'hidden',
+            textOverflow: 'ellipsis',
+            whiteSpace: 'nowrap',
+          }}
+        >
+          {book.title}
+        </span>
+
+        {mode !== 'pdf' && totalPages > 0 && (
+          <div style={{ display: 'flex', alignItems: 'center', gap: 8 }}>
+            <button
+              onClick={() => onPageInputCommit(currentPage - step)}
+              disabled={currentPage <= 1}
+              aria-label={t('reader.previousPage')}
+              style={{ ...btnStyle, opacity: currentPage <= 1 ? 0.4 : 1 }}
+            >
+              <LuChevronLeft size={14} />
+            </button>
+            <input
+              id="reader-page-input"
+              type="text"
+              value={pageInput}
+              onChange={(e) => onPageInputChange(e.target.value)}
+              onKeyDown={(e) => e.key === 'Enter' && onPageInputCommit(parseInt(pageInput) || 1)}
+              onBlur={() => onPageInputCommit(parseInt(pageInput) || 1)}
+              aria-label={t('reader.currentPageNumber')}
+              style={{ width: 50, textAlign: 'center', padding: '4px 6px', fontSize: 15 }}
+            />
+            {mode === 'spread' && hasRight && (
+              <span style={{ fontSize: 15, color: 'var(--text-muted)' }}>– {rightPage}</span>
+            )}
+            <span style={{ fontSize: 15, color: 'var(--text-muted)' }}>
+              {t('common.pageOf', { total: totalPages })}
+            </span>
+            <button
+              onClick={() => onPageInputCommit(currentPage + step)}
+              disabled={currentPage >= totalPages}
+              aria-label={t('reader.nextPage')}
+              style={{ ...btnStyle, opacity: currentPage >= totalPages ? 0.4 : 1 }}
+            >
+              <LuChevronRight size={14} />
+            </button>
+          </div>
+        )}
+
+        <div style={{ width: 1, height: 20, background: 'var(--border)' }} />
+
+        {/* Mode toggle — hidden on mobile phones */}
+        <div
+          style={{
+            display: isMobilePhone ? 'none' : 'flex',
+            border: '1px solid var(--border)',
+            borderRadius: 6,
+            overflow: 'hidden',
+          }}
+        >
+          {MODES.map(({ key, Icon }) => (
+            <button
+              key={key}
+              onClick={() => onModeChange(key)}
+              title={t(`reader.${key}`)}
+              style={{
+                background: mode === key ? 'var(--bg-card-hover)' : 'var(--bg-card)',
+                color: mode === key ? 'var(--gold)' : 'var(--text-dim)',
+                border: 'none',
+                borderRight: key !== 'pdf' ? '1px solid var(--border)' : 'none',
+                padding: '5px 12px',
+                cursor: 'pointer',
+                fontSize: 13,
+                display: 'flex',
+                alignItems: 'center',
+                gap: 5,
+              }}
+            >
+              <Icon size={13} /> {t(`reader.${key}`)}
+            </button>
+          ))}
+        </div>
+
+        {/* Spread offset toggle — only in spread mode */}
+        {mode === 'spread' && !isMobilePhone && (
+          <button
+            onClick={() => onSpreadOffsetChange(spreadOffset === 0 ? 1 : 0)}
+            title={
+              spreadOffset === 0 ? t('reader.spreadIncludeCover') : t('reader.spreadExcludeCover')
+            }
+            style={{
+              background: spreadOffset === 1 ? 'var(--bg-card-hover)' : 'var(--bg-card)',
+              color: spreadOffset === 1 ? 'var(--gold)' : 'var(--text-dim)',
+              border: '1px solid var(--border)',
+              borderRadius: 6,
+              padding: '5px 12px',
+              cursor: 'pointer',
+              fontSize: 13,
+              display: 'flex',
+              alignItems: 'center',
+              gap: 5,
+            }}
+          >
+            <LuPanelLeft size={13} /> {t('reader.spreadCover')}
+          </button>
+        )}
+
+        {/* Panel selector */}
+        {panels.length > 0 && (
+          <div
+            style={{
+              display: 'flex',
+              border: '1px solid var(--border)',
+              borderRadius: 6,
+              overflow: 'hidden',
+            }}
+          >
+            {panels.map(({ key, Icon, label }, idx) => (
+              <button
+                key={key}
+                onClick={() => onTogglePanel(key)}
+                title={label}
+                style={{
+                  background: panel === key ? 'var(--bg-card-hover)' : 'var(--bg-card)',
+                  color: panel === key ? 'var(--gold)' : 'var(--text-dim)',
+                  border: 'none',
+                  borderRight: idx < panels.length - 1 ? '1px solid var(--border)' : 'none',
+                  padding: '5px 12px',
+                  cursor: 'pointer',
+                  fontSize: 13,
+                  display: 'flex',
+                  alignItems: 'center',
+                  gap: 5,
+                }}
+              >
+                <Icon size={13} />
+                {!isMobilePhone && key !== 'search' && <span>{label}</span>}
+              </button>
+            ))}
+          </div>
+        )}
+
+        <AddToCampaignButton resourceType="book" resourceId={bookId} />
+
+        <button
+          onClick={onToggleFavorite}
+          title={isFavorite ? t('reader.removeFromFavorites') : t('reader.addToFavorites')}
+          style={{ ...btnStyle, color: isFavorite ? 'var(--gold)' : 'var(--text-muted)' }}
+        >
+          <LuHeart size={14} fill={isFavorite ? 'var(--gold)' : 'none'} />
+        </button>
+
+        {mode !== 'pdf' && (
+          <button onClick={onBookmarkPage} title={t('reader.bookmarkPage')} style={btnStyle}>
+            <LuBookmarkPlus size={14} />
+          </button>
+        )}
+
+        <a
+          href={mediaUrl(`/books/${bookId}/file`)}
+          download
+          title={t('reader.downloadFile')}
+          style={{
+            background: 'var(--bg-card)',
+            border: '1px solid var(--border)',
+            color: 'var(--text-dim)',
+            borderRadius: 4,
+            padding: '4px 12px',
+            fontSize: 14,
+            display: 'inline-flex',
+            alignItems: 'center',
+            gap: 5,
+          }}
+        >
+          <LuDownload size={13} />
+        </a>
+
+        <button
+          onClick={onToggleShortcuts}
+          title="Keyboard shortcuts (?)"
+          style={{ ...btnStyle, color: showShortcuts ? 'var(--gold)' : 'var(--text-muted)' }}
+        >
+          <LuKeyboard size={14} />
+        </button>
+      </div>
+
+      {showShortcuts && (
+        <div
+          onClick={onToggleShortcuts}
+          style={{
+            position: 'fixed',
+            inset: 0,
+            background: 'rgba(0,0,0,0.5)',
+            zIndex: 200,
+            display: 'flex',
+            alignItems: 'center',
+            justifyContent: 'center',
+          }}
+        >
+          <div
+            onClick={(e) => e.stopPropagation()}
+            style={{
+              background: 'var(--bg-panel)',
+              border: '1px solid var(--border)',
+              borderRadius: 10,
+              padding: 24,
+              minWidth: 280,
+              boxShadow: '0 8px 32px rgba(0,0,0,0.4)',
+            }}
+          >
+            <div style={{ fontSize: 15, fontWeight: 600, marginBottom: 16, color: 'var(--text)' }}>
+              {t('reader.keyboardShortcuts')}
+            </div>
+            {[
+              ['←  /  →', t('reader.shortcutPrevNext')],
+              ['↑  /  ↓', t('reader.shortcutPrevNextVertical')],
+              ['f', t('reader.shortcutFavorite')],
+              ['t', t('reader.shortcutToc')],
+              ['b', t('reader.shortcutBookmarks')],
+              ['s', t('reader.shortcutSearch')],
+              ['?', t('reader.shortcutHelp')],
+              ['Esc', t('reader.shortcutClose')],
+            ].map(([key, desc]) => (
+              <div
+                key={key}
+                style={{
+                  display: 'flex',
+                  justifyContent: 'space-between',
+                  gap: 24,
+                  padding: '5px 0',
+                  borderBottom: '1px solid var(--border)',
+                  fontSize: 13,
+                }}
+              >
+                <kbd
+                  style={{
+                    fontFamily: 'monospace',
+                    background: 'var(--bg-card)',
+                    border: '1px solid var(--border)',
+                    borderRadius: 4,
+                    padding: '1px 7px',
+                    color: 'var(--gold)',
+                    whiteSpace: 'nowrap',
+                  }}
+                >
+                  {key}
+                </kbd>
+                <span style={{ color: 'var(--text-dim)' }}>{desc}</span>
+              </div>
+            ))}
+          </div>
+        </div>
+      )}
+    </>
+  )
+}

--- a/frontend/src/components/reader/ReaderToolbar.test.jsx
+++ b/frontend/src/components/reader/ReaderToolbar.test.jsx
@@ -1,0 +1,235 @@
+import { describe, it, expect, vi } from 'vitest'
+import { render, screen } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+import { MemoryRouter } from 'react-router-dom'
+import ReaderToolbar from './ReaderToolbar'
+
+vi.mock('../campaigns/AddToCampaignButton', () => ({ default: () => null }))
+
+const BOOK_PDF = {
+  id: 'book-1',
+  title: 'Test Book',
+  page_count: 100,
+  mime_type: 'application/pdf',
+  indexed: true,
+}
+
+function defaultProps(overrides = {}) {
+  return {
+    book: BOOK_PDF,
+    bookId: 'book-1',
+    mode: 'page',
+    onModeChange: vi.fn(),
+    spreadOffset: 0,
+    onSpreadOffsetChange: vi.fn(),
+    currentPage: 1,
+    totalPages: 100,
+    step: 1,
+    hasRight: false,
+    rightPage: 2,
+    pageInput: '1',
+    onPageInputChange: vi.fn(),
+    onPageInputCommit: vi.fn(),
+    panel: null,
+    onTogglePanel: vi.fn(),
+    isMobilePhone: false,
+    showShortcuts: false,
+    onToggleShortcuts: vi.fn(),
+    onBack: vi.fn(),
+    isFavorite: false,
+    onToggleFavorite: vi.fn(),
+    onBookmarkPage: vi.fn(),
+    ...overrides,
+  }
+}
+
+function renderToolbar(overrides = {}) {
+  return render(
+    <MemoryRouter>
+      <ReaderToolbar {...defaultProps(overrides)} />
+    </MemoryRouter>
+  )
+}
+
+describe('ReaderToolbar — navigation', () => {
+  it('renders the book title', () => {
+    renderToolbar()
+    expect(screen.getByText('Test Book')).toBeInTheDocument()
+  })
+
+  it('calls onBack when back button is clicked', async () => {
+    const onBack = vi.fn()
+    renderToolbar({ onBack })
+    await userEvent.click(screen.getByLabelText('Back'))
+    expect(onBack).toHaveBeenCalledOnce()
+  })
+
+  it('calls onPageInputCommit with next page when next-page button is clicked', async () => {
+    const onPageInputCommit = vi.fn()
+    renderToolbar({ onPageInputCommit, currentPage: 4, step: 1 })
+    await userEvent.click(screen.getByLabelText('Next page'))
+    expect(onPageInputCommit).toHaveBeenCalledWith(5)
+  })
+
+  it('calls onPageInputCommit with previous page when prev-page button is clicked', async () => {
+    const onPageInputCommit = vi.fn()
+    renderToolbar({ onPageInputCommit, currentPage: 4, step: 1 })
+    await userEvent.click(screen.getByLabelText('Previous page'))
+    expect(onPageInputCommit).toHaveBeenCalledWith(3)
+  })
+
+  it('previous-page button is disabled on page 1', () => {
+    renderToolbar({ currentPage: 1 })
+    expect(screen.getByLabelText('Previous page')).toBeDisabled()
+  })
+
+  it('next-page button is disabled on last page', () => {
+    renderToolbar({ currentPage: 100, totalPages: 100 })
+    expect(screen.getByLabelText('Next page')).toBeDisabled()
+  })
+})
+
+describe('ReaderToolbar — mode toggle', () => {
+  it('highlights the active mode button', () => {
+    renderToolbar({ mode: 'spread' })
+    const spreadBtn = screen.getByTitle('Spread')
+    expect(spreadBtn).toHaveStyle({ color: 'var(--gold)' })
+  })
+
+  it('calls onModeChange when a mode button is clicked', async () => {
+    const onModeChange = vi.fn()
+    renderToolbar({ onModeChange })
+    await userEvent.click(screen.getByTitle('Spread'))
+    expect(onModeChange).toHaveBeenCalledWith('spread')
+  })
+
+  it('hides mode toggle on mobile', () => {
+    renderToolbar({ isMobilePhone: true })
+    // Buttons are rendered but inside a display:none container — check via parent style.
+    const pageBtn = screen.getByTitle('Page')
+    expect(pageBtn.closest('div')).toHaveStyle({ display: 'none' })
+  })
+})
+
+describe('ReaderToolbar — spread offset', () => {
+  it('does not show Cover button in page mode', () => {
+    renderToolbar({ mode: 'page' })
+    expect(screen.queryByText('Cover')).not.toBeInTheDocument()
+  })
+
+  it('shows Cover button in spread mode', () => {
+    renderToolbar({ mode: 'spread' })
+    expect(screen.getByText('Cover')).toBeInTheDocument()
+  })
+
+  it('hides Cover button on mobile even in spread mode', () => {
+    renderToolbar({ mode: 'spread', isMobilePhone: true })
+    expect(screen.queryByText('Cover')).not.toBeInTheDocument()
+  })
+
+  it('calls onSpreadOffsetChange(1) when Cover is clicked and offset is 0', async () => {
+    const onSpreadOffsetChange = vi.fn()
+    renderToolbar({ mode: 'spread', spreadOffset: 0, onSpreadOffsetChange })
+    await userEvent.click(screen.getByText('Cover'))
+    expect(onSpreadOffsetChange).toHaveBeenCalledWith(1)
+  })
+
+  it('calls onSpreadOffsetChange(0) when Cover is clicked and offset is 1', async () => {
+    const onSpreadOffsetChange = vi.fn()
+    renderToolbar({ mode: 'spread', spreadOffset: 1, onSpreadOffsetChange })
+    await userEvent.click(screen.getByText('Cover'))
+    expect(onSpreadOffsetChange).toHaveBeenCalledWith(0)
+  })
+
+  it('shows include-cover tooltip when offset is 0', () => {
+    renderToolbar({ mode: 'spread', spreadOffset: 0 })
+    expect(
+      screen.getByTitle(/Include cover in spread/)
+    ).toBeInTheDocument()
+  })
+
+  it('shows exclude-cover tooltip when offset is 1', () => {
+    renderToolbar({ mode: 'spread', spreadOffset: 1 })
+    expect(
+      screen.getByTitle(/Exclude cover from spread/)
+    ).toBeInTheDocument()
+  })
+
+  it('shows right page number when hasRight is true in spread mode', () => {
+    renderToolbar({ mode: 'spread', hasRight: true, currentPage: 2, rightPage: 3 })
+    expect(screen.getByText('– 3')).toBeInTheDocument()
+  })
+})
+
+describe('ReaderToolbar — panel selector', () => {
+  it('shows Contents, Bookmarks, and Search for an indexed PDF', () => {
+    renderToolbar()
+    expect(screen.getByTitle('Contents')).toBeInTheDocument()
+    expect(screen.getByTitle('Bookmarks')).toBeInTheDocument()
+    expect(screen.getByTitle('Search')).toBeInTheDocument()
+  })
+
+  it('hides Contents in PDF mode', () => {
+    renderToolbar({ mode: 'pdf' })
+    expect(screen.queryByTitle('Contents')).not.toBeInTheDocument()
+  })
+
+  it('calls onTogglePanel when a panel button is clicked', async () => {
+    const onTogglePanel = vi.fn()
+    renderToolbar({ onTogglePanel })
+    await userEvent.click(screen.getByTitle('Contents'))
+    expect(onTogglePanel).toHaveBeenCalledWith('toc')
+  })
+
+  it('highlights the active panel button', () => {
+    renderToolbar({ panel: 'toc' })
+    expect(screen.getByTitle('Contents')).toHaveStyle({ color: 'var(--gold)' })
+  })
+})
+
+describe('ReaderToolbar — actions', () => {
+  it('calls onToggleFavorite when favorite button is clicked', async () => {
+    const onToggleFavorite = vi.fn()
+    renderToolbar({ onToggleFavorite })
+    await userEvent.click(screen.getByTitle('Add to favorites'))
+    expect(onToggleFavorite).toHaveBeenCalledOnce()
+  })
+
+  it('shows remove-favorites title when already favorited', () => {
+    renderToolbar({ isFavorite: true })
+    expect(screen.getByTitle('Remove from favorites')).toBeInTheDocument()
+  })
+
+  it('calls onBookmarkPage when bookmark button is clicked', async () => {
+    const onBookmarkPage = vi.fn()
+    renderToolbar({ onBookmarkPage })
+    await userEvent.click(screen.getByTitle('Bookmark this page'))
+    expect(onBookmarkPage).toHaveBeenCalledOnce()
+  })
+
+  it('hides bookmark button in PDF mode', () => {
+    renderToolbar({ mode: 'pdf' })
+    expect(screen.queryByTitle('Bookmark this page')).not.toBeInTheDocument()
+  })
+
+  it('calls onToggleShortcuts when keyboard button is clicked', async () => {
+    const onToggleShortcuts = vi.fn()
+    renderToolbar({ onToggleShortcuts })
+    await userEvent.click(screen.getByTitle('Keyboard shortcuts (?)'))
+    expect(onToggleShortcuts).toHaveBeenCalledOnce()
+  })
+
+  it('shows the shortcuts modal when showShortcuts is true', () => {
+    renderToolbar({ showShortcuts: true })
+    expect(screen.getByText('Keyboard Shortcuts')).toBeInTheDocument()
+  })
+
+  it('calls onToggleShortcuts when the shortcuts backdrop is clicked', async () => {
+    const onToggleShortcuts = vi.fn()
+    renderToolbar({ showShortcuts: true, onToggleShortcuts })
+    // The backdrop div contains the modal — click outside the inner card.
+    const backdrop = screen.getByText('Keyboard Shortcuts').closest('[style*="inset"]')
+    await userEvent.click(backdrop)
+    expect(onToggleShortcuts).toHaveBeenCalledOnce()
+  })
+})

--- a/frontend/src/hooks/useReaderGestures.js
+++ b/frontend/src/hooks/useReaderGestures.js
@@ -47,8 +47,7 @@ export default function useReaderGestures({
       const now = Date.now()
       if (now - lastWheelRef.current < 500) return
       lastWheelRef.current = now
-      // Compute step here to avoid capturing stale outer-scope values
-      const wheelStep = mode === 'spread' ? (currentPage === 1 ? 1 : 2) : 1
+      const wheelStep = mode === 'spread' ? 2 : 1
       const absDx = Math.abs(e.deltaX)
       const absDy = Math.abs(e.deltaY)
       if (absDy > absDx) {
@@ -162,7 +161,7 @@ export default function useReaderGestures({
     }
     if (type === 'pan') return
     if (!touchStartRef.current) return
-    const step = mode === 'spread' ? (currentPage === 1 ? 1 : 2) : 1
+    const step = mode === 'spread' ? 2 : 1
     const t = e.changedTouches[0]
     const dx = t.clientX - touchStartRef.current.x
     const dy = t.clientY - touchStartRef.current.y

--- a/frontend/src/locales/de-DE.json
+++ b/frontend/src/locales/de-DE.json
@@ -152,7 +152,10 @@
     "shortcutBookmarks": "Lesezeichen",
     "shortcutSearch": "Suche",
     "shortcutHelp": "Diese Hilfe",
-    "shortcutClose": "Panels schließen"
+    "shortcutClose": "Panels schließen",
+    "spreadCover": null,
+    "spreadIncludeCover": null,
+    "spreadExcludeCover": null
   },
   "search": {
     "title": "Bibliothek durchsuchen",

--- a/frontend/src/locales/en-US.json
+++ b/frontend/src/locales/en-US.json
@@ -157,7 +157,10 @@
     "shortcutBookmarks": "Bookmarks",
     "shortcutSearch": "Search",
     "shortcutHelp": "This help",
-    "shortcutClose": "Close panels"
+    "shortcutClose": "Close panels",
+    "spreadCover": "Cover",
+    "spreadIncludeCover": "Include cover in spread (pair pages 1-2, 3-4…)",
+    "spreadExcludeCover": "Exclude cover from spread (pair pages 2-3, 4-5…)"
   },
   "search": {
     "title": "Search Your Library",

--- a/frontend/src/locales/fr-CA.json
+++ b/frontend/src/locales/fr-CA.json
@@ -157,7 +157,10 @@
     "shortcutBookmarks": "Signets",
     "shortcutSearch": "Rechercher",
     "shortcutHelp": "Cette aide",
-    "shortcutClose": "Fermer les panneaux"
+    "shortcutClose": "Fermer les panneaux",
+    "spreadCover": "Couverture",
+    "spreadIncludeCover": "Inclure la couverture dans la double page (pages 1-2, 3-4…)",
+    "spreadExcludeCover": "Exclure la couverture de la double page (pages 2-3, 4-5…)"
   },
   "search": {
     "title": "Rechercher dans votre bibliothèque",

--- a/frontend/src/locales/fr-FR.json
+++ b/frontend/src/locales/fr-FR.json
@@ -157,7 +157,10 @@
     "shortcutBookmarks": "Signets",
     "shortcutSearch": "Rechercher",
     "shortcutHelp": "Cette aide",
-    "shortcutClose": "Fermer les panneaux"
+    "shortcutClose": "Fermer les panneaux",
+    "spreadCover": "Couverture",
+    "spreadIncludeCover": "Inclure la couverture dans la double page (pages 1-2, 3-4…)",
+    "spreadExcludeCover": "Exclure la couverture de la double page (pages 2-3, 4-5…)"
   },
   "search": {
     "title": "Rechercher dans votre bibliothèque",

--- a/frontend/src/views/ReaderView.jsx
+++ b/frontend/src/views/ReaderView.jsx
@@ -1,21 +1,7 @@
 import { useState, useEffect, useCallback, useRef } from 'react'
 import { useParams, useNavigate, useSearchParams, useLocation } from 'react-router-dom'
 import { useTranslation } from 'react-i18next'
-import {
-  LuArrowLeft,
-  LuChevronLeft,
-  LuChevronRight,
-  LuDownload,
-  LuFileText,
-  LuColumns2,
-  LuFile,
-  LuSearch,
-  LuList,
-  LuBookmark,
-  LuBookmarkPlus,
-  LuHeart,
-  LuKeyboard,
-} from 'react-icons/lu'
+import { LuArrowLeft, LuDownload, LuHeart } from 'react-icons/lu'
 import api, { mediaUrl } from '../api'
 import Spinner from '../components/Spinner'
 import { getBookPrefs, saveBookPrefs, saveRecentBook } from '../hooks/useBookPrefs'
@@ -28,7 +14,7 @@ import BookmarkSidebar from '../components/reader/BookmarkSidebar'
 import BookmarkDialog from '../components/reader/BookmarkDialog'
 import SelectionPopup from '../components/reader/SelectionPopup'
 import TextOverlay from '../components/reader/TextOverlay'
-import AddToCampaignButton from '../components/campaigns/AddToCampaignButton'
+import ReaderToolbar from '../components/reader/ReaderToolbar'
 
 // Inject page-turn keyframes once at module load
 if (typeof document !== 'undefined' && !document.getElementById('reader-anim')) {
@@ -57,12 +43,6 @@ export default function ReaderView() {
   // regardless of how many jump-navigation history entries were pushed (ToC, bookmarks, search).
   const backPathRef = useRef(location.state?.from ?? null)
 
-  const MODES = [
-    { key: 'page', Icon: LuFileText, label: t('reader.page') },
-    { key: 'spread', Icon: LuColumns2, label: t('reader.spread') },
-    { key: 'pdf', Icon: LuFile, label: t('reader.pdf') },
-  ]
-
   const _prefs = getBookPrefs(bookId)
   const _userPrefs = getUserPrefs()
   const initialPage = parseInt(searchParams.get('page')) || _prefs.page || 1
@@ -76,10 +56,13 @@ export default function ReaderView() {
       ? searchParams.get('view')
       : (_globalMode ?? (['page', 'spread', 'pdf'].includes(_prefs.mode) ? _prefs.mode : 'page'))
 
+  const initialSpreadOffset = _prefs.spreadOffset ?? 0
+
   const [book, setBook] = useState(null)
   const [currentPage, setCurrentPage] = useState(initialPage)
   const [totalPages, setTotalPages] = useState(0)
   const [mode, setMode] = useState(initialMode)
+  const [spreadOffset, setSpreadOffset] = useState(initialSpreadOffset)
   const [pageInput, setPageInput] = useState(String(initialPage))
   const [panel, setPanel] = useState(null)
   const [activeSearchQuery, setActiveSearchQuery] = useState(null)
@@ -122,8 +105,12 @@ export default function ReaderView() {
     (p, currentMode, axis = 'x') => {
       if (totalPages === 0) return
       let page = Math.max(1, Math.min(p, totalPages))
-      if ((currentMode ?? mode) === 'spread' && page > 1 && page % 2 !== 0) {
-        page = page - 1
+      if ((currentMode ?? mode) === 'spread') {
+        // Snap to the nearest left page based on spreadOffset.
+        // offset=0: left pages are even (2,4,6…), page 1 stands alone.
+        // offset=1: left pages are odd (1,3,5…), cover is part of a spread.
+        const isLeftPage = spreadOffset === 1 ? page % 2 !== 0 : page % 2 === 0 || page === 1
+        if (!isLeftPage) page = page - 1
       }
       directionRef.current = page >= currentPageRef.current ? 1 : -1
       axisRef.current = axis
@@ -131,7 +118,7 @@ export default function ReaderView() {
       setCurrentPage(page)
       setPageInput(String(page))
     },
-    [totalPages, mode]
+    [totalPages, mode, spreadOffset]
   )
 
   useEffect(() => {
@@ -146,7 +133,7 @@ export default function ReaderView() {
   useEffect(() => {
     if (!book || mode === 'pdf') return
     const pages = [currentPage]
-    if (mode === 'spread' && currentPage !== 1 && currentPage + 1 <= totalPages)
+    if (mode === 'spread' && (spreadOffset === 1 || currentPage !== 1) && currentPage + 1 <= totalPages)
       pages.push(currentPage + 1)
     pages.forEach((p) => {
       if (pageTextCacheRef.current[p] !== undefined) return
@@ -160,12 +147,12 @@ export default function ReaderView() {
           pageTextCacheRef.current[p] = ''
         })
     })
-  }, [currentPage, mode, book, bookId, totalPages])
+  }, [currentPage, mode, spreadOffset, book, bookId, totalPages])
 
   useEffect(() => {
     if (!book || book.mime_type !== 'application/pdf' || mode === 'pdf') return
     const pages = [currentPage]
-    if (mode === 'spread' && currentPage !== 1 && currentPage + 1 <= totalPages)
+    if (mode === 'spread' && (spreadOffset === 1 || currentPage !== 1) && currentPage + 1 <= totalPages)
       pages.push(currentPage + 1)
     pages.forEach((p) => {
       if (wordsCacheRef.current[p] !== undefined) return
@@ -180,7 +167,7 @@ export default function ReaderView() {
           wordsCacheRef.current[p] = null
         })
     })
-  }, [currentPage, mode, book, bookId, totalPages])
+  }, [currentPage, mode, spreadOffset, book, bookId, totalPages])
 
   useEffect(() => {
     const onMouseUp = (e) => {
@@ -265,7 +252,11 @@ export default function ReaderView() {
     if (mode === 'spread') goToPage(currentPage, 'spread')
   }, [mode]) // eslint-disable-line react-hooks/exhaustive-deps
 
-  const step = mode === 'spread' ? (currentPage === 1 ? 1 : 2) : 1
+  useEffect(() => {
+    if (mode === 'spread') goToPage(currentPage, 'spread')
+  }, [spreadOffset]) // eslint-disable-line react-hooks/exhaustive-deps
+
+  const step = mode === 'spread' ? 2 : 1
   useEffect(() => {
     const handleKeyDown = (e) => {
       if (e.target.tagName === 'INPUT' || e.target.tagName === 'TEXTAREA') return
@@ -324,7 +315,8 @@ export default function ReaderView() {
   }
 
   const rightPage = currentPage + 1
-  const hasRight = currentPage !== 1 && rightPage <= totalPages
+  // With offset=0: page 1 stands alone; with offset=1, page 1 pairs with page 2.
+  const hasRight = mode === 'spread' && (spreadOffset === 1 || currentPage !== 1) && rightPage <= totalPages
 
   const getAlt = (p) => {
     const text = pageTextCacheRef.current[p]
@@ -333,295 +325,40 @@ export default function ReaderView() {
 
   return (
     <div className="fade-in" style={{ display: 'flex', flexDirection: 'column', height: '100%' }}>
-      {/* Toolbar */}
-      <div
-        style={{
-          display: 'flex',
-          alignItems: 'center',
-          gap: 12,
-          padding: '10px 20px',
-          background: 'var(--bg-panel)',
-          borderBottom: '1px solid var(--border)',
-          flexWrap: 'wrap',
+      <ReaderToolbar
+        book={book}
+        bookId={bookId}
+        mode={mode}
+        onModeChange={(key) => {
+          setMode(key)
+          saveBookPrefs(bookId, { mode: key })
         }}
-      >
-        <button
-          onClick={() => (backPathRef.current ? navigate(backPathRef.current) : navigate(-1))}
-          aria-label={t('reader.back')}
-          style={{
-            background: 'none',
-            color: 'var(--text-dim)',
-            fontSize: 15,
-            display: 'flex',
-            alignItems: 'center',
-            gap: 5,
-            border: 'none',
-            cursor: 'pointer',
-          }}
-        >
-          <LuArrowLeft size={15} /> {t('reader.back')}
-        </button>
-        <div style={{ width: 1, height: 20, background: 'var(--border)' }} />
-        <span
-          style={{
-            fontSize: 16,
-            fontWeight: 500,
-            color: 'var(--text)',
-            flex: 1,
-            overflow: 'hidden',
-            textOverflow: 'ellipsis',
-            whiteSpace: 'nowrap',
-          }}
-        >
-          {book.title}
-        </span>
-
-        {mode !== 'pdf' && totalPages > 0 && (
-          <div style={{ display: 'flex', alignItems: 'center', gap: 8 }}>
-            <button
-              onClick={() => goToPage(currentPage - step)}
-              disabled={currentPage <= 1}
-              aria-label={t('reader.previousPage')}
-              style={{ ...btnStyle, opacity: currentPage <= 1 ? 0.4 : 1 }}
-            >
-              <LuChevronLeft size={14} />
-            </button>
-            <input
-              id="reader-page-input"
-              type="text"
-              value={pageInput}
-              onChange={(e) => setPageInput(e.target.value)}
-              onKeyDown={(e) => e.key === 'Enter' && goToPage(parseInt(pageInput) || 1)}
-              onBlur={() => goToPage(parseInt(pageInput) || 1)}
-              aria-label={t('reader.currentPageNumber')}
-              style={{ width: 50, textAlign: 'center', padding: '4px 6px', fontSize: 15 }}
-            />
-            {mode === 'spread' && hasRight && (
-              <span style={{ fontSize: 15, color: 'var(--text-muted)' }}>– {rightPage}</span>
-            )}
-            <span style={{ fontSize: 15, color: 'var(--text-muted)' }}>
-              {t('common.pageOf', { total: totalPages })}
-            </span>
-            <button
-              onClick={() => goToPage(currentPage + step)}
-              disabled={currentPage >= totalPages}
-              aria-label={t('reader.nextPage')}
-              style={{ ...btnStyle, opacity: currentPage >= totalPages ? 0.4 : 1 }}
-            >
-              <LuChevronRight size={14} />
-            </button>
-          </div>
-        )}
-
-        <div style={{ width: 1, height: 20, background: 'var(--border)' }} />
-
-        {/* Mode toggle — hidden on mobile phones, locked to page view */}
-        <div
-          style={{
-            display: isMobilePhone ? 'none' : 'flex',
-            border: '1px solid var(--border)',
-            borderRadius: 6,
-            overflow: 'hidden',
-          }}
-        >
-          {MODES.map(({ key, Icon, label }) => (
-            <button
-              key={key}
-              onClick={() => {
-                setMode(key)
-                saveBookPrefs(bookId, { mode: key })
-              }}
-              title={label}
-              style={{
-                background: mode === key ? 'var(--bg-card-hover)' : 'var(--bg-card)',
-                color: mode === key ? 'var(--gold)' : 'var(--text-dim)',
-                border: 'none',
-                borderRight: key !== 'pdf' ? '1px solid var(--border)' : 'none',
-                padding: '5px 12px',
-                cursor: 'pointer',
-                fontSize: 13,
-                display: 'flex',
-                alignItems: 'center',
-                gap: 5,
-              }}
-            >
-              <Icon size={13} /> {label}
-            </button>
-          ))}
-        </div>
-
-        {/* Panel selector */}
-        {(() => {
-          const panels = [
-            book.mime_type === 'application/pdf' && mode !== 'pdf'
-              ? { key: 'toc', Icon: LuList, label: t('reader.contents') }
-              : null,
-            mode !== 'pdf'
-              ? { key: 'bookmarks', Icon: LuBookmark, label: t('reader.bookmarks') }
-              : null,
-            book.indexed ? { key: 'search', Icon: LuSearch, label: t('common.search') } : null,
-          ].filter(Boolean)
-          if (panels.length === 0) return null
-          return (
-            <div
-              style={{
-                display: 'flex',
-                border: '1px solid var(--border)',
-                borderRadius: 6,
-                overflow: 'hidden',
-              }}
-            >
-              {panels.map(({ key, Icon, label }, idx) => (
-                <button
-                  key={key}
-                  onClick={() => togglePanel(key)}
-                  title={label}
-                  style={{
-                    background: panel === key ? 'var(--bg-card-hover)' : 'var(--bg-card)',
-                    color: panel === key ? 'var(--gold)' : 'var(--text-dim)',
-                    border: 'none',
-                    borderRight: idx < panels.length - 1 ? '1px solid var(--border)' : 'none',
-                    padding: '5px 12px',
-                    cursor: 'pointer',
-                    fontSize: 13,
-                    display: 'flex',
-                    alignItems: 'center',
-                    gap: 5,
-                  }}
-                >
-                  <Icon size={13} />
-                  {!isMobilePhone && key !== 'search' && <span>{label}</span>}
-                </button>
-              ))}
-            </div>
-          )
-        })()}
-
-        <AddToCampaignButton resourceType="book" resourceId={bookId} />
-
-        <button
-          onClick={() => toggleFavorite('book', bookId)}
-          title={
-            isFavorite('book', bookId)
-              ? t('reader.removeFromFavorites')
-              : t('reader.addToFavorites')
-          }
-          style={{
-            ...btnStyle,
-            color: isFavorite('book', bookId) ? 'var(--gold)' : 'var(--text-muted)',
-          }}
-        >
-          <LuHeart size={14} fill={isFavorite('book', bookId) ? 'var(--gold)' : 'none'} />
-        </button>
-
-        {mode !== 'pdf' && (
-          <button
-            onClick={() => {
-              setPendingBookmark({ page: currentPage })
-              setPendingLabel('')
-            }}
-            title={t('reader.bookmarkPage')}
-            style={btnStyle}
-          >
-            <LuBookmarkPlus size={14} />
-          </button>
-        )}
-
-        <a
-          href={mediaUrl(`/books/${bookId}/file`)}
-          download
-          title={t('reader.downloadFile')}
-          style={{
-            background: 'var(--bg-card)',
-            border: '1px solid var(--border)',
-            color: 'var(--text-dim)',
-            borderRadius: 4,
-            padding: '4px 12px',
-            fontSize: 14,
-            display: 'inline-flex',
-            alignItems: 'center',
-            gap: 5,
-          }}
-        >
-          <LuDownload size={13} />
-        </a>
-
-        <button
-          onClick={() => setShowShortcuts((v) => !v)}
-          title="Keyboard shortcuts (?)"
-          style={{ ...btnStyle, color: showShortcuts ? 'var(--gold)' : 'var(--text-muted)' }}
-        >
-          <LuKeyboard size={14} />
-        </button>
-      </div>
-
-      {showShortcuts && (
-        <div
-          onClick={() => setShowShortcuts(false)}
-          style={{
-            position: 'fixed',
-            inset: 0,
-            background: 'rgba(0,0,0,0.5)',
-            zIndex: 200,
-            display: 'flex',
-            alignItems: 'center',
-            justifyContent: 'center',
-          }}
-        >
-          <div
-            onClick={(e) => e.stopPropagation()}
-            style={{
-              background: 'var(--bg-panel)',
-              border: '1px solid var(--border)',
-              borderRadius: 10,
-              padding: 24,
-              minWidth: 280,
-              boxShadow: '0 8px 32px rgba(0,0,0,0.4)',
-            }}
-          >
-            <div style={{ fontSize: 15, fontWeight: 600, marginBottom: 16, color: 'var(--text)' }}>
-              {t('reader.keyboardShortcuts')}
-            </div>
-            {[
-              ['←  /  →', t('reader.shortcutPrevNext')],
-              ['↑  /  ↓', t('reader.shortcutPrevNextVertical')],
-              ['f', t('reader.shortcutFavorite')],
-              ['t', t('reader.shortcutToc')],
-              ['b', t('reader.shortcutBookmarks')],
-              ['s', t('reader.shortcutSearch')],
-              ['?', t('reader.shortcutHelp')],
-              ['Esc', t('reader.shortcutClose')],
-            ].map(([key, desc]) => (
-              <div
-                key={key}
-                style={{
-                  display: 'flex',
-                  justifyContent: 'space-between',
-                  gap: 24,
-                  padding: '5px 0',
-                  borderBottom: '1px solid var(--border)',
-                  fontSize: 13,
-                }}
-              >
-                <kbd
-                  style={{
-                    fontFamily: 'monospace',
-                    background: 'var(--bg-card)',
-                    border: '1px solid var(--border)',
-                    borderRadius: 4,
-                    padding: '1px 7px',
-                    color: 'var(--gold)',
-                    whiteSpace: 'nowrap',
-                  }}
-                >
-                  {key}
-                </kbd>
-                <span style={{ color: 'var(--text-dim)' }}>{desc}</span>
-              </div>
-            ))}
-          </div>
-        </div>
-      )}
+        spreadOffset={spreadOffset}
+        onSpreadOffsetChange={(next) => {
+          setSpreadOffset(next)
+          saveBookPrefs(bookId, { spreadOffset: next })
+        }}
+        currentPage={currentPage}
+        totalPages={totalPages}
+        step={step}
+        hasRight={hasRight}
+        rightPage={rightPage}
+        pageInput={pageInput}
+        onPageInputChange={setPageInput}
+        onPageInputCommit={goToPage}
+        panel={panel}
+        onTogglePanel={togglePanel}
+        isMobilePhone={isMobilePhone}
+        showShortcuts={showShortcuts}
+        onToggleShortcuts={() => setShowShortcuts((v) => !v)}
+        onBack={() => (backPathRef.current ? navigate(backPathRef.current) : navigate(-1))}
+        isFavorite={isFavorite('book', bookId)}
+        onToggleFavorite={() => toggleFavorite('book', bookId)}
+        onBookmarkPage={() => {
+          setPendingBookmark({ page: currentPage })
+          setPendingLabel('')
+        }}
+      />
 
       {/* Content + optional sidebar */}
       <div style={{ flex: 1, minHeight: 0, overflow: 'hidden', display: 'flex' }}>

--- a/frontend/src/views/ReaderView.test.jsx
+++ b/frontend/src/views/ReaderView.test.jsx
@@ -197,6 +197,35 @@ describe('ReaderView — jump navigation history behaviour', () => {
   })
 })
 
+describe('ReaderView — spread mode (integration)', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    setupApiMocks()
+    vi.stubGlobal('requestAnimationFrame', (cb) => { cb(); return 0 })
+    vi.stubGlobal('cancelAnimationFrame', () => {})
+    localStorage.clear()
+  })
+
+  it('persists spreadOffset to localStorage when Cover is toggled', async () => {
+    localStorage.setItem('grimoire:book:book-1', JSON.stringify({ mode: 'spread' }))
+    renderReader()
+    await waitFor(() => screen.getByText('Test Book'))
+
+    await userEvent.click(screen.getByText('Cover'))
+    expect(JSON.parse(localStorage.getItem('grimoire:book:book-1')).spreadOffset).toBe(1)
+
+    await userEvent.click(screen.getByText('Cover'))
+    expect(JSON.parse(localStorage.getItem('grimoire:book:book-1')).spreadOffset).toBe(0)
+  })
+
+  it('restores spreadOffset from localStorage on mount', async () => {
+    localStorage.setItem('grimoire:book:book-1', JSON.stringify({ mode: 'spread', spreadOffset: 1 }))
+    renderReader()
+    await waitFor(() => screen.getByText('Test Book'))
+    expect(screen.getByTitle(/Exclude cover from spread/)).toBeInTheDocument()
+  })
+})
+
 describe('ReaderView — back button navigation', () => {
   beforeEach(() => {
     vi.clearAllMocks()


### PR DESCRIPTION
## Summary

Add a per-book "Cover" toggle in spread mode that lets readers choose
whether page 1 pairs with page 2 (cover included) or stands alone
(default). Fixes spread alignment for books where the cover offsets
interior spreads (closes #97).

Refactored reader view.

## Type of change

- [ ] Bug fix
- [x] New feature
- [x] Refactor / cleanup
- [ ] Docs / configuration only

## Testing

<!-- How did you verify this works? Check all that apply. -->

- [x] Backend tests pass (`pytest -q`)
- [x] Frontend tests pass (`npm test`)
- [x] Tested manually in the browser

