### PR TITLE
[Enhancement] Add support for guest access to grimoire campaigns.

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -4,7 +4,7 @@ on:
   push:
     branches:
       - main
-      - "release/v*"
+      - dev
   pull_request:
 
 jobs:

--- a/.github/workflows/edge.yml
+++ b/.github/workflows/edge.yml
@@ -1,5 +1,6 @@
-name: Beta
+name: Edge
 
+# Builds a multi-arch edge image from the dev branch after CI succeeds.
 on:
   workflow_run:
     workflows: ["CI"]
@@ -9,25 +10,17 @@ env:
   IMAGE: ${{ secrets.DOCKERHUB_USERNAME }}/grimoire
 
 jobs:
-  beta:
-    name: Build and push beta
+  edge:
+    name: Build and push edge
     runs-on: ubuntu-latest
     if: |
       github.event.workflow_run.conclusion == 'success' &&
-      startsWith(github.event.workflow_run.head_branch, 'release/v')
+      github.event.workflow_run.head_branch == 'dev'
 
     steps:
       - uses: actions/checkout@v4
         with:
           ref: ${{ github.event.workflow_run.head_sha }}
-
-      # Extract version from branch name: release/v1.9.2 → 1.9.2
-      - name: Parse version from branch
-        id: ver
-        run: |
-          BRANCH="${{ github.event.workflow_run.head_branch }}"
-          VERSION="${BRANCH#release/v}"
-          echo "version=$VERSION" >> "$GITHUB_OUTPUT"
 
       - name: Log in to DockerHub
         uses: docker/login-action@v3
@@ -35,19 +28,22 @@ jobs:
           username: ${{ secrets.DOCKERHUB_USERNAME }}
           password: ${{ secrets.DOCKERHUB_TOKEN }}
 
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v3
+
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3
 
-      - name: Build and push beta
+      - name: Build and push edge
         uses: docker/build-push-action@v6
         with:
           context: .
           push: true
+          platforms: linux/amd64,linux/arm64/v8
           build-args: |
-            APP_VERSION=${{ steps.ver.outputs.version }}-beta
+            APP_VERSION=edge
             COMMIT_HASH=${{ github.event.workflow_run.head_sha }}
           tags: |
-            ${{ env.IMAGE }}:${{ steps.ver.outputs.version }}-beta
             ${{ env.IMAGE }}:edge
           cache-from: type=gha
           cache-to: type=gha,mode=max

