### PR TITLE
Enhancement: support Calibre per-book-folder OPF metadata

### DIFF
--- a/README.md
+++ b/README.md
@@ -307,6 +307,49 @@ books/
 
 Users with explicit content disabled will not see this system or its books.
 
+### Book metadata from OPF files
+
+Grimoire reads [OPF](https://idpf.org/epub/20/spec/OPF_2.0.1_draft.htm) sidecar files to populate book metadata automatically on first scan. OPF files are the format used by [Calibre](https://calibre-ebook.com/) and many other library managers.
+
+#### Supported fields
+
+| OPF element | Book field |
+|---|---|
+| `dc:title` | Title |
+| `dc:creator` (role=aut) | Authors |
+| `dc:publisher` | Publisher |
+| `dc:date` | Year (4-digit year extracted) |
+| `dc:description` | Description (HTML tags stripped) |
+| `dc:subject` | Tags (lowercased) |
+| `guide/reference[@type='cover']` | Cover image (file is excluded from the book list) |
+
+`dc:contributor` entries (e.g. Calibre's own tool credit) and `dc:identifier` (UUID/ISBN) are intentionally ignored. `dc:language` is parsed but not stored (no matching field).
+
+#### OPF file discovery
+
+The scanner checks two locations for each book file, in priority order:
+
+1. **`<bookname>.opf`** — a sidecar file with the same stem as the PDF, in the same directory. Suits hand-crafted or single-file layouts.
+2. **`metadata.opf`** — a file named `metadata.opf` in the same directory. This is the format Calibre uses when it exports each book into its own subfolder.
+
+A typical Calibre export looks like this and is fully supported:
+
+```
+books/
+└── Dungeons & Dragons/
+    └── core/
+        ├── Players Handbook/
+        │   ├── players_handbook.pdf
+        │   ├── metadata.opf
+        │   └── cover.jpg          ← skipped (referenced as cover in OPF)
+        └── Dungeon Masters Guide/
+            ├── dungeon_masters_guide.pdf
+            ├── metadata.opf
+            └── cover.jpg
+```
+
+OPF metadata is only applied when a book is **first indexed**. Edits made via the web UI are not overwritten on subsequent rescans.
+
 ### Maps — organize by creator or collection
 
 ```

--- a/backend/indexer.py
+++ b/backend/indexer.py
@@ -7,6 +7,7 @@ import logging
 import hashlib
 import threading
 from pathlib import Path
+from xml.etree import ElementTree
 import fitz  # PyMuPDF
 from PIL import Image
 from sqlalchemy import text
@@ -239,6 +240,82 @@ def _count_eligible_files(directory: Path, extensions: set) -> int:
     return count
 
 
+_OPF_NS = {
+    "dc": "http://purl.org/dc/elements/1.1/",
+    "opf": "http://www.idpf.org/2007/opf",
+}
+
+
+def parse_opf_metadata(opf_path: str) -> dict:
+    """Parse a Calibre/OPF metadata file and return a dict of book fields.
+
+    Returns a dict containing any of: title, authors, description, publisher,
+    year, tags, cover_image_filename. Only keys with actual values are included.
+    cover_image_filename is the bare filename (not a path) of the cover image
+    referenced in the OPF <guide>, if present.
+    """
+    try:
+        tree = ElementTree.parse(opf_path)
+    except Exception as e:
+        logger.warning(f"Could not parse OPF file '{opf_path}': {e}")
+        return {}
+
+    root = tree.getroot()
+    meta = {}
+
+    def _find_text(tag: str) -> str:
+        el = root.find(f"opf:metadata/dc:{tag}", _OPF_NS)
+        return el.text.strip() if el is not None and el.text else ""
+
+    title = _find_text("title")
+    if title:
+        meta["title"] = title
+
+    authors = [
+        el.text.strip()
+        for el in root.findall("opf:metadata/dc:creator", _OPF_NS)
+        if el.text and el.text.strip()
+    ]
+    if authors:
+        meta["authors"] = authors
+
+    description = _find_text("description")
+    if description:
+        # Strip any embedded HTML tags from Calibre descriptions
+        description = re.sub(r"<[^>]+>", "", description).strip()
+        if description:
+            meta["description"] = description
+
+    publisher = _find_text("publisher")
+    if publisher:
+        meta["publisher"] = publisher
+
+    date_str = _find_text("date")
+    if date_str:
+        try:
+            year = int(date_str[:4])
+            if year > 1000:  # Calibre uses 0101-01-01 as a "no date" sentinel
+                meta["year"] = year
+        except (ValueError, IndexError):
+            pass
+
+    subjects = [
+        el.text.strip().lower()
+        for el in root.findall("opf:metadata/dc:subject", _OPF_NS)
+        if el.text and el.text.strip()
+    ]
+    if subjects:
+        meta["tags"] = subjects
+
+    cover_ref = root.find("opf:guide/opf:reference[@type='cover']", _OPF_NS)
+    if cover_ref is not None:
+        href = cover_ref.get("href", "")
+        if href:
+            meta["cover_image_filename"] = Path(href).name
+
+    return meta
+
+
 def scan_library(library_path: str, data_path: str, session: Session, on_progress=None, should_stop=None):
     """Scan the library directory and register all files in the database.
 
@@ -319,6 +396,17 @@ def scan_library(library_path: str, data_path: str, session: Session, on_progres
             for root, dirs, files in os.walk(system_dir):
                 dirs[:] = [d for d in dirs if not d.startswith(".")]
 
+                # Collect cover image filenames declared in any OPF files in this
+                # directory so we can skip them — Calibre exports a cover JPG that
+                # would otherwise appear as a 1-page book entry.
+                opf_cover_filenames: set[str] = set()
+                for f in files:
+                    if Path(f).suffix.lower() == ".opf":
+                        opf_data = parse_opf_metadata(os.path.join(root, f))
+                        cover_fn = opf_data.get("cover_image_filename")
+                        if cover_fn:
+                            opf_cover_filenames.add(cover_fn)
+
                 for filename in sorted(files):
                     if filename.startswith("."):
                         continue
@@ -327,6 +415,10 @@ def scan_library(library_path: str, data_path: str, session: Session, on_progres
                     ext = Path(filename).suffix.lower()
 
                     if ext not in DOC_EXTS and ext not in IMAGE_EXTS:
+                        continue
+
+                    if filename in opf_cover_filenames:
+                        logger.debug(f"Skipping OPF cover image: {filepath}")
                         continue
 
                     scanned_books += 1
@@ -379,15 +471,28 @@ def scan_library(library_path: str, data_path: str, session: Session, on_progres
                             logger.warning(f"Cannot stat file, skipping: {filepath}")
                             continue
 
+                        # Check sibling <stem>.opf first, then Calibre's metadata.opf in the same dir.
+                        opf_path = os.path.join(root, Path(filename).stem + ".opf")
+                        if not os.path.isfile(opf_path):
+                            opf_path = os.path.join(root, "metadata.opf")
+                        opf_meta = parse_opf_metadata(opf_path) if os.path.isfile(opf_path) else {}
+                        if opf_meta:
+                            logger.info(f"Applying OPF metadata to '{filename}' from '{Path(opf_path).name}'")
+
                         book = Book(
                             game_system_id=system.id,
-                            title=title,
+                            title=opf_meta.get("title", title),
                             filename=filename,
                             filepath=filepath,
                             relative_path=relative_path,
                             category=category,
                             file_size=file_size,
                             mime_type="application/pdf" if ext == ".pdf" else f"image/{ext[1:]}",
+                            authors=opf_meta.get("authors"),
+                            description=opf_meta.get("description"),
+                            publisher=opf_meta.get("publisher"),
+                            year=opf_meta.get("year"),
+                            tags=opf_meta.get("tags"),
                         )
 
                         # Commit the book record first so that if a subsequent

--- a/backend/tests/test_indexer_opf.py
+++ b/backend/tests/test_indexer_opf.py
@@ -1,0 +1,348 @@
+"""Tests for OPF metadata parsing in the library indexer."""
+from __future__ import annotations
+
+import os
+import tempfile
+from pathlib import Path
+from textwrap import dedent
+
+import pytest
+
+from backend.config import SessionLocal
+from backend.indexer import parse_opf_metadata, scan_library
+from backend.models import Book
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+def _write_opf(directory: str, name: str, content: str) -> str:
+    path = os.path.join(directory, name)
+    Path(path).write_text(content, encoding="utf-8")
+    return path
+
+
+MARVEL_OPF = dedent("""\
+    <?xml version='1.0' encoding='utf-8'?>
+    <package xmlns="http://www.idpf.org/2007/opf" unique-identifier="uuid_id" version="2.0">
+        <metadata xmlns:dc="http://purl.org/dc/elements/1.1/" xmlns:opf="http://www.idpf.org/2007/opf">
+            <dc:title>Marvel Multiverse: Core Rulebook</dc:title>
+            <dc:creator opf:role="aut">Matt Forbeck</dc:creator>
+            <dc:date>2023-05-15T04:00:00+00:00</dc:date>
+            <dc:description>&lt;div&gt;&lt;p&gt;Take on the roles of Marvel's heroes.&lt;/p&gt;&lt;/div&gt;</dc:description>
+            <dc:publisher>Marvel Universe</dc:publisher>
+            <dc:subject>Comics &amp; Graphic Novels</dc:subject>
+            <dc:subject>Role Playing &amp; Fantasy</dc:subject>
+        </metadata>
+        <guide>
+            <reference type="cover" title="Cover" href="Marvel Multiverse_ Core Rulebook.jpg"/>
+        </guide>
+    </package>
+""")
+
+MINIMAL_OPF = dedent("""\
+    <?xml version='1.0' encoding='utf-8'?>
+    <package xmlns="http://www.idpf.org/2007/opf" version="2.0">
+        <metadata xmlns:dc="http://purl.org/dc/elements/1.1/" xmlns:opf="http://www.idpf.org/2007/opf">
+            <dc:title>Minimal Book</dc:title>
+        </metadata>
+    </package>
+""")
+
+MULTI_AUTHOR_OPF = dedent("""\
+    <?xml version='1.0' encoding='utf-8'?>
+    <package xmlns="http://www.idpf.org/2007/opf" version="2.0">
+        <metadata xmlns:dc="http://purl.org/dc/elements/1.1/" xmlns:opf="http://www.idpf.org/2007/opf">
+            <dc:title>Collaborative Work</dc:title>
+            <dc:creator opf:role="aut">Alice Smith</dc:creator>
+            <dc:creator opf:role="aut">Bob Jones</dc:creator>
+        </metadata>
+    </package>
+""")
+
+
+# ---------------------------------------------------------------------------
+# parse_opf_metadata — full metadata
+# ---------------------------------------------------------------------------
+
+class TestParseOpfMetadataFull:
+    def setup_method(self):
+        self.tmp = tempfile.mkdtemp()
+
+    def test_title_extracted(self):
+        path = _write_opf(self.tmp, "marvel.opf", MARVEL_OPF)
+        assert parse_opf_metadata(path)["title"] == "Marvel Multiverse: Core Rulebook"
+
+    def test_author_extracted(self):
+        path = _write_opf(self.tmp, "marvel.opf", MARVEL_OPF)
+        assert parse_opf_metadata(path)["authors"] == ["Matt Forbeck"]
+
+    def test_publisher_extracted(self):
+        path = _write_opf(self.tmp, "marvel.opf", MARVEL_OPF)
+        assert parse_opf_metadata(path)["publisher"] == "Marvel Universe"
+
+    def test_year_extracted(self):
+        path = _write_opf(self.tmp, "marvel.opf", MARVEL_OPF)
+        assert parse_opf_metadata(path)["year"] == 2023
+
+    def test_description_extracted_and_html_stripped(self):
+        path = _write_opf(self.tmp, "marvel.opf", MARVEL_OPF)
+        desc = parse_opf_metadata(path)["description"]
+        assert "<" not in desc
+        assert "Marvel's heroes" in desc
+
+    def test_subjects_become_tags(self):
+        path = _write_opf(self.tmp, "marvel.opf", MARVEL_OPF)
+        tags = parse_opf_metadata(path)["tags"]
+        assert "comics & graphic novels" in tags
+        assert "role playing & fantasy" in tags
+
+    def test_cover_image_filename_extracted(self):
+        path = _write_opf(self.tmp, "marvel.opf", MARVEL_OPF)
+        assert parse_opf_metadata(path)["cover_image_filename"] == "Marvel Multiverse_ Core Rulebook.jpg"
+
+
+# ---------------------------------------------------------------------------
+# parse_opf_metadata — minimal / missing fields
+# ---------------------------------------------------------------------------
+
+class TestParseOpfMetadataMinimal:
+    def setup_method(self):
+        self.tmp = tempfile.mkdtemp()
+
+    def test_only_title_present(self):
+        path = _write_opf(self.tmp, "minimal.opf", MINIMAL_OPF)
+        meta = parse_opf_metadata(path)
+        assert meta["title"] == "Minimal Book"
+        assert "authors" not in meta
+        assert "publisher" not in meta
+        assert "year" not in meta
+        assert "tags" not in meta
+        assert "description" not in meta
+        assert "cover_image_filename" not in meta
+
+    def test_multiple_authors(self):
+        path = _write_opf(self.tmp, "multi.opf", MULTI_AUTHOR_OPF)
+        assert parse_opf_metadata(path)["authors"] == ["Alice Smith", "Bob Jones"]
+
+    def test_nonexistent_file_returns_empty_dict(self):
+        result = parse_opf_metadata(os.path.join(self.tmp, "nonexistent.opf"))
+        assert result == {}
+
+    def test_malformed_xml_returns_empty_dict(self):
+        path = _write_opf(self.tmp, "bad.opf", "<not valid xml <<>>")
+        assert parse_opf_metadata(path) == {}
+
+    def test_empty_file_returns_empty_dict(self):
+        path = _write_opf(self.tmp, "empty.opf", "")
+        assert parse_opf_metadata(path) == {}
+
+
+# ---------------------------------------------------------------------------
+# parse_opf_metadata — edge cases
+# ---------------------------------------------------------------------------
+
+class TestParseOpfMetadataEdgeCases:
+    def setup_method(self):
+        self.tmp = tempfile.mkdtemp()
+
+    def test_date_year_only(self):
+        opf = dedent("""\
+            <?xml version='1.0' encoding='utf-8'?>
+            <package xmlns="http://www.idpf.org/2007/opf" version="2.0">
+                <metadata xmlns:dc="http://purl.org/dc/elements/1.1/" xmlns:opf="http://www.idpf.org/2007/opf">
+                    <dc:title>Test</dc:title>
+                    <dc:date>2019</dc:date>
+                </metadata>
+            </package>
+        """)
+        path = _write_opf(self.tmp, "test.opf", opf)
+        assert parse_opf_metadata(path)["year"] == 2019
+
+    def test_invalid_date_omitted(self):
+        opf = dedent("""\
+            <?xml version='1.0' encoding='utf-8'?>
+            <package xmlns="http://www.idpf.org/2007/opf" version="2.0">
+                <metadata xmlns:dc="http://purl.org/dc/elements/1.1/" xmlns:opf="http://www.idpf.org/2007/opf">
+                    <dc:title>Test</dc:title>
+                    <dc:date>not-a-date</dc:date>
+                </metadata>
+            </package>
+        """)
+        path = _write_opf(self.tmp, "test.opf", opf)
+        assert "year" not in parse_opf_metadata(path)
+
+    def test_calibre_no_date_sentinel_omitted(self):
+        # Calibre writes 0101-01-01T00:00:00+00:00 when no date is set
+        opf = dedent("""\
+            <?xml version='1.0' encoding='utf-8'?>
+            <package xmlns="http://www.idpf.org/2007/opf" version="2.0">
+                <metadata xmlns:dc="http://purl.org/dc/elements/1.1/" xmlns:opf="http://www.idpf.org/2007/opf">
+                    <dc:title>Test</dc:title>
+                    <dc:date>0101-01-01T00:00:00+00:00</dc:date>
+                </metadata>
+            </package>
+        """)
+        path = _write_opf(self.tmp, "test.opf", opf)
+        assert "year" not in parse_opf_metadata(path)
+
+    def test_description_html_only_becomes_empty_omitted(self):
+        opf = dedent("""\
+            <?xml version='1.0' encoding='utf-8'?>
+            <package xmlns="http://www.idpf.org/2007/opf" version="2.0">
+                <metadata xmlns:dc="http://purl.org/dc/elements/1.1/" xmlns:opf="http://www.idpf.org/2007/opf">
+                    <dc:title>Test</dc:title>
+                    <dc:description>&lt;div&gt;&lt;/div&gt;</dc:description>
+                </metadata>
+            </package>
+        """)
+        path = _write_opf(self.tmp, "test.opf", opf)
+        assert "description" not in parse_opf_metadata(path)
+
+    def test_cover_href_path_stripped_to_filename(self):
+        opf = dedent("""\
+            <?xml version='1.0' encoding='utf-8'?>
+            <package xmlns="http://www.idpf.org/2007/opf" version="2.0">
+                <metadata xmlns:dc="http://purl.org/dc/elements/1.1/" xmlns:opf="http://www.idpf.org/2007/opf">
+                    <dc:title>Test</dc:title>
+                </metadata>
+                <guide>
+                    <reference type="cover" title="Cover" href="subdir/cover.jpg"/>
+                </guide>
+            </package>
+        """)
+        path = _write_opf(self.tmp, "test.opf", opf)
+        assert parse_opf_metadata(path)["cover_image_filename"] == "cover.jpg"
+
+    def test_subjects_lowercased(self):
+        opf = dedent("""\
+            <?xml version='1.0' encoding='utf-8'?>
+            <package xmlns="http://www.idpf.org/2007/opf" version="2.0">
+                <metadata xmlns:dc="http://purl.org/dc/elements/1.1/" xmlns:opf="http://www.idpf.org/2007/opf">
+                    <dc:title>Test</dc:title>
+                    <dc:subject>Science Fiction</dc:subject>
+                    <dc:subject>HORROR</dc:subject>
+                </metadata>
+            </package>
+        """)
+        path = _write_opf(self.tmp, "test.opf", opf)
+        assert parse_opf_metadata(path)["tags"] == ["science fiction", "horror"]
+
+
+# ---------------------------------------------------------------------------
+# Calibre per-book-folder structure — scan_library integration
+# ---------------------------------------------------------------------------
+
+CALIBRE_BOOK_OPF = dedent("""\
+    <?xml version='1.0' encoding='utf-8'?>
+    <package xmlns="http://www.idpf.org/2007/opf" unique-identifier="uuid_id" version="2.0">
+        <metadata xmlns:dc="http://purl.org/dc/elements/1.1/" xmlns:opf="http://www.idpf.org/2007/opf">
+            <dc:title>Player's Handbook</dc:title>
+            <dc:creator opf:role="aut">Wizards of the Coast</dc:creator>
+            <dc:date>2014-08-19T00:00:00+00:00</dc:date>
+            <dc:publisher>Wizards of the Coast</dc:publisher>
+            <dc:subject>tabletop rpg</dc:subject>
+        </metadata>
+        <guide>
+            <reference type="cover" title="Cover" href="cover.jpg"/>
+        </guide>
+    </package>
+""")
+
+
+def _mk_lib():
+    tmp = tempfile.mkdtemp()
+    lib = Path(tmp) / "library"
+    lib.mkdir()
+    return tmp, lib
+
+
+class TestCalibrePerBookFolderStructure:
+    """Calibre exports each book as its own subfolder containing the PDF,
+    metadata.opf, and cover.jpg.  The scanner must pick up metadata.opf
+    and skip cover.jpg."""
+
+    def setup_method(self):
+        self.tmp, self.lib = _mk_lib()
+
+    def _scan(self):
+        db = SessionLocal()
+        try:
+            scan_library(str(self.lib), self.tmp, db)
+        finally:
+            db.close()
+
+    def _get_book(self, title: str):
+        db = SessionLocal()
+        try:
+            return db.query(Book).filter(Book.title == title).first()
+        finally:
+            db.close()
+
+    def _book_folder(self, system: str, category: str, book_name: str) -> Path:
+        d = self.lib / "books" / system / category / book_name
+        d.mkdir(parents=True, exist_ok=True)
+        return d
+
+    def test_metadata_opf_applied_when_no_stem_opf(self):
+        folder = self._book_folder("D&D 5e", "core", "Players Handbook")
+        (folder / "players_handbook.pdf").write_bytes(b"%PDF-1.4")
+        (folder / "metadata.opf").write_text(CALIBRE_BOOK_OPF, encoding="utf-8")
+
+        self._scan()
+
+        book = self._get_book("Player's Handbook")
+        assert book is not None
+        assert book.authors == ["Wizards of the Coast"]
+        assert book.publisher == "Wizards of the Coast"
+        assert book.year == 2014
+        assert "tabletop rpg" in book.tags
+
+    def test_stem_opf_takes_priority_over_metadata_opf(self):
+        stem_opf = dedent("""\
+            <?xml version='1.0' encoding='utf-8'?>
+            <package xmlns="http://www.idpf.org/2007/opf" version="2.0">
+                <metadata xmlns:dc="http://purl.org/dc/elements/1.1/" xmlns:opf="http://www.idpf.org/2007/opf">
+                    <dc:title>Stem Title Wins</dc:title>
+                </metadata>
+            </package>
+        """)
+        folder = self._book_folder("D&D 5e", "core", "Stem Priority Test")
+        (folder / "book.pdf").write_bytes(b"%PDF-1.4")
+        (folder / "book.opf").write_text(stem_opf, encoding="utf-8")
+        (folder / "metadata.opf").write_text(CALIBRE_BOOK_OPF, encoding="utf-8")
+
+        self._scan()
+
+        book = self._get_book("Stem Title Wins")
+        assert book is not None
+
+    def test_cover_jpg_not_indexed_as_book(self):
+        folder = self._book_folder("D&D 5e", "core", "Cover Skip Test")
+        (folder / "players_handbook.pdf").write_bytes(b"%PDF-1.4")
+        (folder / "metadata.opf").write_text(CALIBRE_BOOK_OPF, encoding="utf-8")
+        (folder / "cover.jpg").write_bytes(b"\xff\xd8\xff")  # minimal JPEG header
+
+        self._scan()
+
+        db = SessionLocal()
+        try:
+            cover_book = db.query(Book).filter(Book.filename == "cover.jpg").first()
+        finally:
+            db.close()
+        assert cover_book is None
+
+    def test_book_without_opf_uses_filename_as_title(self):
+        folder = self._book_folder("D&D 5e", "core", "No Metadata")
+        (folder / "dungeon_masters_guide.pdf").write_bytes(b"%PDF-1.4")
+
+        self._scan()
+
+        db = SessionLocal()
+        try:
+            book = db.query(Book).filter(Book.filename == "dungeon_masters_guide.pdf").first()
+        finally:
+            db.close()
+        assert book is not None
+        assert book.title == "dungeon masters guide"

--- a/docs/api.md
+++ b/docs/api.md
@@ -447,3 +447,14 @@ The scanner expects files organized as:
 ```
 
 Game system records are created automatically from the folder names under `books/`. Append `(nsfw)` to a system folder name to mark all its content as explicit.
+
+### OPF sidecar metadata
+
+When a book is first indexed, the scanner looks for an OPF metadata file alongside the PDF. Two locations are checked in order:
+
+1. `<bookname>.opf` — same directory, same stem as the PDF.
+2. `metadata.opf` — same directory (Calibre's per-book-folder format).
+
+Fields read: `dc:title`, `dc:creator` (role=aut → authors), `dc:publisher`, `dc:date` (year), `dc:description` (HTML stripped), `dc:subject` (→ tags). Cover images referenced in the OPF `<guide>` are excluded from the book list automatically.
+
+OPF metadata is applied only on first scan. Subsequent rescans do not overwrite values edited via the API.


### PR DESCRIPTION
## Summary

Fall back to metadata.opf in the same directory when no <stem>.opf exists, supporting Calibre's one-folder-per book export structure
- Filter out Calibre's 0101-01-01 sentinel date so books without a date set don't get year=101
- Document OPF field mapping, file discovery order, and Calibre layout in README and docs/api.md
- Add integration tests for metadata.opf pickup, stem.opf priority, cover image skip, and the date sentinel

## Type of change

- [ ] Bug fix
- [x] New feature
- [ ] Refactor / cleanup
- [ ] Docs / configuration only

## Testing

- [x] Backend tests pass (`pytest -q`)
- [ ] Frontend tests pass (`npm test`)
- [x] Tested manually in the browser

## Notes for reviewer

<!-- Anything that needs extra context, known limitations, or follow-up work. Delete if not needed. -->
