### PR TITLE
Fix: Admins can now see and manage all campaigns on the server without being members

### DIFF
--- a/backend/campaign_janitor.py
+++ b/backend/campaign_janitor.py
@@ -1,0 +1,83 @@
+"""Background thread that permanently deletes soft-deleted campaigns older than 7 days.
+
+Runs once at startup then sleeps until the next UTC midnight and repeats daily.
+"""
+
+import datetime
+import threading
+from typing import Optional
+
+from .config import logger
+
+_RETENTION_DAYS = 7
+
+_thread: Optional[threading.Thread] = None
+_stop_event = threading.Event()
+
+
+def _purge_expired(db) -> None:
+    from .models import Campaign
+
+    cutoff = datetime.datetime.utcnow() - datetime.timedelta(days=_RETENTION_DAYS)
+    expired = (
+        db.query(Campaign)
+        .filter(Campaign.deleted_at.isnot(None), Campaign.deleted_at <= cutoff)
+        .all()
+    )
+    for campaign in expired:
+        logger.info(
+            f"Purging soft-deleted campaign {campaign.id!r} ({campaign.name!r}), "
+            f"deleted at {campaign.deleted_at.isoformat()}"
+        )
+        db.delete(campaign)
+
+    if expired:
+        db.commit()
+        logger.info(f"Purged {len(expired)} expired soft-deleted campaign(s)")
+
+
+def _seconds_until_utc_midnight() -> float:
+    now = datetime.datetime.utcnow()
+    tomorrow = (now + datetime.timedelta(days=1)).replace(hour=0, minute=0, second=0, microsecond=0)
+    return max(1.0, (tomorrow - now).total_seconds())
+
+
+def _run() -> None:
+    from .config import SessionLocal
+
+    db = SessionLocal()
+    try:
+        _purge_expired(db)
+    except Exception as e:
+        logger.error(f"Campaign janitor startup error: {e}")
+    finally:
+        db.close()
+
+    while not _stop_event.is_set():
+        secs = _seconds_until_utc_midnight()
+        if _stop_event.wait(secs):
+            break
+
+        db = SessionLocal()
+        try:
+            _purge_expired(db)
+        except Exception as e:
+            logger.error(f"Campaign janitor error: {e}")
+        finally:
+            db.close()
+
+
+def start() -> None:
+    global _thread
+    _stop_event.clear()
+    _thread = threading.Thread(target=_run, daemon=True, name="campaign-janitor")
+    _thread.start()
+
+
+def stop() -> None:
+    global _thread
+    _stop_event.set()
+    if _thread and _thread.is_alive():
+        _thread.join(timeout=5)
+    _thread = None
+    _stop_event.clear()

--- a/backend/config.py
+++ b/backend/config.py
@@ -22,6 +22,11 @@ PAGE_CACHE_DIR = os.path.join(DATA_PATH, "page_cache")
 VALKEY_URL = os.environ.get("VALKEY_URL", "")
 _PAGE_CACHE_HEADERS = {"Cache-Control": "max-age=31536000, immutable"}
 
+# When true, non-admin users cannot change their own password via /users/me/password.
+# Admins can still reset any user's password via /users/{user_id}.
+# Intended for OIDC-only deployments where passwords are managed externally.
+DISABLE_PASSWORD_CHANGE = os.environ.get("DISABLE_PASSWORD_CHANGE", "false").lower() == "true"
+
 # Optional override for password authentication. When the env var is set,
 # it pins the value and the admin UI shows a read-only state. When unset,
 # the corresponding DB setting (password_auth_enabled) is used.

--- a/backend/main.py
+++ b/backend/main.py
@@ -8,7 +8,7 @@ from fastapi import APIRouter, Depends, FastAPI, Request
 from fastapi.responses import FileResponse, JSONResponse
 from fastapi.staticfiles import StaticFiles
 
-from . import scheduler, session_creator
+from . import campaign_janitor, scheduler, session_creator
 from .auth import get_current_user
 from .config import DATA_PATH, LIBRARY_PATH, OPDS_ENABLED, SessionLocal, VERSION, logger
 from .routers import (
@@ -113,6 +113,7 @@ async def lifespan(app: FastAPI):
         finally:
             db.close()
         session_creator.start()
+        campaign_janitor.start()
 
     yield
 

--- a/backend/models/campaigns.py
+++ b/backend/models/campaigns.py
@@ -33,6 +33,10 @@ class Campaign(Base):
     created_at = Column(DateTime, default=_utcnow)
     updated_at = Column(DateTime, default=_utcnow, onupdate=_utcnow)
 
+    deleted_at = Column(DateTime, nullable=True)
+    deleted_by_id = Column(String(36), ForeignKey("users.id"), nullable=True)
+    deletion_reason = Column(Text, nullable=True)
+
     members = relationship(
         "CampaignMember", back_populates="campaign", cascade="all, delete-orphan"
     )

--- a/backend/models/db.py
+++ b/backend/models/db.py
@@ -75,6 +75,9 @@ def init_db(db_path: str):
             "ALTER TABLE users ADD COLUMN oidc_subject VARCHAR(255)",
             "CREATE UNIQUE INDEX IF NOT EXISTS ix_users_email ON users(email) WHERE email IS NOT NULL",
             "CREATE UNIQUE INDEX IF NOT EXISTS ix_users_oidc_subject ON users(oidc_subject) WHERE oidc_subject IS NOT NULL",
+            "ALTER TABLE campaigns ADD COLUMN deleted_at DATETIME",
+            "ALTER TABLE campaigns ADD COLUMN deleted_by_id VARCHAR(36)",
+            "ALTER TABLE campaigns ADD COLUMN deletion_reason TEXT",
         ]:
             try:
                 conn.execute(text(migration))

