### PR TITLE
[Docs] Fix incorrect container volume paths in docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -108,8 +108,8 @@ services:
     environment:
       SECRET_KEY: "generate-with-openssl-rand-hex-32"
     volumes:
-      - /path/to/your/library:/library:ro   # read-only — use Filebrowser or Calibre to manage files
-      - /path/to/grimoire/data:/data
+      - /path/to/your/library:/app/library:ro   # read-only — use Filebrowser or Calibre to manage files
+      - /path/to/grimoire/data:/app/data
 ```
 
 ### 5. Example compose files

--- a/docs/faq.md
+++ b/docs/faq.md
@@ -41,12 +41,12 @@ Grimoire expects a specific folder structure inside your library volume mount. T
 
 If your PDFs live directly under the mounted folder (e.g. `RPGs/<GameSystem>/...` without a `books/` subfolder), the scanner will find nothing.
 
-**Fix** — mount your library folder as `/library/books` instead of `/library`:
+**Fix** — mount your library folder as `/app/library/books` instead of `/app/library`:
 
 ```yaml
 volumes:
-  - /path/to/your/rpgs:/library/books:ro
-  - ./grimoire/data:/data
+  - /path/to/your/rpgs:/app/library/books:ro
+  - ./grimoire/data:/app/data
 ```
 
 This lets you keep your existing file structure on the host without adding an extra `books/` folder. After updating the compose file, restart the stack and trigger a rescan from the admin panel.


### PR DESCRIPTION
## Summary

Updated the README minimal compose and the faq.md subfolder-fix snipet to mount at app/library and /app/data, matching the container defaults.## Type of change

- [ ] Bug fix
- [ ] New feature
- [ ] Refactor / cleanup
- [x] Docs / configuration only

## Testing

<!-- How did you verify this works? Check all that apply. -->

- [ ] Backend tests pass (`pytest -q`)
- [ ] Frontend tests pass (`npm test`)
- [ ] Tested manually in the browser

## Notes for reviewer