--- a/README.md
+++ b/README.md
@@ -406,6 +406,7 @@ After adding files, trigger a **Rescan** in Grimoire (sidebar or Settings → Ma
 | `OPDS_ENABLED` | `false` | Optional, Set to `true` to enable the OPDS catalog. See [OPDS](#opds) below. |
 | `LOG_LEVEL` | `info` | Optional Console/Docker log verbosity: `debug`, `info`, `warning`, `error`, or `critical`. The in-app Logs tab (Settings → Logs) always captures `debug`-level entries regardless of this setting. |
 | `ALLOW_PASSWORD_AUTHENTICATION` | — | Optional, `true` or `false`. When set, pins password authentication on or off and overrides the toggle in Settings → Authentication (the toggle is shown read-only). When unset, the in-app setting is used. First-run admin setup always requires a username and password regardless of this value. |
+| `GUEST_ACCESS_ENABLED` | — | Optional, `true` or `false`. When set, pins guest invite codes on or off and overrides the toggle in Settings → Authentication (the toggle is shown read-only). When unset, the in-app setting is used. See [Guest invites](#guest-invites) below. |
 | `OIDC_*` env vars | — | Optional. Each OIDC setting (`OIDC_ENABLED`, `OIDC_ISSUER_URL`, `OIDC_TOKEN_ISSUER`, `OIDC_AUTHORIZATION_ENDPOINT`, `OIDC_TOKEN_ENDPOINT`, `OIDC_USERINFO_ENDPOINT`, `OIDC_JWKS_URI`, `OIDC_END_SESSION_ENDPOINT`, `OIDC_CLIENT_ID`, `OIDC_CLIENT_SECRET`, `OIDC_SIGNING_ALG`, `OIDC_BUTTON_TEXT`, `OIDC_GROUPS_CLAIM`, `OIDC_PERMISSIONS_CLAIM`, `OIDC_MATCH_BY`, `OIDC_AUTO_LAUNCH`, `OIDC_AUTO_REGISTER`) can be pinned via env. When set, the field is read-only in Settings → Authentication. When unset, the in-app value is used. See [OpenID Connect](#openid-connect) below. |
 
 ### Volumes
@@ -506,6 +507,7 @@ docker compose up -d
 | `admin` | Everything — user management, app settings, metadata editing, rescan |
 | `gm` | Read everything, edit metadata, create GM campaigns |
 | `player` | Read-only access, personal campaigns, session notes |
+| `guest` | Code-only account scoped to a single campaign. No access to the library, maps, tokens, or search. See [Guest invites](#guest-invites). |
 
 Create additional accounts in **Settings → Users** after logging in as admin.
 
@@ -531,6 +533,16 @@ Each user has a **campaign access** toggle (admins manage it per user in **Setti
 - Locks any campaign they **own** to read-only for everyone (players keep view access, lose all edits) until the owner's access is restored.
 
 When OIDC is configured, this flag can be driven by the provider's [permissions claim](#openid-connect) (`campaignAccess`); a missing key leaves access enabled.
+
+### Guest invites
+
+Guests let you share a single campaign with people who don't have full accounts — for example a player who's only joining one game. A guest is a code-only account: no password, no OIDC, and no access to the library, maps, tokens, or search. They can only see the campaign they were invited to (and its shared resources, wiki, and schedule), and can edit only their **own** character name, character art, character sheet, session notes, and availability.
+
+- **Enable it server-wide** in **Settings → Authentication → Guest Access**, or pin it with the `GUEST_ACCESS_ENABLED` environment variable. It's off by default.
+- **Invite from a GM campaign** — open the members roster and use **Guests** (admins and GMs only). Add a guest with a nickname; each guest gets a unique 10-character invite code. A campaign can have multiple guests.
+- **Share the code** with the built-in **Share** button: copy a ready-made message, copy a version for a Discord DM, or open a pre-filled email. The message includes a deep link (`/guest?code=…`) and the code itself.
+- **Manage codes** — regenerate a guest's code (invalidating the old one) or remove the guest entirely (which deletes their guest account and contributions).
+- **Guests log in** from the login screen via **Have an invite code?**, which works even on OIDC-only servers where password login is disabled.
 
 ### Notes wiki
 

--- a/backend/auth.py
+++ b/backend/auth.py
@@ -29,7 +29,7 @@ pwd_context = CryptContext(
 
 bearer_scheme = HTTPBearer(auto_error=False)
 
-ROLES = ("admin", "gm", "player")
+ROLES = ("admin", "gm", "player", "guest")
 
 
 def hash_password(password: str) -> str:
@@ -120,4 +120,17 @@ def require_gm_or_admin(
 ) -> CurrentUser:
     if user.role not in ("admin", "gm"):
         raise HTTPException(403, "GM or admin access required")
+    return user
+
+
+def require_not_guest(
+    user: CurrentUser = Depends(get_current_user),
+) -> CurrentUser:
+    """Block guest accounts from areas outside their invited campaign(s).
+
+    Guests have no access to the shared library, maps, tokens, search, or
+    settings — only the campaign they hold an invite code for.
+    """
+    if user.role == "guest":
+        raise HTTPException(403, "Guests cannot access this area")
     return user

--- a/backend/config.py
+++ b/backend/config.py
@@ -23,11 +23,6 @@ CAMPAIGN_UPLOAD_DIR = os.path.join(DATA_PATH, "campaign_uploads")
 VALKEY_URL = os.environ.get("VALKEY_URL", "")
 _PAGE_CACHE_HEADERS = {"Cache-Control": "max-age=31536000, immutable"}
 
-# When true, non-admin users cannot change their own password via /users/me/password.
-# Admins can still reset any user's password via /users/{user_id}.
-# Intended for OIDC-only deployments where passwords are managed externally.
-DISABLE_PASSWORD_CHANGE = os.environ.get("DISABLE_PASSWORD_CHANGE", "false").lower() == "true"
-
 # Optional override for password authentication. When the env var is set,
 # it pins the value and the admin UI shows a read-only state. When unset,
 # the corresponding DB setting (password_auth_enabled) is used.
@@ -44,6 +39,12 @@ def _bool_env(name: str) -> Optional[bool]:
     if raw is None:
         return None
     return raw.strip().lower() == "true"
+
+
+# Optional override for guest invite codes. When set, it pins the value and the
+# admin UI shows a read-only state. When unset, the DB setting
+# (guest_access_enabled) is used.
+GUEST_ACCESS_ENABLED_ENV: Optional[bool] = _bool_env("GUEST_ACCESS_ENABLED")
 
 
 # OIDC env-var pins. When set, each individual field is locked and the UI

--- a/backend/models/campaigns.py
+++ b/backend/models/campaigns.py
@@ -36,6 +36,11 @@ class Campaign(Base):
     # Relative filename of the campaign banner, stored under DATA_PATH/campaign_uploads/banners/
     banner_path = Column(String(255), nullable=True)
 
+    # Whether this campaign accepts guest invite codes. Gated globally by the
+    # app-level guest_access_enabled setting; this flips true the first time the
+    # owner creates a guest for the campaign.
+    guest_invites_enabled = Column(Boolean, default=False)
+
     # Manual display order for the resource panel's groups, interleaving the
     # built-in type groups (keys "type:book", "type:map", "type:token",
     # "type:file") with GM-defined categories (key "cat:<category_id>"). A list of
@@ -87,6 +92,11 @@ class CampaignMember(Base):
     user_id = Column(String(36), ForeignKey("users.id"), nullable=False)
     status = Column(String(20), default="invited")
     character_name = Column(String(100), nullable=True)
+
+    # Guest membership: a member backed by a guest User. guest_code is the unique
+    # 10-char alphanumeric code that mints a token for this guest.
+    is_guest = Column(Boolean, default=False)
+    guest_code = Column(String(10), nullable=True, index=True)
 
     # Relative filenames under DATA_PATH/campaign_uploads/{art,sheets}/
     character_art_path = Column(String(255), nullable=True)

--- a/backend/models/db.py
+++ b/backend/models/db.py
@@ -95,6 +95,11 @@ def init_db(db_path: str):
             "ALTER TABLE users ADD COLUMN campaign_access BOOLEAN DEFAULT 1",
             "ALTER TABLE campaigns ADD COLUMN resource_group_order JSON DEFAULT '[]'",
             "ALTER TABLE campaign_files ADD COLUMN is_image BOOLEAN DEFAULT 0",
+            "ALTER TABLE users ADD COLUMN is_guest BOOLEAN DEFAULT 0",
+            "ALTER TABLE campaigns ADD COLUMN guest_invites_enabled BOOLEAN DEFAULT 0",
+            "ALTER TABLE campaign_members ADD COLUMN is_guest BOOLEAN DEFAULT 0",
+            "ALTER TABLE campaign_members ADD COLUMN guest_code VARCHAR(10)",
+            "CREATE INDEX IF NOT EXISTS ix_campaign_members_guest_code ON campaign_members(guest_code)",
         ]:
             try:
                 conn.execute(text(migration))

--- a/backend/models/users.py
+++ b/backend/models/users.py
@@ -25,6 +25,10 @@ class User(Base):
     email = Column(String(254), nullable=True, unique=True, index=True)
     hashed_password = Column(String(255), nullable=True)
     role = Column(String(20), default="player")
+    # A guest is a lightweight, code-only account (no password/OIDC) scoped to a
+    # single campaign they were invited to. role is also "guest"; this flag keeps
+    # them out of the invitable-user pool and the user admin list.
+    is_guest = Column(Boolean, default=False)
     allow_explicit = Column(Boolean, default=True)
     # Whether the user may create campaigns, be added to new campaigns, and manage
     # campaign content. Disabling it preserves existing campaigns but locks the user

--- a/backend/routers/auth/__init__.py
+++ b/backend/routers/auth/__init__.py
@@ -1,7 +1,7 @@
 """Auth package — registers public (unauthenticated) and authenticated routes."""
 from fastapi import APIRouter
 
-from .core import auth_config, auth_login, auth_me, auth_setup, auth_status
+from .core import auth_config, auth_login, auth_me, auth_setup, auth_status, guest_login
 
 public_router = APIRouter(prefix="/api/auth", tags=["auth"])
 public_router.add_api_route(
@@ -30,6 +30,16 @@ public_router.add_api_route(
     methods=["POST"],
     summary="Log in",
     description="Authenticates with username and password. Returns a JWT valid for 30 days.",
+)
+public_router.add_api_route(
+    "/guest-login",
+    guest_login,
+    methods=["POST"],
+    summary="Log in as a guest",
+    description=(
+        "Exchanges a campaign guest invite code for a JWT scoped to a guest "
+        "account. Available only when guest access is enabled."
+    ),
 )
 public_router.add_api_route(
     "/config",

--- a/backend/routers/auth/_schemas.py
+++ b/backend/routers/auth/_schemas.py
@@ -7,6 +7,15 @@ class LoginRequest(BaseModel):
     password: str
 
 
+class GuestLoginRequest(BaseModel):
+    code: str
+
+    @field_validator("code")
+    @classmethod
+    def code_clean(cls, v):
+        return (v or "").strip().upper()
+
+
 class SetupRequest(BaseModel):
     username: str
     password: str

--- a/backend/routers/auth/core.py
+++ b/backend/routers/auth/core.py
@@ -9,14 +9,15 @@ from ...auth import (
     verify_password,
 )
 from ...config import SessionLocal
-from ...models import User
+from ...models import Campaign, CampaignMember, User
 from ..settings._helpers import (
     _get_raw,
+    guest_access_effective,
     oidc_effective,
     oidc_is_configured,
     password_auth_effective,
 )
-from ._schemas import LoginRequest, SetupRequest
+from ._schemas import GuestLoginRequest, LoginRequest, SetupRequest
 
 
 def auth_status():
@@ -66,6 +67,36 @@ def auth_login(data: LoginRequest):
         db.close()
 
 
+def guest_login(data: GuestLoginRequest):
+    db = SessionLocal()
+    try:
+        if not guest_access_effective(_get_raw(db)):
+            raise HTTPException(403, "Guest access is disabled")
+        if not data.code:
+            raise HTTPException(401, "Invalid invite code")
+
+        member = (
+            db.query(CampaignMember)
+            .filter_by(guest_code=data.code, is_guest=True, status="accepted")
+            .first()
+        )
+        if not member:
+            raise HTTPException(401, "Invalid invite code")
+
+        user = db.query(User).filter_by(id=member.user_id).first()
+        if not user or user.role != "guest":
+            raise HTTPException(401, "Invalid invite code")
+
+        token = create_token(user.id, user.username, user.role)
+        return {
+            "token": token,
+            "user": {"id": user.id, "username": user.username, "role": user.role},
+            "campaign_id": member.campaign_id,
+        }
+    finally:
+        db.close()
+
+
 def auth_config():
     db = SessionLocal()
     try:
@@ -75,6 +106,7 @@ def auth_config():
         oidc_ready = oidc_is_configured(raw)
         return {
             "password_auth_enabled": password_auth_effective(raw),
+            "guest_access_enabled": guest_access_effective(raw),
             "custom_login_message_enabled": msg_enabled,
             "custom_login_message": raw.get("custom_login_message", "") if msg_enabled else "",
             # OIDC — only expose enough for the login screen to render the button.

--- a/backend/routers/books/__init__.py
+++ b/backend/routers/books/__init__.py
@@ -1,13 +1,19 @@
 """Books package — registers all book routes on a single router."""
-from fastapi import APIRouter
+from fastapi import APIRouter, Depends
 
+from ...auth import require_not_guest
 from .core import list_books, get_book, update_book, serve_book_file, serve_book_thumbnail
 from .pages import get_book_toc, serve_book_page, get_page_text, get_page_words
 from ._helpers import _invalidate_book_cache  # re-exported for library.py
 
 router = APIRouter(prefix="/books", tags=["books"])
 
-router.add_api_route("", list_books, methods=["GET"], summary="List books")
+# Browsing the whole book library is blocked for guests; reading an individual
+# book shared into their campaign (by id) is not.
+router.add_api_route(
+    "", list_books, methods=["GET"], summary="List books",
+    dependencies=[Depends(require_not_guest)],
+)
 router.add_api_route("/{book_id}", get_book, methods=["GET"], summary="Get a book")
 router.add_api_route("/{book_id}", update_book, methods=["PATCH"], summary="Update book metadata")
 router.add_api_route(

--- a/backend/routers/campaigns/__init__.py
+++ b/backend/routers/campaigns/__init__.py
@@ -72,6 +72,13 @@ from .wiki import (
     page_titles,
     reorder_pages,
 )
+from .guests import (
+    create_guest,
+    list_guests,
+    regenerate_guest_code,
+    remove_guest,
+    guest_share_template,
+)
 from .wiki_io import export_wiki, import_wiki
 from .categories import (
     list_categories,
@@ -144,6 +151,40 @@ router.add_api_route(
     remove_member,
     methods=["DELETE"],
     summary="Remove a member",
+    status_code=204,
+)
+
+# --- Guests (code-based, GM-managed) ---
+router.add_api_route(
+    "/{campaign_id}/guests",
+    create_guest,
+    methods=["POST"],
+    summary="Create a guest invite code for a GM campaign",
+    status_code=201,
+)
+router.add_api_route(
+    "/{campaign_id}/guests",
+    list_guests,
+    methods=["GET"],
+    summary="List a campaign's guests and their invite codes",
+)
+router.add_api_route(
+    "/{campaign_id}/guests/{member_id}/regenerate",
+    regenerate_guest_code,
+    methods=["POST"],
+    summary="Regenerate a guest's invite code",
+)
+router.add_api_route(
+    "/{campaign_id}/guests/{member_id}/share-template",
+    guest_share_template,
+    methods=["GET"],
+    summary="Get share text and links for a guest invite code",
+)
+router.add_api_route(
+    "/{campaign_id}/guests/{member_id}",
+    remove_guest,
+    methods=["DELETE"],
+    summary="Remove a guest (deletes the guest account)",
     status_code=204,
 )
 

--- a/backend/routers/campaigns/_helpers.py
+++ b/backend/routers/campaigns/_helpers.py
@@ -103,6 +103,8 @@ def build_members(c: Campaign, db) -> list:
             "status": m.status,
             "character_name": m.character_name,
             "is_owner": False,
+            "is_guest": bool(m.is_guest),
+            "guest_code": m.guest_code if m.is_guest else None,
             "campaign_access": _access(all_users.get(m.user_id)),
             "has_art": bool(m.character_art_path),
             "has_sheet": bool(m.character_sheet_path),

--- a/backend/routers/campaigns/_schemas.py
+++ b/backend/routers/campaigns/_schemas.py
@@ -37,6 +37,10 @@ class InvitePayload(BaseModel):
     user_id: str
 
 
+class GuestCreate(BaseModel):
+    nickname: str = ""
+
+
 class MemberStatusUpdate(BaseModel):
     status: Optional[str] = None  # accepted | declined
     character_name: Optional[str] = None

--- a/backend/routers/campaigns/core.py
+++ b/backend/routers/campaigns/core.py
@@ -89,6 +89,8 @@ def list_campaigns(current_user: CurrentUser = Depends(get_current_user)):
 
 
 def create_campaign(data: CampaignCreate, current_user: CurrentUser = Depends(get_current_user)):
+    if current_user.role == "guest":
+        raise HTTPException(403, "Guests cannot create campaigns")
     if data.is_gm_campaign and not is_gm_or_admin(current_user):
         raise HTTPException(403, "Only GMs and admins can create GM-run campaigns")
 
@@ -249,6 +251,8 @@ def search_resources_global(
     "Abyssal Fall (30x49)" surfaces every map inside it. Folder-path matches are
     ranked above filename-only matches.
     """
+    if current_user.role == "guest":
+        raise HTTPException(403, "Guests cannot browse the library")
     db = SessionLocal()
     try:
         results = []
@@ -307,6 +311,8 @@ def suggested_resources(system_id: str, current_user: CurrentUser = Depends(get_
     Core-category books are flagged `suggested` so the wizard can pre-select them;
     nothing else is suggested. Ordered with suggested (core) books first.
     """
+    if current_user.role == "guest":
+        raise HTTPException(403, "Guests cannot browse the library")
     db = SessionLocal()
     try:
         books = db.query(Book).filter_by(game_system_id=system_id).order_by(Book.title).all()
@@ -479,7 +485,15 @@ def eligible_members(campaign_id: str, current_user: CurrentUser = Depends(get_c
         existing = {
             m.user_id for m in db.query(CampaignMember).filter_by(campaign_id=campaign_id).all()
         }
-        users = db.query(User).filter(User.id != c.owner_id).all()
+        # Guests are not invitable here — they're created via the guest panel.
+        users = (
+            db.query(User)
+            .filter(
+                User.id != c.owner_id,
+                (User.is_guest == False) | (User.is_guest.is_(None)),  # noqa: E712
+            )
+            .all()
+        )
         return [
             {
                 "id": u.id,

--- a/backend/routers/campaigns/guests.py
+++ b/backend/routers/campaigns/guests.py
@@ -1,0 +1,201 @@
+"""Guest invite management: create/list/regenerate/remove per-campaign guests.
+
+A guest is a lightweight, code-only User (role="guest", no password/OIDC) backing
+a CampaignMember. The 10-char alphanumeric guest_code mints a JWT for that guest
+via POST /api/auth/guest-login. Guests are single-campaign: deleting the member
+also deletes the guest User and cascades their notes/availability.
+"""
+
+import secrets
+import string
+import urllib.parse
+
+from fastapi import Depends, HTTPException
+
+from ...auth import CurrentUser, get_current_user
+from ...config import SessionLocal, BASE_URL
+from ...models import Campaign, CampaignMember, User
+from ..settings._helpers import _get_raw, guest_access_effective
+from ._helpers import assert_can_manage, get_campaign_or_404
+from ._schemas import GuestCreate
+
+_CODE_ALPHABET = string.ascii_uppercase + string.digits
+_CODE_LENGTH = 10
+
+
+def _generate_guest_code(db) -> str:
+    """Return a unique 10-char A–Z0–9 code, retrying on the rare collision."""
+    for _ in range(20):
+        code = "".join(secrets.choice(_CODE_ALPHABET) for _ in range(_CODE_LENGTH))
+        if not db.query(CampaignMember).filter_by(guest_code=code).first():
+            return code
+    raise HTTPException(500, "Could not allocate a unique guest code")
+
+
+def _assert_guest_access(db):
+    if not guest_access_effective(_get_raw(db)):
+        raise HTTPException(403, "Guest access is disabled on this server")
+
+
+def _serialize_guest(member: CampaignMember, user: User) -> dict:
+    return {
+        "id": member.id,
+        "user_id": member.user_id,
+        "nickname": user.display_name if user else None,
+        "guest_code": member.guest_code,
+        "status": member.status,
+        "character_name": member.character_name,
+        "has_art": bool(member.character_art_path),
+        "has_sheet": bool(member.character_sheet_path),
+    }
+
+
+def _share_template(campaign: Campaign, nickname: str, code: str) -> dict:
+    """Build copy-paste share text plus a mailto: link carrying the invite code."""
+    link = f"{BASE_URL}/guest?code={code}"
+    greeting = f"Hi {nickname}," if nickname else "Hi,"
+    message = (
+        f"{greeting}\n\n"
+        f'You\'ve been invited as a guest to the campaign "{campaign.name}" on Grimoire.\n\n'
+        f"Open this link and you're in: {link}\n"
+        f"Or go to the login page and enter your invite code: {code}\n"
+    )
+    subject = f'Guest invite to "{campaign.name}"'
+    mailto = (
+        "mailto:?subject="
+        + urllib.parse.quote(subject)
+        + "&body="
+        + urllib.parse.quote(message)
+    )
+    return {
+        "code": code,
+        "link": link,
+        "message": message,
+        "mailto_url": mailto,
+        # Discord has no addressable "DM a user" URL, so the client copies this
+        # text into a DM. Kept distinct in case the wording diverges later.
+        "discord_message": message,
+    }
+
+
+def _get_managed_campaign(db, campaign_id: str, current_user: CurrentUser) -> Campaign:
+    c = get_campaign_or_404(db, campaign_id)
+    assert_can_manage(c, current_user, db)
+    if not c.is_gm_campaign:
+        raise HTTPException(400, "Only GM campaigns support guest invites")
+    return c
+
+
+def _get_guest_member(db, campaign_id: str, member_id: str) -> CampaignMember:
+    member = (
+        db.query(CampaignMember)
+        .filter_by(id=member_id, campaign_id=campaign_id, is_guest=True)
+        .first()
+    )
+    if not member:
+        raise HTTPException(404, "Guest not found")
+    return member
+
+
+def create_guest(
+    campaign_id: str, data: GuestCreate, current_user: CurrentUser = Depends(get_current_user)
+):
+    db = SessionLocal()
+    try:
+        _assert_guest_access(db)
+        c = _get_managed_campaign(db, campaign_id, current_user)
+
+        nickname = (data.nickname or "").strip() or "Guest"
+        code = _generate_guest_code(db)
+
+        guest_user = User(
+            username=f"guest_{secrets.token_hex(8)}",
+            display_name=nickname,
+            role="guest",
+            is_guest=True,
+            hashed_password=None,
+            campaign_access=True,
+        )
+        db.add(guest_user)
+        db.flush()
+
+        member = CampaignMember(
+            campaign_id=campaign_id,
+            user_id=guest_user.id,
+            status="accepted",
+            is_guest=True,
+            guest_code=code,
+        )
+        db.add(member)
+
+        # First guest flips the per-campaign flag on.
+        if not c.guest_invites_enabled:
+            c.guest_invites_enabled = True
+
+        db.commit()
+        db.refresh(member)
+        return _serialize_guest(member, guest_user)
+    finally:
+        db.close()
+
+
+def list_guests(campaign_id: str, current_user: CurrentUser = Depends(get_current_user)):
+    db = SessionLocal()
+    try:
+        _get_managed_campaign(db, campaign_id, current_user)
+        members = (
+            db.query(CampaignMember).filter_by(campaign_id=campaign_id, is_guest=True).all()
+        )
+        users = {u.id: u for u in db.query(User).all()}
+        return [_serialize_guest(m, users.get(m.user_id)) for m in members]
+    finally:
+        db.close()
+
+
+def regenerate_guest_code(
+    campaign_id: str, member_id: str, current_user: CurrentUser = Depends(get_current_user)
+):
+    db = SessionLocal()
+    try:
+        _assert_guest_access(db)
+        _get_managed_campaign(db, campaign_id, current_user)
+        member = _get_guest_member(db, campaign_id, member_id)
+        member.guest_code = _generate_guest_code(db)
+        db.commit()
+        db.refresh(member)
+        user = db.query(User).filter_by(id=member.user_id).first()
+        return _serialize_guest(member, user)
+    finally:
+        db.close()
+
+
+def remove_guest(
+    campaign_id: str, member_id: str, current_user: CurrentUser = Depends(get_current_user)
+):
+    db = SessionLocal()
+    try:
+        _get_managed_campaign(db, campaign_id, current_user)
+        member = _get_guest_member(db, campaign_id, member_id)
+        guest_user = db.query(User).filter_by(id=member.user_id).first()
+        db.delete(member)
+        # Guests are single-campaign — drop the backing User too so no orphan
+        # account lingers. Only ever delete genuine guest accounts.
+        if guest_user and guest_user.is_guest:
+            db.delete(guest_user)
+        db.commit()
+    finally:
+        db.close()
+
+
+def guest_share_template(
+    campaign_id: str, member_id: str, current_user: CurrentUser = Depends(get_current_user)
+):
+    db = SessionLocal()
+    try:
+        c = _get_managed_campaign(db, campaign_id, current_user)
+        member = _get_guest_member(db, campaign_id, member_id)
+        user = db.query(User).filter_by(id=member.user_id).first()
+        nickname = user.display_name if user else ""
+        return _share_template(c, nickname, member.guest_code)
+    finally:
+        db.close()

--- a/backend/routers/maps/__init__.py
+++ b/backend/routers/maps/__init__.py
@@ -1,6 +1,7 @@
 """Maps package — registers all map routes on a single router."""
-from fastapi import APIRouter
+from fastapi import APIRouter, Depends
 
+from ...auth import require_not_guest
 from .core import (
     list_maps,
     list_map_folders,
@@ -13,12 +14,15 @@ from .core import (
 
 router = APIRouter(tags=["maps"])
 
+# Browsing the whole map library is blocked for guests; serving an individual
+# map/thumbnail by id is not, so shared campaign resources still render.
 router.add_api_route(
     "/maps",
     list_maps,
     methods=["GET"],
     summary="List maps",
     description="Returns a paginated list of maps. Filter by `map_type`.",
+    dependencies=[Depends(require_not_guest)],
 )
 router.add_api_route(
     "/map-folders",
@@ -26,6 +30,7 @@ router.add_api_route(
     methods=["GET"],
     summary="List map folders",
     description="Returns all known map folder paths and their associated tags.",
+    dependencies=[Depends(require_not_guest)],
 )
 router.add_api_route(
     "/map-folders",

--- a/backend/routers/search/__init__.py
+++ b/backend/routers/search/__init__.py
@@ -1,6 +1,7 @@
 """Search package — FTS5 full-text search across the library."""
-from fastapi import APIRouter
+from fastapi import APIRouter, Depends
 
+from ...auth import require_not_guest
 from .core import search_library
 
 router = APIRouter(tags=["search"])
@@ -9,6 +10,7 @@ router.add_api_route(
     search_library,
     methods=["GET"],
     summary="Full-text search",
+    dependencies=[Depends(require_not_guest)],
     description=(
         "Searches indexed book pages using SQLite FTS5. Optionally scope to a "
         "single book (`book_id`) or game system (`system_id`). Returns "

--- a/backend/routers/settings/_helpers.py
+++ b/backend/routers/settings/_helpers.py
@@ -1,7 +1,13 @@
 """Shared helpers and defaults for settings endpoints."""
 import re
 
-from ...config import SessionLocal, ALLOW_PASSWORD_AUTHENTICATION_ENV, OIDC_ENV, BASE_URL
+from ...config import (
+    SessionLocal,
+    ALLOW_PASSWORD_AUTHENTICATION_ENV,
+    GUEST_ACCESS_ENABLED_ENV,
+    OIDC_ENV,
+    BASE_URL,
+)
 from ...models import AppSetting
 
 
@@ -26,6 +32,8 @@ _DEFAULTS = {
     "show_stat_tokens": "false",
     "show_stat_size": "true",
     "password_auth_enabled": "true",
+    # Whether GMs/admins may create guest invite codes for their campaigns.
+    "guest_access_enabled": "false",
     "custom_login_message_enabled": "false",
     "custom_login_message": "",
     # OIDC — all stored as strings; "" means unset
@@ -107,6 +115,8 @@ def _to_typed(raw: dict) -> dict:
         "show_stat_size": raw["show_stat_size"] == "true",
         "password_auth_enabled": password_auth_effective(raw),
         "password_auth_env_locked": ALLOW_PASSWORD_AUTHENTICATION_ENV is not None,
+        "guest_access_enabled": guest_access_effective(raw),
+        "guest_access_env_locked": GUEST_ACCESS_ENABLED_ENV is not None,
         "custom_login_message_enabled": raw.get("custom_login_message_enabled", "false") == "true",
         "custom_login_message": raw.get("custom_login_message", ""),
         # OIDC
@@ -138,6 +148,13 @@ def password_auth_effective(raw: dict) -> bool:
     if ALLOW_PASSWORD_AUTHENTICATION_ENV is not None:
         return ALLOW_PASSWORD_AUTHENTICATION_ENV
     return raw.get("password_auth_enabled", "true") == "true"
+
+
+def guest_access_effective(raw: dict) -> bool:
+    """Return the effective guest-access setting, honoring the env override."""
+    if GUEST_ACCESS_ENABLED_ENV is not None:
+        return GUEST_ACCESS_ENABLED_ENV
+    return raw.get("guest_access_enabled", "false") == "true"
 
 
 def oidc_effective(raw: dict) -> dict:

--- a/backend/routers/settings/_schemas.py
+++ b/backend/routers/settings/_schemas.py
@@ -24,6 +24,7 @@ class SettingsPatch(BaseModel):
     campaign_upload_max_file_mb: Optional[int] = None
     campaign_upload_max_total_mb: Optional[int] = None
     password_auth_enabled: Optional[bool] = None
+    guest_access_enabled: Optional[bool] = None
     custom_login_message_enabled: Optional[bool] = None
     custom_login_message: Optional[str] = None  # HTML (sanitized on save)
     # OIDC config

--- a/backend/routers/settings/core.py
+++ b/backend/routers/settings/core.py
@@ -3,7 +3,12 @@ import secrets
 
 from fastapi import APIRouter, Depends, HTTPException
 
-from ...config import SessionLocal, ALLOW_PASSWORD_AUTHENTICATION_ENV, DISABLE_PASSWORD_CHANGE, OIDC_ENV
+from ...config import (
+    SessionLocal,
+    ALLOW_PASSWORD_AUTHENTICATION_ENV,
+    GUEST_ACCESS_ENABLED_ENV,
+    OIDC_ENV,
+)
 from ...auth import require_admin, get_current_user, CurrentUser
 from ._helpers import (
     _get_raw,
@@ -15,6 +20,7 @@ from ._helpers import (
     _OIDC_STRING_FIELDS,
     _OIDC_BOOL_FIELDS,
     password_auth_effective,
+    guest_access_effective,
     sanitize_login_message,
 )
 from ._schemas import SettingsPatch
@@ -86,6 +92,13 @@ def update_settings(data: SettingsPatch, _: CurrentUser = Depends(require_admin)
                     "Password authentication is locked by the ALLOW_PASSWORD_AUTHENTICATION environment variable",
                 )
             _set(db, "password_auth_enabled", "true" if data.password_auth_enabled else "false")
+        if data.guest_access_enabled is not None:
+            if GUEST_ACCESS_ENABLED_ENV is not None:
+                raise HTTPException(
+                    400,
+                    "Guest access is locked by the GUEST_ACCESS_ENABLED environment variable",
+                )
+            _set(db, "guest_access_enabled", "true" if data.guest_access_enabled else "false")
         if data.custom_login_message_enabled is not None:
             _set(
                 db,
@@ -188,10 +201,10 @@ def get_ui_settings(_: CurrentUser = Depends(get_current_user)):
             "show_stat_maps": raw["show_stat_maps"] == "true",
             "show_stat_tokens": raw["show_stat_tokens"] == "true",
             "show_stat_size": raw["show_stat_size"] == "true",
-            "disable_password_change": DISABLE_PASSWORD_CHANGE,
             "campaign_uploads_disabled": raw["campaign_uploads_disabled"] == "true",
             "campaign_upload_max_file_mb": int(raw.get("campaign_upload_max_file_mb") or 0),
             "campaign_upload_max_total_mb": int(raw.get("campaign_upload_max_total_mb") or 0),
+            "guest_access_enabled": guest_access_effective(raw),
         }
     finally:
         db.close()

--- a/backend/routers/systems/__init__.py
+++ b/backend/routers/systems/__init__.py
@@ -1,6 +1,7 @@
 """Systems package — registers all game system routes on a single router."""
-from fastapi import APIRouter
+from fastapi import APIRouter, Depends
 
+from ...auth import require_not_guest
 from .core import (
     get_system,
     list_book_folders,
@@ -11,12 +12,14 @@ from .core import (
 
 router = APIRouter(prefix="/systems", tags=["systems"])
 
+# Browsing systems and their book lists is library browsing — blocked for guests.
 router.add_api_route(
     "",
     list_systems,
     methods=["GET"],
     summary="List all game systems",
     description="Returns all game systems with book counts, tags, genre, and mechanics.",
+    dependencies=[Depends(require_not_guest)],
 )
 router.add_api_route(
     "/{system_id}",
@@ -27,6 +30,7 @@ router.add_api_route(
         "Returns full details for a game system including all associated books "
         "grouped by category."
     ),
+    dependencies=[Depends(require_not_guest)],
 )
 router.add_api_route(
     "/{system_id}/book-folders",

--- a/backend/routers/tokens/__init__.py
+++ b/backend/routers/tokens/__init__.py
@@ -1,6 +1,7 @@
 """Tokens package — registers all token routes on a single router."""
-from fastapi import APIRouter
+from fastapi import APIRouter, Depends
 
+from ...auth import require_not_guest
 from .core import (
     list_tokens,
     list_token_folders,
@@ -13,12 +14,15 @@ from .core import (
 
 router = APIRouter(tags=["tokens"])
 
+# Browsing the whole token library is blocked for guests; serving an individual
+# token/thumbnail by id is not, so shared campaign resources still render.
 router.add_api_route(
     "/tokens",
     list_tokens,
     methods=["GET"],
     summary="List tokens",
     description="Returns a paginated list of tokens.",
+    dependencies=[Depends(require_not_guest)],
 )
 router.add_api_route(
     "/token-folders",
@@ -26,6 +30,7 @@ router.add_api_route(
     methods=["GET"],
     summary="List token folders",
     description="Returns all known token folder paths and their associated tags.",
+    dependencies=[Depends(require_not_guest)],
 )
 router.add_api_route(
     "/token-folders",

--- a/backend/routers/users/core.py
+++ b/backend/routers/users/core.py
@@ -13,7 +13,14 @@ router = APIRouter()
 def list_users(_: CurrentUser = Depends(require_admin)):
     db = SessionLocal()
     try:
-        users = db.query(User).order_by(User.username).all()
+        # Guests are code-only accounts managed per-campaign by their GM; they
+        # never appear in the global user admin list.
+        users = (
+            db.query(User)
+            .filter((User.is_guest == False) | (User.is_guest.is_(None)))  # noqa: E712
+            .order_by(User.username)
+            .all()
+        )
         return [
             {
                 "id": u.id,

--- a/backend/routers/users/me.py
+++ b/backend/routers/users/me.py
@@ -4,7 +4,7 @@ import secrets
 from fastapi import APIRouter, Depends, HTTPException
 from sqlalchemy import text
 
-from ...config import SessionLocal, OPDS_ENABLED, BASE_URL, DISABLE_PASSWORD_CHANGE
+from ...config import SessionLocal, OPDS_ENABLED, BASE_URL
 from ...models import User, Campaign
 from ...auth import get_current_user, CurrentUser, hash_password, verify_password
 from ._schemas import PasswordChange, PreferencesUpdate
@@ -46,8 +46,6 @@ def change_own_password(
     data: PasswordChange,
     current_user: CurrentUser = Depends(get_current_user),
 ):
-    if DISABLE_PASSWORD_CHANGE and current_user.role != "admin":
-        raise HTTPException(403, "Password changes are disabled on this server")
     db = SessionLocal()
     try:
         user = db.query(User).filter_by(id=current_user.id).first()

--- a/backend/tests/test_guests.py
+++ b/backend/tests/test_guests.py
@@ -1,0 +1,202 @@
+"""Tests for the guest invite system (issue #96)."""
+import pytest
+
+
+def _set_guest_access(client, admin_headers, enabled: bool):
+    resp = client.patch(
+        "/api/settings",
+        json={"guest_access_enabled": enabled},
+        headers=admin_headers,
+    )
+    assert resp.status_code == 200, resp.text
+    assert resp.json()["guest_access_enabled"] is enabled
+
+
+@pytest.fixture
+def gm_campaign(client, gm_headers):
+    """A fresh GM campaign owned by the gm fixture user."""
+    resp = client.post(
+        "/api/campaigns",
+        json={"name": "Guest Test Campaign", "is_gm_campaign": True},
+        headers=gm_headers,
+    )
+    assert resp.status_code == 201, resp.text
+    return resp.json()["id"]
+
+
+def test_create_guest_requires_global_setting(client, gm_headers, admin_headers, gm_campaign):
+    _set_guest_access(client, admin_headers, False)
+    resp = client.post(
+        f"/api/campaigns/{gm_campaign}/guests",
+        json={"nickname": "Alice"},
+        headers=gm_headers,
+    )
+    assert resp.status_code == 403
+
+    _set_guest_access(client, admin_headers, True)
+    resp = client.post(
+        f"/api/campaigns/{gm_campaign}/guests",
+        json={"nickname": "Alice"},
+        headers=gm_headers,
+    )
+    assert resp.status_code == 201, resp.text
+    body = resp.json()
+    assert body["nickname"] == "Alice"
+    assert len(body["guest_code"]) == 10
+    assert body["guest_code"].isalnum() and body["guest_code"].isupper()
+
+
+def test_only_owner_manages_guests(client, gm_headers, player_headers, admin_headers, gm_campaign):
+    _set_guest_access(client, admin_headers, True)
+    # A non-owner (player) cannot create guests.
+    resp = client.post(
+        f"/api/campaigns/{gm_campaign}/guests",
+        json={"nickname": "Bob"},
+        headers=player_headers,
+    )
+    assert resp.status_code == 403
+
+
+def test_guest_login_and_scope(client, gm_headers, admin_headers, gm_campaign):
+    _set_guest_access(client, admin_headers, True)
+    created = client.post(
+        f"/api/campaigns/{gm_campaign}/guests",
+        json={"nickname": "Carol"},
+        headers=gm_headers,
+    ).json()
+    code = created["guest_code"]
+
+    # Bad code is rejected.
+    bad = client.post("/api/auth/guest-login", json={"code": "NOPENOPE00"})
+    assert bad.status_code == 401
+
+    # Valid code mints a token + returns the campaign id.
+    login = client.post("/api/auth/guest-login", json={"code": code.lower()})
+    assert login.status_code == 200, login.text
+    data = login.json()
+    assert data["user"]["role"] == "guest"
+    assert data["campaign_id"] == gm_campaign
+    guest_headers = {"Authorization": f"Bearer {data['token']}"}
+
+    # Guest can view their campaign.
+    resp = client.get(f"/api/campaigns/{gm_campaign}", headers=guest_headers)
+    assert resp.status_code == 200
+
+    # Guest can update their own character name + availability.
+    member_id = created["id"]
+    user_id = created["user_id"]
+    patch = client.patch(
+        f"/api/campaigns/{gm_campaign}/members/{user_id}",
+        json={"character_name": "Sir Carol"},
+        headers=guest_headers,
+    )
+    assert patch.status_code == 200, patch.text
+    assert patch.json()["character_name"] == "Sir Carol"
+
+    # Guest is locked out of library browsing, maps, tokens, search, systems.
+    for path in ("/api/books", "/api/maps", "/api/tokens", "/api/search?q=x", "/api/systems"):
+        r = client.get(path, headers=guest_headers)
+        assert r.status_code == 403, f"{path} should be 403 for guests, got {r.status_code}"
+
+    # Guest cannot create a campaign.
+    r = client.post(
+        "/api/campaigns",
+        json={"name": "Sneaky", "is_gm_campaign": False},
+        headers=guest_headers,
+    )
+    assert r.status_code == 403
+
+
+def test_regenerate_invalidates_old_code(client, gm_headers, admin_headers, gm_campaign):
+    _set_guest_access(client, admin_headers, True)
+    created = client.post(
+        f"/api/campaigns/{gm_campaign}/guests",
+        json={"nickname": "Dave"},
+        headers=gm_headers,
+    ).json()
+    old_code = created["guest_code"]
+    member_id = created["id"]
+
+    regen = client.post(
+        f"/api/campaigns/{gm_campaign}/guests/{member_id}/regenerate",
+        headers=gm_headers,
+    )
+    assert regen.status_code == 200, regen.text
+    new_code = regen.json()["guest_code"]
+    assert new_code != old_code
+
+    assert client.post("/api/auth/guest-login", json={"code": old_code}).status_code == 401
+    assert client.post("/api/auth/guest-login", json={"code": new_code}).status_code == 200
+
+
+def test_share_template(client, gm_headers, admin_headers, gm_campaign):
+    _set_guest_access(client, admin_headers, True)
+    created = client.post(
+        f"/api/campaigns/{gm_campaign}/guests",
+        json={"nickname": "Eve"},
+        headers=gm_headers,
+    ).json()
+    member_id = created["id"]
+    code = created["guest_code"]
+
+    resp = client.get(
+        f"/api/campaigns/{gm_campaign}/guests/{member_id}/share-template",
+        headers=gm_headers,
+    )
+    assert resp.status_code == 200, resp.text
+    body = resp.json()
+    assert code in body["message"]
+    assert code in body["link"]
+    assert body["mailto_url"].startswith("mailto:?")
+
+
+def test_remove_guest_deletes_account(client, gm_headers, admin_headers, gm_campaign):
+    _set_guest_access(client, admin_headers, True)
+    created = client.post(
+        f"/api/campaigns/{gm_campaign}/guests",
+        json={"nickname": "Frank"},
+        headers=gm_headers,
+    ).json()
+    member_id = created["id"]
+    code = created["guest_code"]
+
+    resp = client.delete(
+        f"/api/campaigns/{gm_campaign}/guests/{member_id}",
+        headers=gm_headers,
+    )
+    assert resp.status_code == 204
+
+    # The code no longer logs in.
+    assert client.post("/api/auth/guest-login", json={"code": code}).status_code == 401
+
+    # The guest does not appear in the global user list.
+    users = client.get("/api/users", headers=admin_headers).json()
+    assert all(u["id"] != created["user_id"] for u in users)
+
+
+def test_guests_not_in_eligible_members(client, gm_headers, admin_headers, gm_campaign):
+    _set_guest_access(client, admin_headers, True)
+    client.post(
+        f"/api/campaigns/{gm_campaign}/guests",
+        json={"nickname": "Grace"},
+        headers=gm_headers,
+    )
+    eligible = client.get(
+        f"/api/campaigns/{gm_campaign}/eligible-members", headers=gm_headers
+    ).json()
+    assert all(u["role"] != "guest" for u in eligible)
+
+
+def test_non_gm_campaign_rejects_guests(client, gm_headers, admin_headers):
+    _set_guest_access(client, admin_headers, True)
+    personal = client.post(
+        "/api/campaigns",
+        json={"name": "Personal", "is_gm_campaign": False},
+        headers=gm_headers,
+    ).json()["id"]
+    resp = client.post(
+        f"/api/campaigns/{personal}/guests",
+        json={"nickname": "Heidi"},
+        headers=gm_headers,
+    )
+    assert resp.status_code == 400

--- a/docs/api.md
+++ b/docs/api.md
@@ -15,7 +15,7 @@ The live API is self-documented via OpenAPI. With the server running:
 
 ## Authentication
 
-All endpoints except `/api/auth/status`, `/api/auth/setup`, `/api/auth/login`, and `/api/auth/config` require a JWT.
+All endpoints except `/api/auth/status`, `/api/auth/setup`, `/api/auth/login`, `/api/auth/guest-login`, and `/api/auth/config` require a JWT.
 
 **Header** (preferred for API clients):
 ```
@@ -46,9 +46,10 @@ Tokens are returned by `/api/auth/login` and expire after **30 days**.
 | Endpoint | Method | Auth | Description |
 |----------|--------|------|-------------|
 | `/api/auth/status` | GET | — | Returns `{"initialized": bool}` — used by the frontend to decide whether to show first-run setup |
-| `/api/auth/config` | GET | — | Public auth configuration for the login screen: `{password_auth_enabled, custom_login_message_enabled, custom_login_message, oidc_enabled, oidc_button_text, oidc_auto_launch}`. The custom message is only returned when its toggle is on. OIDC fields are only true/non-empty when the IdP is fully configured. |
+| `/api/auth/config` | GET | — | Public auth configuration for the login screen: `{password_auth_enabled, guest_access_enabled, custom_login_message_enabled, custom_login_message, oidc_enabled, oidc_button_text, oidc_auto_launch}`. The custom message is only returned when its toggle is on. OIDC fields are only true/non-empty when the IdP is fully configured. |
 | `/api/auth/setup` | POST | — | First-run admin account creation. Body: `{username, password}`. Returns `{token, user}`. Fails with 400 if any users exist. |
 | `/api/auth/login` | POST | — | Authenticate. Body: `{username, password}`. Returns `{token, user}`. Returns 403 if password authentication is disabled. |
+| `/api/auth/guest-login` | POST | — | Exchange a campaign guest invite code for a JWT. Body: `{code}`. Returns `{token, user, campaign_id}`. Returns 403 if guest access is disabled, 401 for an unknown/expired code. |
 | `/api/auth/me` | GET | any | Current user: `{id, username, display_name, email, role, allow_explicit, campaign_access, oidc_linked}` |
 | `/api/auth/openid/login` | GET | — | Start an OIDC login. Redirects to the IdP. Optional `?return_to=/path` to redirect after callback. Returns 503 if OIDC isn't configured. |
 | `/api/auth/openid/callback` | GET | — | OIDC callback. Validates the code, finds/creates the local user, and redirects to the frontend with `#oidc_token=<jwt>`. |
@@ -236,6 +237,20 @@ Bookmarks are per-user — users cannot see or modify each other's bookmarks.
 
 Member statuses: `invited` → `accepted` or `declined`
 
+#### Guests
+
+Guests are code-only accounts (role `guest`) scoped to a single GM campaign. All endpoints require the campaign owner and a server with guest access enabled (the global `guest_access_enabled` setting, or the `GUEST_ACCESS_ENABLED` env pin); otherwise they return 403. Guest members appear in the campaign-detail member list flagged with `is_guest: true`.
+
+| Endpoint | Method | Auth | Description |
+|----------|--------|------|-------------|
+| `/api/campaigns/:id/guests` | POST | owner | Create a guest. Body: `{nickname}`. Returns `{id, user_id, nickname, guest_code, status, ...}` with a unique 10-char code. GM campaigns only (400 otherwise). |
+| `/api/campaigns/:id/guests` | GET | owner | List the campaign's guests with their codes. |
+| `/api/campaigns/:id/guests/:member_id/regenerate` | POST | owner | Issue a new code for a guest, invalidating the old one. |
+| `/api/campaigns/:id/guests/:member_id/share-template` | GET | owner | Returns share content: `{code, link, message, mailto_url, discord_message}`. `link` is a `/guest?code=…` deep link built from `BASE_URL`. |
+| `/api/campaigns/:id/guests/:member_id` | DELETE | owner | Remove a guest; also deletes the backing guest account and its contributions. |
+
+Guests authenticate via [`/api/auth/guest-login`](#auth) and may write only their own character name, art, sheet, session notes, and availability — everything else is read-only. The shared library, maps, tokens, and search return 403 for guests.
+
 #### Banner, character art & sheets
 
 Files are stored on disk under `DATA_PATH/campaign_uploads/`. Banners are keyed by campaign id; character art and sheets are keyed by the **CampaignMember id** (`member.id` from the campaign-detail response), so a player in multiple campaigns gets a distinct file per membership. Image uploads (banner, art) accept PNG/JPEG/WebP/GIF up to 5 MB; sheets additionally accept PDF up to 15 MB. Serving endpoints accept the `?token=` query param for use in `<img>`/download URLs.
@@ -399,6 +414,7 @@ Availability statuses: `available`, `tentative`, `unavailable`
 | `show_stat_size` | bool | Show/hide library size in sidebar |
 | `show_stat_version` | bool | Show/hide version in sidebar |
 | `password_auth_enabled` | bool | Allow password sign-in. Cannot be patched if `ALLOW_PASSWORD_AUTHENTICATION` is set in the environment (returns 400). The `password_auth_env_locked` field on the GET response indicates whether the env override is active. |
+| `guest_access_enabled` | bool | Allow GMs/admins to create guest invite codes. Cannot be patched if `GUEST_ACCESS_ENABLED` is set in the environment (returns 400). The `guest_access_env_locked` field on the GET response indicates whether the env override is active. |
 | `custom_login_message_enabled` | bool | Show a custom message above the sign-in form |
 | `custom_login_message` | string | HTML for the login message. Sanitized server-side: only `<b>`, `<strong>`, `<i>`, `<em>`, `<s>`, `<strike>`, `<del>`, `<u>`, `<p>`, `<br>`, `<ul>`, `<ol>`, `<li>`, and `<a href>` (http/https/mailto/relative) are allowed; everything else is dropped. |
 | `oidc_enabled` | bool | Master toggle for OIDC sign-in. Has no effect until issuer / client id / client secret are also set. |

--- a/frontend/src/api.js
+++ b/frontend/src/api.js
@@ -44,6 +44,14 @@ export const campaigns = {
   removeMember: (id, userId) => api.delete(`/campaigns/${id}/members/${userId}`),
   eligibleMembers: (id) => api.get(`/campaigns/${id}/eligible-members`),
 
+  // Guests (code-based, GM-managed)
+  listGuests: (id) => api.get(`/campaigns/${id}/guests`),
+  createGuest: (id, nickname) => api.post(`/campaigns/${id}/guests`, { nickname }),
+  regenerateGuestCode: (id, memberId) => api.post(`/campaigns/${id}/guests/${memberId}/regenerate`),
+  removeGuest: (id, memberId) => api.delete(`/campaigns/${id}/guests/${memberId}`),
+  guestShareTemplate: (id, memberId) =>
+    api.get(`/campaigns/${id}/guests/${memberId}/share-template`),
+
   // Banner (keyed by campaign id)
   uploadBanner: (id, file) => api.upload(`/campaigns/${id}/banner`, file),
   deleteBanner: (id) => api.delete(`/campaigns/${id}/banner`),
@@ -152,6 +160,11 @@ export const campaigns = {
 
   // Admin: read-only view of a user's campaigns (user page)
   adminListByUser: (userId) => api.get(`/campaigns/admin/by-user/${userId}`),
+}
+
+export const auth = {
+  config: () => api.get('/auth/config'),
+  guestLogin: (code) => api.post('/auth/guest-login', { code }),
 }
 
 export const opds = {

--- a/frontend/src/components/AppShell.jsx
+++ b/frontend/src/components/AppShell.jsx
@@ -1,5 +1,5 @@
 import { useState, useEffect } from 'react'
-import { Routes, Route, Navigate, useLocation } from 'react-router-dom'
+import { Routes, Route, Navigate, useLocation, useNavigate } from 'react-router-dom'
 import useScrollRestoration from '../hooks/useScrollRestoration'
 import { useAuth } from '../context/AuthContext'
 import { UISettingsProvider } from '../context/UISettingsContext'
@@ -42,6 +42,8 @@ export default function AppShell() {
       return next
     })
   const location = useLocation()
+  const navigate = useNavigate()
+  const isGuest = user?.role === 'guest'
   const isReader =
     location.pathname.startsWith('/library/book/') ||
     location.pathname.startsWith('/maps/') ||
@@ -69,6 +71,17 @@ export default function AppShell() {
     }
   }, [])
 
+  // After a guest logs in via an invite code, drop them straight into the
+  // campaign the code belongs to.
+  useEffect(() => {
+    const target = sessionStorage.getItem('grimoire:guest_campaign')
+    if (target) {
+      sessionStorage.removeItem('grimoire:guest_campaign')
+      navigate(`/campaigns/${target}/overview`, { replace: true })
+    }
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [])
+
   return (
     <UISettingsProvider value={uiSettings}>
       <div style={{ display: 'flex', height: '100vh' }}>
@@ -93,24 +106,38 @@ export default function AppShell() {
             paddingBottom: isMobile ? 64 : 0,
           }}
         >
-          <Routes>
-            <Route path="/" element={<Navigate to="/library" replace />} />
-            <Route path="/library" element={<LibraryView />} />
-            <Route path="/library/system/:systemId" element={<SystemDetailView />} />
-            <Route path="/library/book/:bookId" element={<BookReader />} />
-            <Route path="/maps" element={<MapsView />} />
-            <Route path="/maps/:mapId" element={<MapDetailView />} />
-            <Route path="/tokens" element={<TokensView />} />
-            <Route path="/tokens/:tokenId" element={<TokenDetailView />} />
-            <Route path="/search" element={<SearchView />} />
-            <Route path="/favorites" element={<FavoritesView />} />
-            <Route path="/campaigns" element={<CampaignsView />} />
-            <Route path="/campaigns/:campaignId" element={<Navigate to="overview" replace />} />
-            <Route path="/campaigns/:campaignId/notes" element={<CampaignNotesView />} />
-            <Route path="/campaigns/:campaignId/:tab" element={<CampaignDetailView />} />
-            <Route path="/settings" element={<Navigate to="/settings/account" replace />} />
-            <Route path="/settings/:tab" element={<SettingsView user={user} onLogout={logout} />} />
-          </Routes>
+          {isGuest ? (
+            // Guests are scoped to their campaign(s); everything else redirects.
+            <Routes>
+              <Route path="/campaigns" element={<CampaignsView />} />
+              <Route path="/campaigns/:campaignId" element={<Navigate to="overview" replace />} />
+              <Route path="/campaigns/:campaignId/notes" element={<CampaignNotesView />} />
+              <Route path="/campaigns/:campaignId/:tab" element={<CampaignDetailView />} />
+              <Route path="*" element={<Navigate to="/campaigns" replace />} />
+            </Routes>
+          ) : (
+            <Routes>
+              <Route path="/" element={<Navigate to="/library" replace />} />
+              <Route path="/library" element={<LibraryView />} />
+              <Route path="/library/system/:systemId" element={<SystemDetailView />} />
+              <Route path="/library/book/:bookId" element={<BookReader />} />
+              <Route path="/maps" element={<MapsView />} />
+              <Route path="/maps/:mapId" element={<MapDetailView />} />
+              <Route path="/tokens" element={<TokensView />} />
+              <Route path="/tokens/:tokenId" element={<TokenDetailView />} />
+              <Route path="/search" element={<SearchView />} />
+              <Route path="/favorites" element={<FavoritesView />} />
+              <Route path="/campaigns" element={<CampaignsView />} />
+              <Route path="/campaigns/:campaignId" element={<Navigate to="overview" replace />} />
+              <Route path="/campaigns/:campaignId/notes" element={<CampaignNotesView />} />
+              <Route path="/campaigns/:campaignId/:tab" element={<CampaignDetailView />} />
+              <Route path="/settings" element={<Navigate to="/settings/account" replace />} />
+              <Route
+                path="/settings/:tab"
+                element={<SettingsView user={user} onLogout={logout} />}
+              />
+            </Routes>
+          )}
         </main>
 
         {isMobile && <MobileSidebar user={user} onLogout={logout} uiSettings={uiSettings} />}

--- a/frontend/src/components/MobileSidebar.jsx
+++ b/frontend/src/components/MobileSidebar.jsx
@@ -15,10 +15,11 @@ import {
 } from 'react-icons/lu'
 import MoreItem, { moreItemStyle } from './MoreItem'
 
-export default function MobileSidebar({ onLogout, uiSettings = {} }) {
+export default function MobileSidebar({ user, onLogout, uiSettings = {} }) {
   const { t } = useTranslation()
   const [moreOpen, setMoreOpen] = useState(false)
   const location = useLocation()
+  const isGuest = user?.role === 'guest'
   const { hide_maps, hide_tokens, hide_campaigns } = uiSettings
   const moreRoutes = [
     '/settings',
@@ -26,6 +27,35 @@ export default function MobileSidebar({ onLogout, uiSettings = {} }) {
     ...(!hide_tokens ? ['/tokens'] : []),
   ]
   const moreActive = moreRoutes.some((r) => location.pathname.startsWith(r))
+
+  if (isGuest) {
+    // Guests only have their campaign(s); show a minimal bar.
+    return (
+      <div
+        style={{
+          position: 'fixed',
+          bottom: 0,
+          left: 0,
+          right: 0,
+          zIndex: 100,
+          background: 'var(--bg-panel)',
+          borderTop: '1px solid var(--border)',
+          display: 'flex',
+          justifyContent: 'space-around',
+          padding: '8px 0',
+        }}
+      >
+        <NavLink to="/campaigns" end={false} style={({ isActive }) => mobileNavStyle(isActive)}>
+          <LuScroll size={20} />
+          {t('nav.campaigns')}
+        </NavLink>
+        <button onClick={onLogout} style={mobileNavStyle(false)}>
+          <LuLogOut size={20} />
+          {t('nav.logOut')}
+        </button>
+      </div>
+    )
+  }
 
   return (
     <>

--- a/frontend/src/components/Sidebar.jsx
+++ b/frontend/src/components/Sidebar.jsx
@@ -64,6 +64,9 @@ export default function Sidebar({
   onToggleCollapse,
 }) {
   const { t } = useTranslation()
+  // Guests only see their campaign(s) — no library, maps, tokens, search,
+  // favorites, or settings.
+  const isGuest = user?.role === 'guest'
   const hide_maps = uiSettings.hide_maps
   const hide_tokens = uiSettings.hide_tokens
   const hide_campaigns = uiSettings.hide_campaigns
@@ -180,14 +183,16 @@ export default function Sidebar({
         aria-label="Main navigation"
         style={{ padding: collapsed ? '12px 8px' : '12px 8px', flex: 1 }}
       >
-        {navItem('/library', <LuLibrary size={16} />, t('nav.library'), { end: false })}
-        {!hide_maps && navItem('/maps', <LuMap size={16} />, t('nav.maps'))}
-        {!hide_tokens && navItem('/tokens', <LuUser size={16} />, t('nav.tokens'))}
-        {navItem('/search', <LuSearch size={16} />, t('nav.search'))}
+        {!isGuest && navItem('/library', <LuLibrary size={16} />, t('nav.library'), { end: false })}
+        {!isGuest && !hide_maps && navItem('/maps', <LuMap size={16} />, t('nav.maps'))}
+        {!isGuest && !hide_tokens && navItem('/tokens', <LuUser size={16} />, t('nav.tokens'))}
+        {!isGuest && navItem('/search', <LuSearch size={16} />, t('nav.search'))}
 
-        <div style={{ margin: '12px 8px 8px', borderTop: '1px solid var(--border)' }} />
+        {!isGuest && (
+          <div style={{ margin: '12px 8px 8px', borderTop: '1px solid var(--border)' }} />
+        )}
 
-        {navItem('/favorites', <LuHeart size={16} />, t('nav.favorites'))}
+        {!isGuest && navItem('/favorites', <LuHeart size={16} />, t('nav.favorites'))}
         {!hide_campaigns && navItem('/campaigns', <LuScroll size={16} />, t('nav.campaigns'))}
       </nav>
 
@@ -382,24 +387,26 @@ export default function Sidebar({
               </div>
             </div>
           )}
-          <NavLink
-            to="/settings"
-            title={t('nav.settings')}
-            aria-label={t('nav.settings')}
-            style={({ isActive }) => ({
-              background: 'none',
-              border: '1px solid var(--border)',
-              borderRadius: 6,
-              color: isActive ? 'var(--gold)' : 'var(--text-muted)',
-              padding: '6px',
-              cursor: 'pointer',
-              display: 'flex',
-              alignItems: 'center',
-              textDecoration: 'none',
-            })}
-          >
-            <LuSettings size={14} />
-          </NavLink>
+          {!isGuest && (
+            <NavLink
+              to="/settings"
+              title={t('nav.settings')}
+              aria-label={t('nav.settings')}
+              style={({ isActive }) => ({
+                background: 'none',
+                border: '1px solid var(--border)',
+                borderRadius: 6,
+                color: isActive ? 'var(--gold)' : 'var(--text-muted)',
+                padding: '6px',
+                cursor: 'pointer',
+                display: 'flex',
+                alignItems: 'center',
+                textDecoration: 'none',
+              })}
+            >
+              <LuSettings size={14} />
+            </NavLink>
+          )}
           <button
             onClick={onLogout}
             title={t('nav.logOut')}

--- a/frontend/src/components/campaigns/CampaignMembers.test.jsx
+++ b/frontend/src/components/campaigns/CampaignMembers.test.jsx
@@ -68,6 +68,16 @@ describe('MemberRow', () => {
     expect(screen.getByText('invited')).toBeTruthy()
   })
 
+  it('shows a Guest badge for guest members', () => {
+    renderRow({ is_guest: true, display_name: 'Wanderer' })
+    expect(screen.getByText('Guest')).toBeTruthy()
+  })
+
+  it('does not show a Guest badge for normal members', () => {
+    renderRow({ is_guest: false })
+    expect(screen.queryByText('Guest')).toBeNull()
+  })
+
   it('shows accept/decline buttons for current user with invited status', () => {
     renderRow({ status: 'invited' }, { currentUserId: 'u1' })
     expect(screen.getByRole('button', { name: 'Accept' })).toBeTruthy()

--- a/frontend/src/components/campaigns/GuestPanel.jsx
+++ b/frontend/src/components/campaigns/GuestPanel.jsx
@@ -1,0 +1,275 @@
+import { useState, useEffect } from 'react'
+import { useTranslation } from 'react-i18next'
+import { LuUserPlus, LuRefreshCw, LuTrash2, LuShare2, LuCopy, LuMail } from 'react-icons/lu'
+import { campaigns } from '../../api'
+import Spinner from '../Spinner'
+
+/** GM-only management of a campaign's code-based guests. */
+export default function GuestPanel({ campaignId, onChanged }) {
+  const { t } = useTranslation()
+  const [guests, setGuests] = useState(null)
+  const [nickname, setNickname] = useState('')
+  const [busy, setBusy] = useState(false)
+  const [share, setShare] = useState(null) // { ...template } for the share modal
+  const [copied, setCopied] = useState('')
+
+  const reload = () =>
+    campaigns
+      .listGuests(campaignId)
+      .then(setGuests)
+      .catch(() => setGuests([]))
+
+  useEffect(() => {
+    reload()
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [campaignId])
+
+  const create = async (e) => {
+    e.preventDefault()
+    setBusy(true)
+    try {
+      await campaigns.createGuest(campaignId, nickname.trim())
+      setNickname('')
+      await reload()
+      onChanged?.()
+    } catch (err) {
+      alert(err.message)
+    } finally {
+      setBusy(false)
+    }
+  }
+
+  const regenerate = async (memberId) => {
+    setBusy(true)
+    try {
+      await campaigns.regenerateGuestCode(campaignId, memberId)
+      await reload()
+    } catch (err) {
+      alert(err.message)
+    } finally {
+      setBusy(false)
+    }
+  }
+
+  const remove = async (memberId) => {
+    if (!window.confirm(t('guests.confirmRemove'))) return
+    setBusy(true)
+    try {
+      await campaigns.removeGuest(campaignId, memberId)
+      await reload()
+      onChanged?.()
+    } catch (err) {
+      alert(err.message)
+    } finally {
+      setBusy(false)
+    }
+  }
+
+  const openShare = async (memberId) => {
+    try {
+      const tpl = await campaigns.guestShareTemplate(campaignId, memberId)
+      setShare(tpl)
+    } catch (err) {
+      alert(err.message)
+    }
+  }
+
+  const copy = async (text, key) => {
+    try {
+      await navigator.clipboard.writeText(text)
+      setCopied(key)
+      setTimeout(() => setCopied(''), 1500)
+    } catch {
+      /* clipboard unavailable */
+    }
+  }
+
+  if (!guests) return <Spinner size={16} />
+
+  return (
+    <div style={{ marginTop: 12 }}>
+      <form onSubmit={create} style={{ display: 'flex', gap: 8, marginBottom: 12 }}>
+        <input
+          type="text"
+          value={nickname}
+          onChange={(e) => setNickname(e.target.value)}
+          placeholder={t('guests.nicknamePlaceholder')}
+          maxLength={100}
+          style={{ flex: 1 }}
+        />
+        <button
+          type="submit"
+          disabled={busy}
+          style={{
+            display: 'flex',
+            alignItems: 'center',
+            gap: 5,
+            padding: '6px 12px',
+            background: 'var(--bg-deep)',
+            border: '1px solid var(--border)',
+            borderRadius: 6,
+            color: 'var(--text-dim)',
+            cursor: busy ? 'default' : 'pointer',
+            fontSize: 12,
+          }}
+        >
+          <LuUserPlus size={12} /> {t('guests.add')}
+        </button>
+      </form>
+
+      {guests.length === 0 ? (
+        <div style={{ fontSize: 13, color: 'var(--text-muted)', paddingBottom: 4 }}>
+          {t('guests.none')}
+        </div>
+      ) : (
+        guests.map((g) => (
+          <div
+            key={g.id}
+            style={{ display: 'flex', alignItems: 'center', gap: 8, padding: '6px 0' }}
+          >
+            <span style={{ flex: 1, fontSize: 14, minWidth: 0 }}>
+              {g.nickname || t('guests.guest')}
+              <code
+                style={{
+                  marginLeft: 8,
+                  fontSize: 12,
+                  color: 'var(--gold)',
+                  letterSpacing: '0.1em',
+                }}
+              >
+                {g.guest_code}
+              </code>
+            </span>
+            <IconBtn title={t('guests.share')} onClick={() => openShare(g.id)}>
+              <LuShare2 size={13} />
+            </IconBtn>
+            <IconBtn
+              title={t('guests.regenerate')}
+              onClick={() => regenerate(g.id)}
+              disabled={busy}
+            >
+              <LuRefreshCw size={13} />
+            </IconBtn>
+            <IconBtn title={t('guests.remove')} onClick={() => remove(g.id)} disabled={busy}>
+              <LuTrash2 size={13} />
+            </IconBtn>
+          </div>
+        ))
+      )}
+
+      {share && (
+        <div
+          onClick={() => setShare(null)}
+          style={{
+            position: 'fixed',
+            inset: 0,
+            background: 'rgba(0,0,0,0.5)',
+            display: 'flex',
+            alignItems: 'center',
+            justifyContent: 'center',
+            zIndex: 200,
+            padding: 20,
+          }}
+        >
+          <div
+            onClick={(e) => e.stopPropagation()}
+            style={{
+              background: 'var(--bg-panel)',
+              border: '1px solid var(--border)',
+              borderRadius: 12,
+              padding: 24,
+              maxWidth: 460,
+              width: '100%',
+            }}
+          >
+            <h3 style={{ marginTop: 0, marginBottom: 12, fontSize: 18 }}>
+              {t('guests.shareTitle')}
+            </h3>
+            <textarea
+              readOnly
+              value={share.message}
+              rows={6}
+              style={{ width: '100%', resize: 'vertical', fontSize: 13, marginBottom: 12 }}
+            />
+            <div style={{ display: 'flex', flexWrap: 'wrap', gap: 8 }}>
+              <ShareBtn onClick={() => copy(share.message, 'msg')}>
+                <LuCopy size={13} />{' '}
+                {copied === 'msg' ? t('guests.copied') : t('guests.copyMessage')}
+              </ShareBtn>
+              <ShareBtn onClick={() => copy(share.discord_message, 'discord')}>
+                <LuCopy size={13} />{' '}
+                {copied === 'discord' ? t('guests.copied') : t('guests.copyForDiscord')}
+              </ShareBtn>
+              <a href={share.mailto_url} style={{ textDecoration: 'none' }}>
+                <ShareBtn as="span">
+                  <LuMail size={13} /> {t('guests.email')}
+                </ShareBtn>
+              </a>
+            </div>
+            <button
+              onClick={() => setShare(null)}
+              style={{
+                marginTop: 16,
+                padding: '6px 14px',
+                background: 'var(--bg-deep)',
+                border: '1px solid var(--border)',
+                borderRadius: 6,
+                color: 'var(--text-dim)',
+                cursor: 'pointer',
+                fontSize: 13,
+              }}
+            >
+              {t('common.close')}
+            </button>
+          </div>
+        </div>
+      )}
+    </div>
+  )
+}
+
+function IconBtn({ children, title, onClick, disabled }) {
+  return (
+    <button
+      onClick={onClick}
+      disabled={disabled}
+      title={title}
+      aria-label={title}
+      style={{
+        display: 'flex',
+        alignItems: 'center',
+        padding: 6,
+        background: 'var(--bg-deep)',
+        border: '1px solid var(--border)',
+        borderRadius: 6,
+        color: 'var(--text-dim)',
+        cursor: disabled ? 'default' : 'pointer',
+      }}
+    >
+      {children}
+    </button>
+  )
+}
+
+function ShareBtn({ children, onClick, as = 'button' }) {
+  const Tag = as
+  return (
+    <Tag
+      onClick={onClick}
+      style={{
+        display: 'inline-flex',
+        alignItems: 'center',
+        gap: 5,
+        padding: '6px 12px',
+        background: 'var(--bg-deep)',
+        border: '1px solid var(--border)',
+        borderRadius: 6,
+        color: 'var(--text-dim)',
+        cursor: 'pointer',
+        fontSize: 13,
+      }}
+    >
+      {children}
+    </Tag>
+  )
+}

--- a/frontend/src/components/campaigns/GuestPanel.test.jsx
+++ b/frontend/src/components/campaigns/GuestPanel.test.jsx
@@ -1,0 +1,54 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { render, screen, fireEvent, waitFor } from '@testing-library/react'
+import GuestPanel from './GuestPanel'
+
+vi.mock('../../api', () => ({
+  campaigns: {
+    listGuests: vi.fn(),
+    createGuest: vi.fn(),
+    regenerateGuestCode: vi.fn(),
+    removeGuest: vi.fn(),
+    guestShareTemplate: vi.fn(),
+  },
+}))
+
+import { campaigns } from '../../api'
+
+beforeEach(() => {
+  vi.clearAllMocks()
+})
+
+describe('GuestPanel', () => {
+  it('lists existing guests with their codes', async () => {
+    campaigns.listGuests.mockResolvedValue([
+      { id: 'm1', user_id: 'g1', nickname: 'Alice', guest_code: 'ABC1234567' },
+    ])
+    render(<GuestPanel campaignId="c1" onChanged={vi.fn()} />)
+    expect(await screen.findByText('Alice')).toBeTruthy()
+    expect(screen.getByText('ABC1234567')).toBeTruthy()
+  })
+
+  it('creates a guest and reloads', async () => {
+    campaigns.listGuests.mockResolvedValue([])
+    campaigns.createGuest.mockResolvedValue({
+      id: 'm2',
+      user_id: 'g2',
+      nickname: 'Bob',
+      guest_code: 'XYZ7654321',
+    })
+    const onChanged = vi.fn()
+    render(<GuestPanel campaignId="c1" onChanged={onChanged} />)
+    await screen.findByText(/no guests/i)
+
+    const input = screen.getByPlaceholderText(/nickname/i)
+    fireEvent.change(input, { target: { value: 'Bob' } })
+    // After create, listGuests is called again — return the new guest.
+    campaigns.listGuests.mockResolvedValue([
+      { id: 'm2', user_id: 'g2', nickname: 'Bob', guest_code: 'XYZ7654321' },
+    ])
+    fireEvent.click(screen.getByText(/^Add$/))
+
+    await waitFor(() => expect(campaigns.createGuest).toHaveBeenCalledWith('c1', 'Bob'))
+    expect(onChanged).toHaveBeenCalled()
+  })
+})

--- a/frontend/src/components/campaigns/MemberRow.jsx
+++ b/frontend/src/components/campaigns/MemberRow.jsx
@@ -299,6 +299,22 @@ export default function MemberRow({
               {t('members.gm')}
             </span>
           )}
+          {member.is_guest && (
+            <span
+              style={{
+                fontSize: 11,
+                color: 'var(--text-dim)',
+                fontWeight: 600,
+                background: 'var(--bg-deep)',
+                border: '1px solid var(--border)',
+                borderRadius: 10,
+                padding: '1px 6px',
+                letterSpacing: '0.04em',
+              }}
+            >
+              {t('guests.guest')}
+            </span>
+          )}
           {isCurrentUser && (
             <span style={{ color: 'var(--text-muted)', fontWeight: 400 }}>{t('members.you')}</span>
           )}

--- a/frontend/src/components/settings/AuthenticationTab.jsx
+++ b/frontend/src/components/settings/AuthenticationTab.jsx
@@ -10,6 +10,7 @@ export default function AuthenticationTab() {
   const { t } = useTranslation()
   const [values, setValues] = useState(null)
   const [envLocked, setEnvLocked] = useState(false)
+  const [guestEnvLocked, setGuestEnvLocked] = useState(false)
   const [saving, setSaving] = useState(null)
   const [saved, setSaved] = useState(null)
   const [messageDraft, setMessageDraft] = useState('')
@@ -23,14 +24,21 @@ export default function AuthenticationTab() {
       .then((d) => {
         setValues({
           password_auth_enabled: !!d.password_auth_enabled,
+          guest_access_enabled: !!d.guest_access_enabled,
           custom_login_message_enabled: !!d.custom_login_message_enabled,
         })
         setEnvLocked(!!d.password_auth_env_locked)
+        setGuestEnvLocked(!!d.guest_access_env_locked)
         setMessageDraft(d.custom_login_message || '')
       })
       .catch(() => {
-        setValues({ password_auth_enabled: true, custom_login_message_enabled: false })
+        setValues({
+          password_auth_enabled: true,
+          guest_access_enabled: false,
+          custom_login_message_enabled: false,
+        })
         setEnvLocked(false)
+        setGuestEnvLocked(false)
       })
   }, [])
 
@@ -213,6 +221,70 @@ export default function AuthenticationTab() {
           >
             {t('authSettings.passwordAuth.envLocked', {
               value: values.password_auth_enabled ? 'true' : 'false',
+            })}
+          </div>
+        )}
+      </div>
+
+      <div style={{ borderTop: '1px solid var(--border)', margin: '40px 0' }} />
+
+      {/* Guest access */}
+      <div>
+        <h3 style={{ fontSize: 18, fontWeight: 600, marginBottom: 6 }}>
+          {t('authSettings.guestAccess.title')}
+        </h3>
+        <p style={{ fontSize: 14, color: 'var(--text-dim)', marginBottom: 20, lineHeight: 1.6 }}>
+          {t('authSettings.guestAccess.description')}
+        </p>
+
+        <label
+          htmlFor="guest_access_enabled"
+          style={{
+            display: 'flex',
+            alignItems: 'center',
+            gap: 12,
+            cursor: guestEnvLocked ? 'not-allowed' : 'pointer',
+            width: 'fit-content',
+            opacity: guestEnvLocked ? 0.7 : 1,
+          }}
+        >
+          <input
+            id="guest_access_enabled"
+            type="checkbox"
+            checked={values.guest_access_enabled}
+            onChange={() => toggle('guest_access_enabled')}
+            disabled={guestEnvLocked || saving === 'guest_access_enabled'}
+            style={{
+              width: 16,
+              height: 16,
+              cursor: guestEnvLocked ? 'not-allowed' : 'pointer',
+              accentColor: 'var(--gold)',
+            }}
+          />
+          <span style={{ fontSize: 14, color: 'var(--text)' }}>
+            {t('authSettings.guestAccess.enable')}
+          </span>
+          {saving === 'guest_access_enabled' && <Spinner size={13} />}
+          {saved === 'guest_access_enabled' && (
+            <LuCircleCheck size={14} style={{ color: 'var(--green)' }} />
+          )}
+        </label>
+
+        {guestEnvLocked && (
+          <div
+            style={{
+              marginTop: 12,
+              padding: '10px 12px',
+              borderRadius: 6,
+              background: 'var(--bg-card)',
+              border: '1px solid var(--border)',
+              fontSize: 13,
+              color: 'var(--text-dim)',
+              lineHeight: 1.5,
+            }}
+          >
+            {t('authSettings.guestAccess.envLocked', {
+              value: values.guest_access_enabled ? 'true' : 'false',
             })}
           </div>
         )}

--- a/frontend/src/components/settings/ChangePasswordSection.jsx
+++ b/frontend/src/components/settings/ChangePasswordSection.jsx
@@ -3,21 +3,15 @@ import { useTranslation } from 'react-i18next'
 import { LuCircleCheck } from 'react-icons/lu'
 import api from '../../api'
 import Spinner from '../Spinner'
-import { useAuth } from '../../context/AuthContext'
-import { useUISettings } from '../../context/UISettingsContext'
 
 export default function ChangePasswordSection() {
   const { t } = useTranslation()
-  const { user } = useAuth()
-  const { disable_password_change } = useUISettings()
   const [current, setCurrent] = useState('')
   const [next, setNext] = useState('')
   const [confirm, setConfirm] = useState('')
   const [saving, setSaving] = useState(false)
   const [saved, setSaved] = useState(false)
   const [error, setError] = useState(null)
-
-  if (disable_password_change && user?.role !== 'admin') return null
 
   const handleSubmit = async (e) => {
     e.preventDefault()

--- a/frontend/src/context/UISettingsContext.jsx
+++ b/frontend/src/context/UISettingsContext.jsx
@@ -4,10 +4,10 @@ const UISettingsContext = createContext({
   hide_maps: false,
   hide_tokens: false,
   hide_campaigns: false,
-  disable_password_change: false,
   campaign_uploads_disabled: false,
   campaign_upload_max_file_mb: 0,
   campaign_upload_max_total_mb: 0,
+  guest_access_enabled: false,
 })
 
 export const UISettingsProvider = UISettingsContext.Provider

--- a/frontend/src/locales/de-DE.json
+++ b/frontend/src/locales/de-DE.json
@@ -90,7 +90,11 @@
     "entering": "Anmelden…",
     "loginFailed": "Anmeldung fehlgeschlagen.",
     "serverUnreachable": "Server nicht erreichbar.",
-    "passwordAuthDisabled": null
+    "passwordAuthDisabled": null,
+    "haveInviteCode": "Einladungscode vorhanden?",
+    "inviteCode": "Einladungscode",
+    "enterAsGuest": "Als Gast eintreten",
+    "guestInvalidCode": "Ungültiger oder abgelaufener Einladungscode."
   },
   "setup": {
     "title": "Ersteinrichtung",
@@ -312,6 +316,12 @@
       "description": null,
       "enable": null,
       "envLocked": null
+    },
+    "guestAccess": {
+      "title": "Gastzugang",
+      "description": "Erlaubt SLs und Administratoren, Einladungscodes für ihre Kampagnen zu erstellen. Gäste erhalten ein eingeschränktes, codebasiertes Konto für eine einzelne Kampagne.",
+      "enable": "Einladungscodes aktivieren",
+      "envLocked": "Gesperrt durch die Umgebungsvariable GUEST_ACCESS_ENABLED (aktueller Wert: {{value}})."
     }
   },
   "userSettings": {
@@ -1098,5 +1108,21 @@
     "field_explicit": "Explizite Inhalte",
     "previous": "Zurück",
     "next": "Weiter"
+  },
+  "guests": {
+    "guests": "Gäste",
+    "guest": "Gast",
+    "add": "Hinzufügen",
+    "none": "Noch keine Gäste.",
+    "nicknamePlaceholder": "Gast-Spitzname",
+    "share": "Einladung teilen",
+    "regenerate": "Code neu erzeugen",
+    "remove": "Gast entfernen",
+    "confirmRemove": "Diesen Gast entfernen? Sein Konto und seine Beiträge werden gelöscht.",
+    "shareTitle": "Gast-Einladung teilen",
+    "copyMessage": "Nachricht kopieren",
+    "copyForDiscord": "Für Discord kopieren",
+    "email": "E-Mail",
+    "copied": "Kopiert!"
   }
 }

--- a/frontend/src/locales/en-US.json
+++ b/frontend/src/locales/en-US.json
@@ -94,7 +94,11 @@
     "or": "or",
     "oidcDefault": "Sign in with SSO",
     "oidcError": "Single sign-on failed: {{error}}",
-    "oidcLoginFailed": "Single sign-on succeeded but the session could not be established."
+    "oidcLoginFailed": "Single sign-on succeeded but the session could not be established.",
+    "haveInviteCode": "Have an invite code?",
+    "inviteCode": "Invite Code",
+    "enterAsGuest": "Enter as Guest",
+    "guestInvalidCode": "Invalid or expired invite code."
   },
   "setup": {
     "title": "First-Time Setup",
@@ -367,6 +371,12 @@
       "autoRegister": "Auto-register",
       "autoRegisterHint": "Automatically create new local accounts on first OIDC login. Without this, users must already exist locally.",
       "saveFailed": "Could not save."
+    },
+    "guestAccess": {
+      "title": "Guest Access",
+      "description": "Allow GMs and admins to create guest invite codes for their campaigns. Guests get a code-based, locked-down account scoped to a single campaign.",
+      "enable": "Enable guest invite codes",
+      "envLocked": "Locked by the GUEST_ACCESS_ENABLED environment variable (current value: {{value}})."
     }
   },
   "userSettings": {
@@ -1167,5 +1177,21 @@
     "field_explicit": "Explicit content",
     "previous": "Previous",
     "next": "Next"
+  },
+  "guests": {
+    "guests": "Guests",
+    "guest": "Guest",
+    "add": "Add",
+    "none": "No guests yet.",
+    "nicknamePlaceholder": "Guest nickname",
+    "share": "Share invite",
+    "regenerate": "Regenerate code",
+    "remove": "Remove guest",
+    "confirmRemove": "Remove this guest? Their account and contributions will be deleted.",
+    "shareTitle": "Share guest invite",
+    "copyMessage": "Copy message",
+    "copyForDiscord": "Copy for Discord",
+    "email": "Email",
+    "copied": "Copied!"
   }
 }

--- a/frontend/src/locales/fr-CA.json
+++ b/frontend/src/locales/fr-CA.json
@@ -94,7 +94,11 @@
     "or": "ou",
     "oidcDefault": "Se connecter via SSO",
     "oidcError": "Échec de la connexion unique : {{error}}",
-    "oidcLoginFailed": "La connexion unique a réussi, mais la session n'a pas pu être établie."
+    "oidcLoginFailed": "La connexion unique a réussi, mais la session n'a pas pu être établie.",
+    "haveInviteCode": "Vous avez un code d'invitation ?",
+    "inviteCode": "Code d'invitation",
+    "enterAsGuest": "Entrer en tant qu'invité",
+    "guestInvalidCode": "Code d'invitation invalide ou expiré."
   },
   "setup": {
     "title": "Configuration initiale",
@@ -367,6 +371,12 @@
       "autoRegister": "Inscription automatique",
       "autoRegisterHint": "Crée automatiquement les comptes locaux lors de la première connexion OIDC. Sans cela, les utilisateurs doivent déjà exister localement.",
       "saveFailed": "Impossible d'enregistrer."
+    },
+    "guestAccess": {
+      "title": "Accès invité",
+      "description": "Permet aux MJ et administrateurs de créer des codes d'invitation pour leurs campagnes. Les invités obtiennent un compte restreint, basé sur un code et limité à une seule campagne.",
+      "enable": "Activer les codes d'invitation",
+      "envLocked": "Verrouillé par la variable d'environnement GUEST_ACCESS_ENABLED (valeur actuelle : {{value}})."
     }
   },
   "userSettings": {
@@ -1166,5 +1176,21 @@
     "field_explicit": "Contenu explicite",
     "previous": "Précédent",
     "next": "Suivant"
+  },
+  "guests": {
+    "guests": "Invités",
+    "guest": "Invité",
+    "add": "Ajouter",
+    "none": "Aucun invité pour le moment.",
+    "nicknamePlaceholder": "Surnom de l'invité",
+    "share": "Partager l'invitation",
+    "regenerate": "Régénérer le code",
+    "remove": "Supprimer l'invité",
+    "confirmRemove": "Supprimer cet invité ? Son compte et ses contributions seront supprimés.",
+    "shareTitle": "Partager l'invitation",
+    "copyMessage": "Copier le message",
+    "copyForDiscord": "Copier pour Discord",
+    "email": "Courriel",
+    "copied": "Copié !"
   }
 }

--- a/frontend/src/locales/fr-FR.json
+++ b/frontend/src/locales/fr-FR.json
@@ -94,7 +94,11 @@
     "or": "ou",
     "oidcDefault": "Se connecter via SSO",
     "oidcError": "Échec de la connexion unique : {{error}}",
-    "oidcLoginFailed": "La connexion unique a réussi, mais la session n'a pas pu être établie."
+    "oidcLoginFailed": "La connexion unique a réussi, mais la session n'a pas pu être établie.",
+    "haveInviteCode": "Vous avez un code d'invitation ?",
+    "inviteCode": "Code d'invitation",
+    "enterAsGuest": "Entrer en tant qu'invité",
+    "guestInvalidCode": "Code d'invitation invalide ou expiré."
   },
   "setup": {
     "title": "Configuration initiale",
@@ -367,6 +371,12 @@
       "autoRegister": "Inscription automatique",
       "autoRegisterHint": "Crée automatiquement les comptes locaux lors de la première connexion OIDC. Sans cela, les utilisateurs doivent déjà exister localement.",
       "saveFailed": "Impossible d'enregistrer."
+    },
+    "guestAccess": {
+      "title": "Accès invité",
+      "description": "Permet aux MJ et administrateurs de créer des codes d'invitation pour leurs campagnes. Les invités obtiennent un compte restreint, basé sur un code et limité à une seule campagne.",
+      "enable": "Activer les codes d'invitation",
+      "envLocked": "Verrouillé par la variable d'environnement GUEST_ACCESS_ENABLED (valeur actuelle : {{value}})."
     }
   },
   "userSettings": {
@@ -1166,5 +1176,21 @@
     "field_explicit": "Contenu explicite",
     "previous": "Précédent",
     "next": "Suivant"
+  },
+  "guests": {
+    "guests": "Invités",
+    "guest": "Invité",
+    "add": "Ajouter",
+    "none": "Aucun invité pour le moment.",
+    "nicknamePlaceholder": "Surnom de l'invité",
+    "share": "Partager l'invitation",
+    "regenerate": "Régénérer le code",
+    "remove": "Supprimer l'invité",
+    "confirmRemove": "Supprimer cet invité ? Son compte et ses contributions seront supprimés.",
+    "shareTitle": "Partager l'invitation",
+    "copyMessage": "Copier le message",
+    "copyForDiscord": "Copier pour Discord",
+    "email": "Courriel",
+    "copied": "Copié !"
   }
 }

--- a/frontend/src/views/CampaignDetailView.jsx
+++ b/frontend/src/views/CampaignDetailView.jsx
@@ -7,6 +7,7 @@ import {
   LuChevronLeft,
   LuSettings,
   LuUserPlus,
+  LuUserCheck,
   LuCalendar,
   LuLink,
   LuImagePlus,
@@ -14,6 +15,7 @@ import {
 } from 'react-icons/lu'
 import api, { campaigns } from '../api'
 import { useAuth } from '../context/AuthContext'
+import { useUISettings } from '../context/UISettingsContext'
 import Spinner from '../components/Spinner'
 import CampaignEditor from '../components/campaigns/CampaignEditor'
 import WikiView from '../components/campaigns/WikiView'
@@ -23,6 +25,7 @@ import ResourcesPanel from '../components/campaigns/ResourcesPanel'
 import BannerHero from '../components/campaigns/BannerHero'
 import MemberRow from '../components/campaigns/MemberRow'
 import InvitePanel from '../components/campaigns/InvitePanel'
+import GuestPanel from '../components/campaigns/GuestPanel'
 import { utcTimeToLocal, USER_TZ } from '../components/campaigns/_scheduleShared'
 
 const CARD = {
@@ -57,6 +60,19 @@ const SECTION_HEADING = {
   display: 'flex',
   alignItems: 'center',
   gap: 8,
+}
+
+const ROSTER_BTN = {
+  display: 'flex',
+  alignItems: 'center',
+  gap: 5,
+  padding: '5px 10px',
+  background: 'var(--bg-deep)',
+  border: '1px solid var(--border)',
+  borderRadius: 6,
+  color: 'var(--text-dim)',
+  cursor: 'pointer',
+  fontSize: 12,
 }
 
 // Compact one-line schedule summary (e.g. "Weekly — Fri · 7:00 PM") for the meta row.
@@ -107,11 +123,13 @@ export default function CampaignDetailView() {
   const { campaignId } = useParams()
   const navigate = useNavigate()
   const { user } = useAuth()
+  const { guest_access_enabled } = useUISettings()
   const [campaign, setCampaign] = useState(null)
   const [systems, setSystems] = useState([])
   const [schedule, setSchedule] = useState(null)
   const [showEditor, setShowEditor] = useState(false)
   const [showInvite, setShowInvite] = useState(false)
+  const [showGuests, setShowGuests] = useState(false)
   const [error, setError] = useState(null)
 
   const load = () => {
@@ -437,7 +455,8 @@ export default function CampaignDetailView() {
         {isGmCampaign &&
           (() => {
             const gmMember = campaign.members?.find((m) => m.is_owner)
-            const playerMembers = campaign.members?.filter((m) => !m.is_owner) ?? []
+            const playerMembers = campaign.members?.filter((m) => !m.is_owner && !m.is_guest) ?? []
+            const guestMembers = campaign.members?.filter((m) => m.is_guest) ?? []
             return (
               <div style={SCROLL_CARD}>
                 <div
@@ -452,23 +471,28 @@ export default function CampaignDetailView() {
                     <LuUsers size={15} /> {t('campaignDetail.overview.members')}
                   </h3>
                   {canManage && (
-                    <button
-                      onClick={() => setShowInvite(!showInvite)}
-                      style={{
-                        display: 'flex',
-                        alignItems: 'center',
-                        gap: 5,
-                        padding: '5px 10px',
-                        background: 'var(--bg-deep)',
-                        border: '1px solid var(--border)',
-                        borderRadius: 6,
-                        color: 'var(--text-dim)',
-                        cursor: 'pointer',
-                        fontSize: 12,
-                      }}
-                    >
-                      <LuUserPlus size={12} /> {t('campaignDetail.overview.invite')}
-                    </button>
+                    <div style={{ display: 'flex', gap: 6 }}>
+                      <button
+                        onClick={() => {
+                          setShowInvite(!showInvite)
+                          setShowGuests(false)
+                        }}
+                        style={ROSTER_BTN}
+                      >
+                        <LuUserPlus size={12} /> {t('campaignDetail.overview.invite')}
+                      </button>
+                      {guest_access_enabled && (
+                        <button
+                          onClick={() => {
+                            setShowGuests(!showGuests)
+                            setShowInvite(false)
+                          }}
+                          style={ROSTER_BTN}
+                        >
+                          <LuUserCheck size={12} /> {t('guests.guests')}
+                        </button>
+                      )}
+                    </div>
                   )}
                 </div>
 
@@ -480,6 +504,10 @@ export default function CampaignDetailView() {
                       load()
                     }}
                   />
+                )}
+
+                {showGuests && canManage && guest_access_enabled && (
+                  <GuestPanel campaignId={campaign.id} onChanged={load} />
                 )}
 
                 <div style={{ overflowY: 'auto', flex: 1, marginRight: -8, paddingRight: 8 }}>
@@ -523,6 +551,28 @@ export default function CampaignDetailView() {
                         onMediaChanged={load}
                       />
                     ))
+                  )}
+
+                  {guestMembers.length > 0 && (
+                    <>
+                      <div style={{ ...GROUP_LABEL, marginTop: 12 }}>
+                        {t('guests.guests')} ({guestMembers.length})
+                      </div>
+                      {guestMembers.map((m) => (
+                        <MemberRow
+                          key={m.user_id}
+                          member={m}
+                          isOwner={isOwner}
+                          canManage={canManage}
+                          currentUserId={user?.id}
+                          campaignId={campaign.id}
+                          onRemove={handleRemoveMember}
+                          onUpdateStatus={handleUpdateMember}
+                          onSetCharacterName={handleSetCharacterName}
+                          onMediaChanged={load}
+                        />
+                      ))}
+                    </>
                   )}
                 </div>
               </div>

--- a/frontend/src/views/LoginView.jsx
+++ b/frontend/src/views/LoginView.jsx
@@ -1,6 +1,7 @@
 import { useState, useEffect } from 'react'
 import { useTranslation } from 'react-i18next'
 import { sanitizeLoginMessage } from '../utils/sanitizeLoginMessage'
+import { auth as authApi } from '../api'
 
 export default function LoginView({ onLogin }) {
   const { t } = useTranslation()
@@ -9,6 +10,7 @@ export default function LoginView({ onLogin }) {
   const [loading, setLoading] = useState(false)
   const [config, setConfig] = useState({
     password_auth_enabled: true,
+    guest_access_enabled: false,
     custom_login_message_enabled: false,
     custom_login_message: '',
     oidc_enabled: false,
@@ -20,6 +22,13 @@ export default function LoginView({ onLogin }) {
   // ?autoLaunch=0 (or other falsy strings) suppresses the auto-redirect.
   // Logout sets a sessionStorage flag so we don't bounce the user straight back.
   const queryParams = new URLSearchParams(window.location.search)
+
+  // Guest invite code entry. Pre-filled from /guest?code=… deep links.
+  const initialCode = queryParams.get('code') || ''
+  const [showGuest, setShowGuest] = useState(!!initialCode)
+  const [guestCode, setGuestCode] = useState(initialCode)
+  const [guestError, setGuestError] = useState('')
+  const [guestLoading, setGuestLoading] = useState(false)
   const autoLaunchParam = queryParams.get('autoLaunch')
   const suppressAutoLaunch =
     autoLaunchParam === '0' ||
@@ -55,6 +64,7 @@ export default function LoginView({ onLogin }) {
         if (!data || typeof data.password_auth_enabled !== 'boolean') return
         const next = {
           password_auth_enabled: data.password_auth_enabled,
+          guest_access_enabled: !!data.guest_access_enabled,
           custom_login_message_enabled: !!data.custom_login_message_enabled,
           custom_login_message: data.custom_login_message || '',
           oidc_enabled: !!data.oidc_enabled,
@@ -96,6 +106,24 @@ export default function LoginView({ onLogin }) {
       setError(t('login.serverUnreachable'))
     } finally {
       setLoading(false)
+    }
+  }
+
+  const handleGuestSubmit = async (e) => {
+    e.preventDefault()
+    setGuestError('')
+    setGuestLoading(true)
+    try {
+      const data = await authApi.guestLogin(guestCode.trim())
+      // Land the guest directly in the campaign their code belongs to.
+      if (data.campaign_id) {
+        sessionStorage.setItem('grimoire:guest_campaign', data.campaign_id)
+      }
+      onLogin(data.token, data.user)
+    } catch (err) {
+      setGuestError(err?.body?.detail || t('login.guestInvalidCode'))
+    } finally {
+      setGuestLoading(false)
     }
   }
 
@@ -271,6 +299,65 @@ export default function LoginView({ onLogin }) {
                 </button>
               )}
             </>
+          )}
+
+          {/* Guest invite code — works independently of password/OIDC auth. */}
+          {config.guest_access_enabled && (
+            <div style={{ marginTop: 20, borderTop: '1px solid var(--border)', paddingTop: 16 }}>
+              {!showGuest ? (
+                <button
+                  type="button"
+                  onClick={() => setShowGuest(true)}
+                  style={{
+                    background: 'none',
+                    border: 'none',
+                    color: 'var(--text-muted)',
+                    cursor: 'pointer',
+                    fontSize: 13,
+                    width: '100%',
+                    textAlign: 'center',
+                  }}
+                >
+                  {t('login.haveInviteCode')}
+                </button>
+              ) : (
+                <form onSubmit={handleGuestSubmit}>
+                  <label htmlFor="guest-code" style={labelStyle}>
+                    {t('login.inviteCode')}
+                  </label>
+                  <input
+                    id="guest-code"
+                    type="text"
+                    value={guestCode}
+                    onChange={(e) => setGuestCode(e.target.value.toUpperCase())}
+                    required
+                    autoFocus
+                    maxLength={10}
+                    autoComplete="off"
+                    style={{ width: '100%', marginBottom: 12, letterSpacing: '0.2em' }}
+                  />
+                  {guestError && (
+                    <div
+                      style={{
+                        color: 'var(--red)',
+                        fontSize: 13,
+                        marginBottom: 12,
+                        textAlign: 'center',
+                      }}
+                    >
+                      {guestError}
+                    </div>
+                  )}
+                  <button
+                    type="submit"
+                    disabled={guestLoading}
+                    style={submitBtnStyle(guestLoading)}
+                  >
+                    {guestLoading ? t('login.entering') : t('login.enterAsGuest')}
+                  </button>
+                </form>
+              )}
+            </div>
           )}
         </div>
       </div>

--- a/frontend/src/views/LoginView.test.jsx
+++ b/frontend/src/views/LoginView.test.jsx
@@ -78,6 +78,61 @@ describe('LoginView', () => {
     expect(await screen.findByText('Could not reach the server.')).toBeInTheDocument()
   })
 
+  it('shows the guest invite field when guest access is enabled', async () => {
+    global.fetch = vi.fn().mockImplementation((url) => {
+      if (url === '/api/auth/config') {
+        return Promise.resolve({
+          ok: true,
+          json: () => Promise.resolve({ password_auth_enabled: true, guest_access_enabled: true }),
+        })
+      }
+      return Promise.resolve({ ok: true, json: () => Promise.resolve({}) })
+    })
+
+    render(<LoginView onLogin={vi.fn()} />)
+    const toggle = await screen.findByText(/have an invite code/i)
+    fireEvent.click(toggle)
+    expect(screen.getByLabelText('Invite Code')).toBeInTheDocument()
+  })
+
+  it('logs in as a guest and stashes the campaign id for redirect', async () => {
+    global.fetch = vi.fn().mockImplementation((url) => {
+      if (url === '/api/auth/config') {
+        return Promise.resolve({
+          ok: true,
+          json: () => Promise.resolve({ password_auth_enabled: true, guest_access_enabled: true }),
+        })
+      }
+      if (url === '/api/auth/guest-login') {
+        return Promise.resolve({
+          ok: true,
+          status: 200,
+          json: () =>
+            Promise.resolve({
+              token: 'gtok',
+              user: { username: 'guest_x', role: 'guest' },
+              campaign_id: 'camp42',
+            }),
+        })
+      }
+      return Promise.resolve({ ok: true, json: () => Promise.resolve({}) })
+    })
+    const onLogin = vi.fn()
+
+    render(<LoginView onLogin={onLogin} />)
+    fireEvent.click(await screen.findByText(/have an invite code/i))
+    await userEvent.type(screen.getByLabelText('Invite Code'), 'abc1234567')
+    fireEvent.click(screen.getByRole('button', { name: /enter as guest/i }))
+
+    await waitFor(() =>
+      expect(onLogin).toHaveBeenCalledWith('gtok', {
+        username: 'guest_x',
+        role: 'guest',
+      })
+    )
+    expect(sessionStorage.getItem('grimoire:guest_campaign')).toBe('camp42')
+  })
+
   it('disables the button and shows loading text while submitting', async () => {
     let resolve
     global.fetch = vi.fn().mockReturnValue(


### PR DESCRIPTION
## Summary

Allow campaign GMs to invite guests who can view campaign content
without a full account, via invite links validated server-side.

## Type of change

- [ ] Bug fix
- [x] New feature
- [ ] Refactor / cleanup
- [ ] Docs / configuration only

## Testing

<!-- How did you verify this works? Check all that apply. -->

- [x] Backend tests pass (`pytest -q`)
- [x] Frontend tests pass (`npm test`)
- [x] Tested manually in the browser
