### PR TITLE
fix(docker): respect WORKERS env var for uvicorn worker count

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -34,4 +34,5 @@ ENV PYTHONUNBUFFERED=1
 
 EXPOSE 9481
 
-CMD ["python", "-m", "uvicorn", "backend.main:app", "--host", "0.0.0.0", "--port", "9481", "--workers", "2"]
+ENV WORKERS=2
+CMD ["sh", "-c", "exec python -m uvicorn backend.main:app --host 0.0.0.0 --port 9481 --workers ${WORKERS}"]


### PR DESCRIPTION
## Summary

Current Dockerfile does not respect the env var setting for uvicorn workers (WORKERS). Uvicorn is always called with `--workers 2`. Fix is simply to use the env var provided and default to 2 when no env var is given.

## Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / cleanup
- [ ] Docs / configuration only

## Testing

- [ ] Backend tests pass (`pytest -q`)
- [ ] Frontend tests pass (`npm test`)
- [ ] Tested manually in the browser

Launched with docker-compose and uvicorn started with the correct number of workers.

## Notes for reviewer