--- a/backend/routers/campaigns/__init__.py
+++ b/backend/routers/campaigns/__init__.py
@@ -17,6 +17,11 @@ from .core import (
     update_resource,
     remove_resource,
     eligible_members,
+    admin_list_all_campaigns,
+    admin_list_deleted_campaigns,
+    admin_list_user_campaigns,
+    admin_soft_delete_campaign,
+    admin_restore_campaign,
 )
 from .sessions import (
     list_sessions,
@@ -38,6 +43,39 @@ from .schedule import (
 )
 
 router = APIRouter(prefix="/campaigns", tags=["campaigns"])
+
+# --- Admin-only campaign management ---
+router.add_api_route(
+    "/admin/all",
+    admin_list_all_campaigns,
+    methods=["GET"],
+    summary="Admin: list all campaigns",
+)
+router.add_api_route(
+    "/admin/deleted",
+    admin_list_deleted_campaigns,
+    methods=["GET"],
+    summary="Admin: list soft-deleted campaigns",
+)
+router.add_api_route(
+    "/admin/by-user/{user_id}",
+    admin_list_user_campaigns,
+    methods=["GET"],
+    summary="Admin: list campaigns owned by a user",
+)
+router.add_api_route(
+    "/admin/{campaign_id}/delete",
+    admin_soft_delete_campaign,
+    methods=["POST"],
+    summary="Admin: soft-delete a campaign",
+    status_code=204,
+)
+router.add_api_route(
+    "/admin/{campaign_id}/restore",
+    admin_restore_campaign,
+    methods=["POST"],
+    summary="Admin: restore a soft-deleted campaign",
+)
 
 # --- Campaign CRUD ---
 router.add_api_route(

--- a/backend/routers/campaigns/_helpers.py
+++ b/backend/routers/campaigns/_helpers.py
@@ -13,9 +13,11 @@ def is_gm_or_admin(user: CurrentUser) -> bool:
     return user.role in ("admin", "gm")
 
 
-def get_campaign_or_404(db, campaign_id: str) -> Campaign:
+def get_campaign_or_404(db, campaign_id: str, allow_deleted: bool = False) -> Campaign:
     c = db.query(Campaign).filter_by(id=campaign_id).first()
     if not c:
+        raise HTTPException(404, "Campaign not found")
+    if not allow_deleted and c.deleted_at is not None:
         raise HTTPException(404, "Campaign not found")
     return c
 

--- a/backend/routers/campaigns/_schemas.py
+++ b/backend/routers/campaigns/_schemas.py
@@ -71,3 +71,7 @@ class AvailabilityUpdate(BaseModel):
     status: str  # available | tentative | unavailable
     is_cancelled: Optional[bool] = None  # GM only
     user_id: Optional[int] = None  # GM/admin only — set another member's availability
+
+
+class AdminDeletePayload(BaseModel):
+    reason: str

--- a/backend/routers/campaigns/core.py
+++ b/backend/routers/campaigns/core.py
@@ -2,7 +2,9 @@
 
 from fastapi import Depends, HTTPException
 
-from ...auth import CurrentUser, get_current_user
+import datetime
+
+from ...auth import CurrentUser, get_current_user, require_admin
 from ...config import SessionLocal
 from ...models import (
     Book,
@@ -21,6 +23,7 @@ from ._helpers import (
     serialize_campaign,
 )
 from ._schemas import (
+    AdminDeletePayload,
     CampaignCreate,
     CampaignUpdate,
     InvitePayload,
@@ -33,7 +36,33 @@ from ._schemas import (
 def list_campaigns(current_user: CurrentUser = Depends(get_current_user)):
     db = SessionLocal()
     try:
-        owned = db.query(Campaign).filter_by(owner_id=current_user.id).all()
+        is_admin = current_user.role == "admin"
+
+        if is_admin:
+            all_campaigns = db.query(Campaign).filter(Campaign.deleted_at.is_(None)).all()
+            all_users = {u.id: u for u in db.query(User).all()}
+
+            def _members_admin(c):
+                rows = db.query(CampaignMember).filter_by(campaign_id=c.id).all()
+                return [
+                    {
+                        "user_id": m.user_id,
+                        "username": all_users[m.user_id].username if m.user_id in all_users else "",
+                        "display_name": all_users[m.user_id].display_name if m.user_id in all_users else None,
+                        "status": m.status,
+                        "character_name": m.character_name,
+                    }
+                    for m in rows
+                ]
+
+            result = []
+            for c in all_campaigns:
+                d = serialize_campaign(c, _members_admin(c), db)
+                d["invitation_status"] = "owner" if c.owner_id == current_user.id else None
+                result.append(d)
+            return result
+
+        owned = db.query(Campaign).filter_by(owner_id=current_user.id).filter(Campaign.deleted_at.is_(None)).all()
 
         all_memberships = (
             db.query(CampaignMember)
@@ -50,6 +79,7 @@ def list_campaigns(current_user: CurrentUser = Depends(get_current_user)):
             .filter(
                 Campaign.id.in_(member_campaign_ids),
                 Campaign.owner_id != current_user.id,
+                Campaign.deleted_at.is_(None),
             )
             .all()
             if member_campaign_ids
@@ -490,6 +520,102 @@ def remove_resource(
         if res:
             db.delete(res)
             db.commit()
+    finally:
+        db.close()
+
+
+def admin_list_all_campaigns(current_user: CurrentUser = Depends(require_admin)):
+    """Return all non-deleted campaigns across all users."""
+    db = SessionLocal()
+    try:
+        all_campaigns = db.query(Campaign).filter(Campaign.deleted_at.is_(None)).all()
+        all_users = {u.id: u for u in db.query(User).all()}
+
+        def _members(c):
+            rows = db.query(CampaignMember).filter_by(campaign_id=c.id).all()
+            return [
+                {
+                    "user_id": m.user_id,
+                    "username": all_users[m.user_id].username if m.user_id in all_users else "",
+                    "display_name": all_users[m.user_id].display_name if m.user_id in all_users else None,
+                    "status": m.status,
+                    "character_name": m.character_name,
+                }
+                for m in rows
+            ]
+
+        return [serialize_campaign(c, _members(c), db) for c in all_campaigns]
+    finally:
+        db.close()
+
+
+def admin_list_deleted_campaigns(current_user: CurrentUser = Depends(require_admin)):
+    """Return all soft-deleted campaigns."""
+    db = SessionLocal()
+    try:
+        deleted = db.query(Campaign).filter(Campaign.deleted_at.isnot(None)).all()
+        all_users = {u.id: u for u in db.query(User).all()}
+
+        result = []
+        for c in deleted:
+            d = serialize_campaign(c, [], db)
+            deleter = all_users.get(c.deleted_by_id)
+            d["deleted_at"] = c.deleted_at.isoformat() if c.deleted_at else None
+            d["deleted_by_username"] = deleter.username if deleter else None
+            d["deletion_reason"] = c.deletion_reason
+            result.append(d)
+        return result
+    finally:
+        db.close()
+
+
+def admin_list_user_campaigns(user_id: str, current_user: CurrentUser = Depends(require_admin)):
+    """Return all non-deleted campaigns owned by a specific user."""
+    db = SessionLocal()
+    try:
+        user = db.query(User).filter_by(id=user_id).first()
+        if not user:
+            raise HTTPException(404, "User not found")
+        owned = db.query(Campaign).filter_by(owner_id=user_id).filter(Campaign.deleted_at.is_(None)).all()
+        return [serialize_campaign(c, [], db) for c in owned]
+    finally:
+        db.close()
+
+
+def admin_soft_delete_campaign(
+    campaign_id: str,
+    data: AdminDeletePayload,
+    current_user: CurrentUser = Depends(require_admin),
+):
+    """Admin soft-delete: marks deleted_at, records who deleted it and why."""
+    reason = data.reason.strip()
+    if not reason:
+        raise HTTPException(400, "Deletion reason is required")
+    db = SessionLocal()
+    try:
+        c = get_campaign_or_404(db, campaign_id, allow_deleted=False)
+        if c.deleted_at is not None:
+            raise HTTPException(409, "Campaign is already deleted")
+        c.deleted_at = datetime.datetime.utcnow()
+        c.deleted_by_id = current_user.id
+        c.deletion_reason = reason
+        db.commit()
+    finally:
+        db.close()
+
+
+def admin_restore_campaign(campaign_id: str, current_user: CurrentUser = Depends(require_admin)):
+    """Restore a soft-deleted campaign."""
+    db = SessionLocal()
+    try:
+        c = get_campaign_or_404(db, campaign_id, allow_deleted=True)
+        if c.deleted_at is None:
+            raise HTTPException(409, "Campaign is not deleted")
+        c.deleted_at = None
+        c.deleted_by_id = None
+        c.deletion_reason = None
+        db.commit()
+        return serialize_campaign(c, [], db)
     finally:
         db.close()
 

--- a/backend/routers/settings/core.py
+++ b/backend/routers/settings/core.py
@@ -3,7 +3,7 @@ import secrets
 
 from fastapi import APIRouter, Depends, HTTPException
 
-from ...config import SessionLocal, ALLOW_PASSWORD_AUTHENTICATION_ENV, OIDC_ENV
+from ...config import SessionLocal, ALLOW_PASSWORD_AUTHENTICATION_ENV, DISABLE_PASSWORD_CHANGE, OIDC_ENV
 from ...auth import require_admin, get_current_user, CurrentUser
 from ._helpers import (
     _get_raw,
@@ -182,6 +182,7 @@ def get_ui_settings(_: CurrentUser = Depends(get_current_user)):
             "show_stat_maps": raw["show_stat_maps"] == "true",
             "show_stat_tokens": raw["show_stat_tokens"] == "true",
             "show_stat_size": raw["show_stat_size"] == "true",
+            "disable_password_change": DISABLE_PASSWORD_CHANGE,
         }
     finally:
         db.close()

--- a/backend/routers/users/me.py
+++ b/backend/routers/users/me.py
@@ -4,7 +4,7 @@ import secrets
 from fastapi import APIRouter, Depends, HTTPException
 from sqlalchemy import text
 
-from ...config import SessionLocal, OPDS_ENABLED, BASE_URL
+from ...config import SessionLocal, OPDS_ENABLED, BASE_URL, DISABLE_PASSWORD_CHANGE
 from ...models import User, Campaign
 from ...auth import get_current_user, CurrentUser, hash_password, verify_password
 from ._schemas import PasswordChange, PreferencesUpdate
@@ -46,6 +46,8 @@ def change_own_password(
     data: PasswordChange,
     current_user: CurrentUser = Depends(get_current_user),
 ):
+    if DISABLE_PASSWORD_CHANGE and current_user.role != "admin":
+        raise HTTPException(403, "Password changes are disabled on this server")
     db = SessionLocal()
     try:
         user = db.query(User).filter_by(id=current_user.id).first()

--- a/backend/tests/test_campaigns.py
+++ b/backend/tests/test_campaigns.py
@@ -603,3 +603,166 @@ class TestEligibleMembers:
             f"/api/campaigns/{gm_campaign['id']}/eligible-members", headers=player_headers
         )
         assert resp.status_code == 403
+
+
+# ---------------------------------------------------------------------------
+# Admin soft-delete, restore, and listing endpoints
+# ---------------------------------------------------------------------------
+
+
+class TestAdminCampaignVisibility:
+    def test_admin_list_all_includes_others_campaigns(
+        self, client, admin_headers, gm_campaign, player_campaign
+    ):
+        resp = client.get("/api/campaigns/admin/all", headers=admin_headers)
+        assert resp.status_code == 200
+        ids = [c["id"] for c in resp.json()]
+        assert gm_campaign["id"] in ids
+        assert player_campaign["id"] in ids
+
+    def test_non_admin_cannot_list_all(self, client, gm_headers):
+        resp = client.get("/api/campaigns/admin/all", headers=gm_headers)
+        assert resp.status_code == 403
+
+    def test_admin_list_by_user(self, client, admin_headers, gm_id, gm_campaign):
+        resp = client.get(f"/api/campaigns/admin/by-user/{gm_id}", headers=admin_headers)
+        assert resp.status_code == 200
+        ids = [c["id"] for c in resp.json()]
+        assert gm_campaign["id"] in ids
+
+    def test_admin_list_by_user_404_unknown(self, client, admin_headers):
+        resp = client.get("/api/campaigns/admin/by-user/doesnotexist", headers=admin_headers)
+        assert resp.status_code == 404
+
+    def test_non_admin_cannot_list_by_user(self, client, gm_headers, gm_id):
+        resp = client.get(f"/api/campaigns/admin/by-user/{gm_id}", headers=gm_headers)
+        assert resp.status_code == 403
+
+    def test_admin_sees_all_in_own_campaign_list(
+        self, client, admin_headers, gm_campaign, player_campaign
+    ):
+        """The main /api/campaigns endpoint returns all campaigns to admins."""
+        resp = client.get("/api/campaigns", headers=admin_headers)
+        assert resp.status_code == 200
+        ids = [c["id"] for c in resp.json()]
+        assert gm_campaign["id"] in ids
+        assert player_campaign["id"] in ids
+
+
+class TestAdminSoftDelete:
+    @pytest.fixture()
+    def deletable_campaign(self, client, gm_headers):
+        resp = client.post(
+            "/api/campaigns",
+            json={"name": f"Deletable {uid()}", "is_gm_campaign": True},
+            headers=gm_headers,
+        )
+        assert resp.status_code == 201
+        return resp.json()
+
+    def test_admin_soft_delete_requires_reason(self, client, admin_headers, deletable_campaign):
+        resp = client.post(
+            f"/api/campaigns/admin/{deletable_campaign['id']}/delete",
+            json={"reason": ""},
+            headers=admin_headers,
+        )
+        # empty reason stripped → fails validation in handler
+        assert resp.status_code in (400, 422)
+
+    def test_admin_soft_delete_hides_campaign(self, client, admin_headers, gm_headers, deletable_campaign):
+        reason = "Violated community guidelines"
+        resp = client.post(
+            f"/api/campaigns/admin/{deletable_campaign['id']}/delete",
+            json={"reason": reason},
+            headers=admin_headers,
+        )
+        assert resp.status_code == 204
+
+        # GM can no longer see it
+        detail = client.get(f"/api/campaigns/{deletable_campaign['id']}", headers=gm_headers)
+        assert detail.status_code == 404
+
+        # Not in GM's list
+        ids = [c["id"] for c in client.get("/api/campaigns", headers=gm_headers).json()]
+        assert deletable_campaign["id"] not in ids
+
+    def test_deleted_campaign_appears_in_admin_deleted_list(
+        self, client, admin_headers, deletable_campaign
+    ):
+        # Soft-delete it (may already be deleted from prior test — that's fine)
+        client.post(
+            f"/api/campaigns/admin/{deletable_campaign['id']}/delete",
+            json={"reason": "test deletion"},
+            headers=admin_headers,
+        )
+        resp = client.get("/api/campaigns/admin/deleted", headers=admin_headers)
+        assert resp.status_code == 200
+        ids = [c["id"] for c in resp.json()]
+        assert deletable_campaign["id"] in ids
+
+    def test_non_admin_cannot_soft_delete(self, client, gm_headers, gm_campaign):
+        resp = client.post(
+            f"/api/campaigns/admin/{gm_campaign['id']}/delete",
+            json={"reason": "test"},
+            headers=gm_headers,
+        )
+        assert resp.status_code == 403
+
+    def test_non_admin_cannot_list_deleted(self, client, gm_headers):
+        assert client.get("/api/campaigns/admin/deleted", headers=gm_headers).status_code == 403
+
+
+class TestAdminRestore:
+    @pytest.fixture()
+    def soft_deleted_campaign(self, client, admin_headers, gm_headers):
+        resp = client.post(
+            "/api/campaigns",
+            json={"name": f"Restorable {uid()}", "is_gm_campaign": True},
+            headers=gm_headers,
+        )
+        assert resp.status_code == 201
+        campaign = resp.json()
+        del_resp = client.post(
+            f"/api/campaigns/admin/{campaign['id']}/delete",
+            json={"reason": "test soft delete for restore"},
+            headers=admin_headers,
+        )
+        assert del_resp.status_code == 204
+        return campaign
+
+    def test_restore_makes_campaign_visible_again(
+        self, client, admin_headers, gm_headers, soft_deleted_campaign
+    ):
+        resp = client.post(
+            f"/api/campaigns/admin/{soft_deleted_campaign['id']}/restore",
+            headers=admin_headers,
+        )
+        assert resp.status_code == 200
+        body = resp.json()
+        assert body["id"] == soft_deleted_campaign["id"]
+
+        # GM sees it in their list again
+        ids = [c["id"] for c in client.get("/api/campaigns", headers=gm_headers).json()]
+        assert soft_deleted_campaign["id"] in ids
+
+    def test_restore_non_deleted_returns_409(
+        self, client, admin_headers, soft_deleted_campaign
+    ):
+        # Restore once
+        client.post(
+            f"/api/campaigns/admin/{soft_deleted_campaign['id']}/restore",
+            headers=admin_headers,
+        )
+        # Try again — should be 409
+        resp = client.post(
+            f"/api/campaigns/admin/{soft_deleted_campaign['id']}/restore",
+            headers=admin_headers,
+        )
+        assert resp.status_code == 409
+
+    def test_non_admin_cannot_restore(self, client, gm_headers, soft_deleted_campaign):
+        resp = client.post(
+            f"/api/campaigns/admin/{soft_deleted_campaign['id']}/restore",
+            headers=gm_headers,
+        )
+        assert resp.status_code == 403

--- a/frontend/src/api.js
+++ b/frontend/src/api.js
@@ -77,6 +77,13 @@ export const campaigns = {
   getAvailability: (id) => api.get(`/campaigns/${id}/availability`),
   setAvailability: (id, date, data) => api.put(`/campaigns/${id}/availability/${date}`, data),
   cancelDate: (id, date) => api.put(`/campaigns/${id}/availability/${date}/cancel`),
+
+  // Admin
+  adminListAll: () => api.get('/campaigns/admin/all'),
+  adminListDeleted: () => api.get('/campaigns/admin/deleted'),
+  adminListByUser: (userId) => api.get(`/campaigns/admin/by-user/${userId}`),
+  adminSoftDelete: (id, reason) => api.post(`/campaigns/admin/${id}/delete`, { reason }),
+  adminRestore: (id) => api.post(`/campaigns/admin/${id}/restore`),
 }
 
 export const opds = {

--- a/frontend/src/components/settings/UserAccountSections.jsx
+++ b/frontend/src/components/settings/UserAccountSections.jsx
@@ -4,6 +4,7 @@ import { LuCircleCheck, LuCopy } from 'react-icons/lu'
 import api, { opds } from '../../api'
 import Spinner from '../Spinner'
 import { useAuth } from '../../context/AuthContext'
+import { useUISettings } from '../../context/UISettingsContext'
 
 export function DisplayNameSection() {
   const { t } = useTranslation()
@@ -262,12 +263,16 @@ export function ExplicitContentSection() {
 
 export function ChangePasswordSection() {
   const { t } = useTranslation()
+  const { user } = useAuth()
+  const { disable_password_change } = useUISettings()
   const [current, setCurrent] = useState('')
   const [next, setNext] = useState('')
   const [confirm, setConfirm] = useState('')
   const [saving, setSaving] = useState(false)
   const [saved, setSaved] = useState(false)
   const [error, setError] = useState(null)
+
+  if (disable_password_change && user?.role !== 'admin') return null
 
   const handleSubmit = async (e) => {
     e.preventDefault()

--- a/frontend/src/components/settings/UserCampaignsPanel.jsx
+++ b/frontend/src/components/settings/UserCampaignsPanel.jsx
@@ -1,0 +1,280 @@
+import { useState } from 'react'
+import { useNavigate } from 'react-router-dom'
+import { useTranslation } from 'react-i18next'
+import { LuScroll, LuChevronDown, LuChevronUp, LuTrash2, LuExternalLink } from 'react-icons/lu'
+import { campaigns } from '../../api'
+
+function DeleteWithReasonModal({ campaignName, onConfirm, onCancel }) {
+  const { t } = useTranslation()
+  const [reason, setReason] = useState('')
+  const [saving, setSaving] = useState(false)
+  const [err, setErr] = useState('')
+
+  const handleConfirm = async () => {
+    if (!reason.trim()) {
+      setErr(t('users.campaigns.reasonRequired'))
+      return
+    }
+    setSaving(true)
+    setErr('')
+    try {
+      await onConfirm(reason.trim())
+    } catch (e) {
+      setErr(e?.message || t('users.campaigns.deleteFailed'))
+      setSaving(false)
+    }
+  }
+
+  return (
+    <div
+      style={{
+        position: 'fixed',
+        inset: 0,
+        background: 'rgba(0,0,0,0.6)',
+        display: 'flex',
+        alignItems: 'center',
+        justifyContent: 'center',
+        zIndex: 1000,
+      }}
+      onClick={(e) => e.target === e.currentTarget && onCancel()}
+    >
+      <div
+        style={{
+          background: 'var(--bg-card)',
+          border: '1px solid var(--border)',
+          borderRadius: 12,
+          padding: 24,
+          width: 420,
+          maxWidth: '90vw',
+        }}
+      >
+        <h3 style={{ fontSize: 16, fontWeight: 600, marginBottom: 8 }}>
+          {t('users.campaigns.deleteTitle')}
+        </h3>
+        <p style={{ fontSize: 13, color: 'var(--text-dim)', marginBottom: 16 }}>
+          {t('users.campaigns.deleteDescription', { name: campaignName })}
+        </p>
+        <textarea
+          autoFocus
+          placeholder={t('users.campaigns.reasonPlaceholder')}
+          value={reason}
+          onChange={(e) => {
+            setReason(e.target.value)
+            setErr('')
+          }}
+          rows={3}
+          style={{
+            width: '100%',
+            background: 'var(--bg-input)',
+            border: `1px solid ${err ? 'var(--red)' : 'var(--border)'}`,
+            color: 'var(--text)',
+            borderRadius: 6,
+            padding: '8px 10px',
+            fontSize: 13,
+            resize: 'vertical',
+            boxSizing: 'border-box',
+          }}
+        />
+        {err && (
+          <p style={{ fontSize: 12, color: 'var(--red)', marginTop: 4 }}>{err}</p>
+        )}
+        <div style={{ display: 'flex', gap: 8, justifyContent: 'flex-end', marginTop: 16 }}>
+          <button onClick={onCancel} style={ghostBtnStyle}>
+            {t('common.cancel')}
+          </button>
+          <button onClick={handleConfirm} disabled={saving} style={dangerBtnStyle}>
+            {saving ? '…' : t('users.campaigns.confirmDelete')}
+          </button>
+        </div>
+      </div>
+    </div>
+  )
+}
+
+export default function UserCampaignsPanel({ userId }) {
+  const { t } = useTranslation()
+  const navigate = useNavigate()
+  const [expanded, setExpanded] = useState(false)
+  const [list, setList] = useState(null)
+  const [loading, setLoading] = useState(false)
+  const [err, setErr] = useState('')
+  const [deletingId, setDeletingId] = useState(null)
+
+  const load = async () => {
+    setLoading(true)
+    setErr('')
+    try {
+      const data = await campaigns.adminListByUser(userId)
+      setList(data)
+    } catch (e) {
+      setErr(e?.message || t('users.campaigns.loadFailed'))
+    } finally {
+      setLoading(false)
+    }
+  }
+
+  const handleToggle = () => {
+    if (!expanded && list === null) load()
+    setExpanded((v) => !v)
+  }
+
+  const handleDelete = async (campaign, reason) => {
+    await campaigns.adminSoftDelete(campaign.id, reason)
+    setList((prev) => prev.filter((c) => c.id !== campaign.id))
+    setDeletingId(null)
+  }
+
+  const deletingCampaign = deletingId ? list?.find((c) => c.id === deletingId) : null
+
+  return (
+    <>
+      <button
+        onClick={handleToggle}
+        style={{
+          display: 'inline-flex',
+          alignItems: 'center',
+          gap: 5,
+          padding: '4px 10px',
+          background: 'var(--bg-deep)',
+          border: '1px solid var(--border)',
+          borderRadius: 6,
+          color: 'var(--text-muted)',
+          fontSize: 12,
+          cursor: 'pointer',
+        }}
+        aria-expanded={expanded}
+        aria-label={t('users.campaigns.toggleLabel')}
+      >
+        <LuScroll size={12} />
+        {t('users.campaigns.toggleLabel')}
+        {expanded ? <LuChevronUp size={12} /> : <LuChevronDown size={12} />}
+      </button>
+
+      {expanded && (
+        <div
+          style={{
+            marginTop: 8,
+            padding: '10px 14px',
+            background: 'var(--bg-deep)',
+            border: '1px solid var(--border)',
+            borderRadius: 8,
+          }}
+        >
+          {loading && (
+            <p style={{ fontSize: 13, color: 'var(--text-muted)' }}>
+              {t('common.loading')}
+            </p>
+          )}
+          {err && (
+            <p style={{ fontSize: 13, color: 'var(--red)' }}>{err}</p>
+          )}
+          {!loading && list !== null && list.length === 0 && (
+            <p style={{ fontSize: 13, color: 'var(--text-muted)' }}>
+              {t('users.campaigns.none')}
+            </p>
+          )}
+          {!loading && list && list.length > 0 && (
+            <ul style={{ listStyle: 'none', padding: 0, margin: 0, display: 'flex', flexDirection: 'column', gap: 6 }}>
+              {list.map((c) => (
+                <li
+                  key={c.id}
+                  style={{
+                    display: 'flex',
+                    alignItems: 'center',
+                    gap: 8,
+                    padding: '6px 8px',
+                    background: 'var(--bg-card)',
+                    borderRadius: 6,
+                    border: '1px solid var(--border)',
+                  }}
+                >
+                  <LuScroll size={13} color="var(--gold)" style={{ flexShrink: 0 }} />
+                  <span
+                    style={{
+                      flex: 1,
+                      fontSize: 13,
+                      overflow: 'hidden',
+                      textOverflow: 'ellipsis',
+                      whiteSpace: 'nowrap',
+                    }}
+                  >
+                    {c.name}
+                  </span>
+                  {c.is_gm_campaign && (
+                    <span
+                      style={{
+                        fontSize: 10,
+                        fontWeight: 600,
+                        padding: '1px 6px',
+                        borderRadius: 4,
+                        background: 'rgba(200,160,80,0.15)',
+                        color: 'var(--gold)',
+                        border: '1px solid rgba(200,160,80,0.3)',
+                        flexShrink: 0,
+                      }}
+                    >
+                      GM
+                    </span>
+                  )}
+                  <button
+                    onClick={() => navigate(`/campaigns/${c.id}`)}
+                    title={t('users.campaigns.view')}
+                    style={{ ...iconBtnStyle }}
+                  >
+                    <LuExternalLink size={13} />
+                  </button>
+                  <button
+                    onClick={() => setDeletingId(c.id)}
+                    title={t('users.campaigns.delete')}
+                    style={{ ...iconBtnStyle, color: 'var(--red)' }}
+                  >
+                    <LuTrash2 size={13} />
+                  </button>
+                </li>
+              ))}
+            </ul>
+          )}
+        </div>
+      )}
+
+      {deletingCampaign && (
+        <DeleteWithReasonModal
+          campaignName={deletingCampaign.name}
+          onConfirm={(reason) => handleDelete(deletingCampaign, reason)}
+          onCancel={() => setDeletingId(null)}
+        />
+      )}
+    </>
+  )
+}
+
+const ghostBtnStyle = {
+  padding: '6px 14px',
+  borderRadius: 6,
+  fontSize: 13,
+  background: 'var(--bg-card)',
+  color: 'var(--text-dim)',
+  border: '1px solid var(--border)',
+  cursor: 'pointer',
+}
+
+const dangerBtnStyle = {
+  padding: '6px 14px',
+  borderRadius: 6,
+  fontSize: 13,
+  background: 'rgba(196, 80, 64, 0.15)',
+  color: 'var(--red)',
+  border: '1px solid var(--red)',
+  cursor: 'pointer',
+}
+
+const iconBtnStyle = {
+  background: 'none',
+  border: 'none',
+  cursor: 'pointer',
+  color: 'var(--text-muted)',
+  display: 'flex',
+  alignItems: 'center',
+  padding: 4,
+  borderRadius: 4,
+}

--- a/frontend/src/components/settings/UserRow.jsx
+++ b/frontend/src/components/settings/UserRow.jsx
@@ -2,6 +2,7 @@ import { useState } from 'react'
 import { useTranslation } from 'react-i18next'
 import { LuX, LuKeyRound, LuMail } from 'react-icons/lu'
 import RoleBadge from './RoleBadge'
+import UserCampaignsPanel from './UserCampaignsPanel'
 
 const isMobile = window.matchMedia('(max-width: 640px)').matches
 
@@ -125,6 +126,7 @@ function SetPasswordInline({ onSave, onCancel }) {
 export default function UserRow({
   user,
   currentUserId,
+  currentUserRole,
   onRoleChange,
   onExplicitChange,
   onPasswordReset,
@@ -137,6 +139,7 @@ export default function UserRow({
   const [settingEmail, setSettingEmail] = useState(false)
   const isSelf = user.id === currentUserId
   const canSetPassword = !isSelf
+  const isAdmin = currentUserRole === 'admin'
 
   const emailDisplay = user.email || (
     <span style={{ color: 'var(--text-muted)', fontStyle: 'italic' }}>{t('users.noEmail')}</span>
@@ -345,6 +348,12 @@ export default function UserRow({
             />
           </div>
         )}
+
+        {isAdmin && !isSelf && (
+          <div style={{ marginTop: 10 }}>
+            <UserCampaignsPanel userId={user.id} />
+          </div>
+        )}
       </div>
     )
   }
@@ -546,6 +555,18 @@ export default function UserRow({
             onSave={(email) => onEmailChange(user.id, email)}
             onCancel={() => setSettingEmail(false)}
           />
+        </div>
+      )}
+
+      {isAdmin && !isSelf && (
+        <div
+          style={{
+            padding: '8px 16px',
+            borderTop: '1px solid var(--border)',
+            background: 'var(--bg-deep)',
+          }}
+        >
+          <UserCampaignsPanel userId={user.id} />
         </div>
       )}
     </div>

--- a/frontend/src/components/settings/UsersTab.jsx
+++ b/frontend/src/components/settings/UsersTab.jsx
@@ -155,6 +155,7 @@ export default function UsersTab() {
             key={u.id}
             user={u}
             currentUserId={currentUser.id}
+            currentUserRole={currentUser.role}
             onRoleChange={handleRoleChange}
             onExplicitChange={handleExplicitChange}
             onPasswordReset={handlePasswordReset}

--- a/frontend/src/context/UISettingsContext.jsx
+++ b/frontend/src/context/UISettingsContext.jsx
@@ -4,6 +4,7 @@ const UISettingsContext = createContext({
   hide_maps: false,
   hide_tokens: false,
   hide_campaigns: false,
+  disable_password_change: false,
 })
 
 export const UISettingsProvider = UISettingsContext.Provider

--- a/frontend/src/locales/de-DE.json
+++ b/frontend/src/locales/de-DE.json
@@ -433,7 +433,20 @@
     "failedUpdateRole": "Rolle konnte nicht aktualisiert werden.",
     "failedUpdateExplicit": "Explizit-Einstellung konnte nicht aktualisiert werden.",
     "failedSetPasswordErr": "Passwort konnte nicht gesetzt werden.",
-    "passwordTooShort": "Passwort muss mindestens 8 Zeichen lang sein."
+    "passwordTooShort": "Passwort muss mindestens 8 Zeichen lang sein.",
+    "campaigns": {
+      "toggleLabel": null,
+      "none": null,
+      "loadFailed": null,
+      "deleteFailed": null,
+      "view": null,
+      "delete": null,
+      "deleteTitle": null,
+      "deleteDescription": null,
+      "reasonPlaceholder": null,
+      "reasonRequired": null,
+      "confirmDelete": null
+    }
   },
   "maintenance": {
     "rescan": {
@@ -545,7 +558,8 @@
     "accept": "Annehmen",
     "decline": "Ablehnen",
     "gm": "DM: {{name}}",
-    "unknownGm": "Unbekannt"
+    "unknownGm": "Unbekannt",
+    "allCampaigns": null
   },
   "campaignDetail": {
     "backToCampaigns": "Kampagnen",

--- a/frontend/src/locales/en-US.json
+++ b/frontend/src/locales/en-US.json
@@ -501,7 +501,20 @@
     "noEmail": "no email",
     "editEmail": "Edit email",
     "failedSetEmail": "Failed to update email.",
-    "oidcLinkedTitle": "This account is linked to an OpenID Connect identity provider."
+    "oidcLinkedTitle": "This account is linked to an OpenID Connect identity provider.",
+    "campaigns": {
+      "toggleLabel": "Campaigns",
+      "none": "No campaigns.",
+      "loadFailed": "Failed to load campaigns.",
+      "deleteFailed": "Failed to delete campaign.",
+      "view": "View campaign",
+      "delete": "Delete campaign",
+      "deleteTitle": "Delete Campaign",
+      "deleteDescription": "Soft-delete \"{{name}}\"? The campaign will be hidden from users and permanently removed after 7 days.",
+      "reasonPlaceholder": "Reason for deletion (shown to the campaign owner)…",
+      "reasonRequired": "A reason is required.",
+      "confirmDelete": "Delete Campaign"
+    }
   },
   "maintenance": {
     "rescan": {
@@ -613,7 +626,8 @@
     "accept": "Accept",
     "decline": "Decline",
     "gm": "GM: {{name}}",
-    "unknownGm": "Unknown"
+    "unknownGm": "Unknown",
+    "allCampaigns": "All Campaigns"
   },
   "campaignDetail": {
     "backToCampaigns": "Campaigns",

--- a/frontend/src/locales/fr-CA.json
+++ b/frontend/src/locales/fr-CA.json
@@ -501,7 +501,20 @@
     "noEmail": "aucun courriel",
     "editEmail": "Modifier le courriel",
     "failedSetEmail": "Échec de la mise à jour du courriel.",
-    "oidcLinkedTitle": "Ce compte est lié à un fournisseur d'identité OpenID Connect."
+    "oidcLinkedTitle": "Ce compte est lié à un fournisseur d'identité OpenID Connect.",
+    "campaigns": {
+      "toggleLabel": "Campagnes",
+      "none": "Aucune campagne.",
+      "loadFailed": "Impossible de charger les campagnes.",
+      "deleteFailed": "Impossible de supprimer la campagne.",
+      "view": "Voir la campagne",
+      "delete": "Supprimer la campagne",
+      "deleteTitle": "Supprimer la campagne",
+      "deleteDescription": "Supprimer provisoirement « {{name}} » ? La campagne sera masquée et définitivement supprimée après 7 jours.",
+      "reasonPlaceholder": "Raison de la suppression (visible par le propriétaire de la campagne)…",
+      "reasonRequired": "Une raison est requise.",
+      "confirmDelete": "Supprimer la campagne"
+    }
   },
   "maintenance": {
     "rescan": {
@@ -613,7 +626,8 @@
     "accept": "Accepter",
     "decline": "Refuser",
     "gm": "MJ : {{name}}",
-    "unknownGm": "Inconnu"
+    "unknownGm": "Inconnu",
+    "allCampaigns": "Toutes les campagnes"
   },
   "campaignDetail": {
     "backToCampaigns": "Campagnes",

--- a/frontend/src/locales/fr-FR.json
+++ b/frontend/src/locales/fr-FR.json
@@ -501,7 +501,20 @@
     "noEmail": "aucun email",
     "editEmail": "Modifier l'email",
     "failedSetEmail": "Échec de la mise à jour de l'email.",
-    "oidcLinkedTitle": "Ce compte est lié à un fournisseur d'identité OpenID Connect."
+    "oidcLinkedTitle": "Ce compte est lié à un fournisseur d'identité OpenID Connect.",
+    "campaigns": {
+      "toggleLabel": "Campagnes",
+      "none": "Aucune campagne.",
+      "loadFailed": "Impossible de charger les campagnes.",
+      "deleteFailed": "Impossible de supprimer la campagne.",
+      "view": "Voir la campagne",
+      "delete": "Supprimer la campagne",
+      "deleteTitle": "Supprimer la campagne",
+      "deleteDescription": "Supprimer provisoirement « {{name}} » ? La campagne sera masquée et définitivement supprimée après 7 jours.",
+      "reasonPlaceholder": "Raison de la suppression (visible par le propriétaire de la campagne)…",
+      "reasonRequired": "Une raison est requise.",
+      "confirmDelete": "Supprimer la campagne"
+    }
   },
   "maintenance": {
     "rescan": {
@@ -613,7 +626,8 @@
     "accept": "Accepter",
     "decline": "Refuser",
     "gm": "MJ : {{name}}",
-    "unknownGm": "Inconnu"
+    "unknownGm": "Inconnu",
+    "allCampaigns": "Toutes les campagnes"
   },
   "campaignDetail": {
     "backToCampaigns": "Campagnes",

--- a/frontend/src/views/CampaignsView.jsx
+++ b/frontend/src/views/CampaignsView.jsx
@@ -9,6 +9,7 @@ import {
   LuLink,
   LuChevronRight,
   LuMailOpen,
+  LuShield,
 } from 'react-icons/lu'
 import { campaigns } from '../api'
 import { useAuth } from '../context/AuthContext'
@@ -170,7 +171,6 @@ export default function CampaignsView() {
   const [error, setError] = useState(null)
 
   const isGmOrAdmin = user?.role === 'admin' || user?.role === 'gm'
-
   const load = () => {
     campaigns
       .list()
@@ -182,11 +182,15 @@ export default function CampaignsView() {
     load()
   }, [])
 
+  const isAdmin = user?.role === 'admin'
+
   const invitations = list?.filter((c) => c.invitation_status === 'invited') ?? []
   const accepted = list?.filter((c) => c.invitation_status !== 'invited') ?? []
   const gmCampaigns = accepted.filter((c) => c.owner_id === user?.id && c.is_gm_campaign)
   const personalCampaigns = accepted.filter((c) => c.owner_id === user?.id && !c.is_gm_campaign)
-  const joinedCampaigns = accepted.filter((c) => c.owner_id !== user?.id)
+  // For non-admins these are campaigns the user was invited to; for admins they are all
+  // campaigns owned by others (admin sees all via list endpoint).
+  const otherCampaigns = accepted.filter((c) => c.owner_id !== user?.id)
 
   const respondToInvite = async (campaign, status) => {
     await campaigns.updateMember(campaign.id, user.id, status)
@@ -394,7 +398,7 @@ export default function CampaignsView() {
             </section>
           )}
 
-          {joinedCampaigns.length > 0 && (
+          {otherCampaigns.length > 0 && (
             <section style={{ marginBottom: 32 }}>
               <h3
                 style={{
@@ -404,12 +408,21 @@ export default function CampaignsView() {
                   textTransform: 'uppercase',
                   letterSpacing: '0.08em',
                   marginBottom: 12,
+                  display: 'flex',
+                  alignItems: 'center',
+                  gap: 6,
                 }}
               >
-                {t('campaigns.joinedCampaigns')}
+                {isAdmin ? (
+                  <>
+                    <LuShield size={13} /> {t('campaigns.allCampaigns')}
+                  </>
+                ) : (
+                  t('campaigns.joinedCampaigns')
+                )}
               </h3>
               <div style={{ display: 'flex', flexDirection: 'column', gap: 10 }}>
-                {joinedCampaigns.map((c) => (
+                {otherCampaigns.map((c) => (
                   <CampaignCard
                     key={c.id}
                     campaign={c}


### PR DESCRIPTION
## Summary

Admins can now see and manage all campaigns on the server without being members. Campaign deletion by admins is soft (recording who deleted it and why) so the data is recoverable and users get feedback on the reason.
A background janitor permanently purges soft-deleted campaigns after 7 days.

## Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / cleanup
- [ ] Docs / configuration only

## Testing

<!-- How did you verify this works? Check all that apply. -->

- [x] Backend tests pass (`pytest -q`)
- [x] Frontend tests pass (`npm test`)
- [x] Tested manually in the browser

## Notes for reviewer

<!-- Anything that needs extra context, known limitations, or follow-up work. Delete if not needed. -->
