### PR TITLE
[Feature]: scoped rescan + sidecar metadata refresh (#109, #106)

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -7,6 +7,7 @@ on:
   pull_request:
     branches:
       - main
+      - dev
   schedule:
     - cron: "0 8 * * 1"
 

--- a/README.md
+++ b/README.md
@@ -217,7 +217,7 @@ Folder name matching is **case-insensitive**, and hyphens, underscores, and spac
 >
 > Any subfolder name that doesn't match the recognized keywords becomes its own category, slugified from the folder name. For example, a folder named `Bestiary` becomes the `bestiary` category.
 >
-> After adding new files, use **Rescan** in the sidebar (or Settings → Maintenance) to pick up the changes.
+> After adding new files, use **Rescan** in the sidebar (or Settings → Maintenance) to pick up the changes. For large libraries you can also rescan a single corner: every system, category, subfolder, and map/token group has its own rescan button that re-scans just that folder.
 
 #### Subfolders within a category
 
@@ -326,7 +326,11 @@ books/
             └── cover.jpg
 ```
 
-OPF metadata is only applied when a book is **first indexed**. Edits made via the web UI are not overwritten on subsequent rescans.
+OPF metadata is only applied when a book is **first indexed**, and ordinary rescans leave existing books alone, so edits made via the web UI are not overwritten. To pick up an OPF or `tags.json` you added or corrected after the initial scan, choose a metadata-refresh mode in the rescan dialog (available on the global Rescan button and every per-folder rescan button):
+
+- **Find new files** — the default: add new files, flag missing ones, leave existing records untouched.
+- **Update missing metadata** — additionally fill **empty** book fields from sidecar files, without touching anything you've already set (non-destructive).
+- **Replace all metadata** — overwrite fields with whatever the sidecar files provide (this discards UI edits the sidecar covers).
 
 ### Maps — organize by creator or collection
 

--- a/backend/indexer.py
+++ b/backend/indexer.py
@@ -316,13 +316,91 @@ def parse_opf_metadata(opf_path: str) -> dict:
     return meta
 
 
-def scan_library(library_path: str, data_path: str, session: Session, on_progress=None, should_stop=None):
+# Metadata-refresh modes for scan_library / _apply_opf_to_book.
+METADATA_MODES = ("new", "missing", "replace")
+
+# Book fields that can be sourced from an OPF sidecar.
+_OPF_BOOK_FIELDS = ("title", "authors", "description", "publisher", "year", "tags")
+
+
+def resolve_scope(library_path: str, scope_path: str) -> tuple[str, Path]:
+    """Resolve a user-supplied scope path against the library root.
+
+    `scope_path` is a path relative to the library root and must begin with one
+    of the known collection folders (``books``/``maps``/``tokens``).  Returns a
+    tuple of (section, absolute_dir).  Raises ValueError if the scope escapes the
+    library root or names an unknown collection.
+    """
+    library = Path(library_path)
+    cleaned = (scope_path or "").strip().replace("\\", "/").strip("/")
+    if not cleaned:
+        raise ValueError("scope path is empty")
+
+    section = cleaned.split("/", 1)[0]
+    if section not in ("books", "maps", "tokens"):
+        raise ValueError(f"scope must start with books/, maps/, or tokens/: {scope_path!r}")
+
+    # Build the target without resolving symlinks so the walked paths match the
+    # filepaths stored by an unscoped scan (which uses library_path verbatim).
+    target = library / cleaned
+    # Guard against path traversal using fully-resolved paths.
+    resolved_lib = str(library.resolve())
+    if os.path.commonpath([resolved_lib, str(target.resolve())]) != resolved_lib:
+        raise ValueError(f"scope path escapes the library root: {scope_path!r}")
+
+    return section, target
+
+
+def _find_opf_meta(root: str, filename: str) -> dict:
+    """Look up sidecar OPF metadata for a file: sibling <stem>.opf, then metadata.opf."""
+    opf_path = os.path.join(root, Path(filename).stem + ".opf")
+    if not os.path.isfile(opf_path):
+        opf_path = os.path.join(root, "metadata.opf")
+    return parse_opf_metadata(opf_path) if os.path.isfile(opf_path) else {}
+
+
+def _apply_opf_to_book(book: Book, opf_meta: dict, mode: str) -> bool:
+    """Re-apply OPF metadata to an already-indexed book.
+
+    mode="missing": only fill a field whose current DB value is falsy
+    (None/""/[]), treating any populated value as user-protected.
+    mode="replace": overwrite a field whenever the OPF provides it.
+    Fields absent from `opf_meta` are never touched.
+
+    Returns True if any field was changed.
+    """
+    if not opf_meta or mode not in ("missing", "replace"):
+        return False
+
+    changed = False
+    for field in _OPF_BOOK_FIELDS:
+        if field not in opf_meta:
+            continue
+        new_value = opf_meta[field]
+        if mode == "missing" and getattr(book, field, None):
+            continue
+        if getattr(book, field, None) != new_value:
+            setattr(book, field, new_value)
+            changed = True
+    return changed
+
+
+def scan_library(library_path: str, data_path: str, session: Session, on_progress=None,
+                 should_stop=None, scope_path: str | None = None, metadata_mode: str = "new"):
     """Scan the library directory and register all files in the database.
 
     on_progress(scanned_books, total_books, scanned_maps, total_maps, scanned_tokens, total_tokens)
     is called after each file is processed if provided.
 
     should_stop() is an optional callable that returns True when the scan should abort early.
+
+    scope_path, when given, restricts the scan to a single subtree (relative to the
+    library root, e.g. "books/D&D 5e/adventure").  Only the matching collection is
+    walked and the missing-file sweep is limited to that subtree.
+
+    metadata_mode controls how sidecar metadata is applied to already-indexed books:
+    "new" (default) leaves existing records alone, "missing" fills empty fields from
+    OPF sidecars, "replace" overwrites fields wherever the sidecar provides a value.
     """
     library = Path(library_path)
     books_dir = library / "books"
@@ -334,23 +412,55 @@ def scan_library(library_path: str, data_path: str, session: Session, on_progres
         "new_books": 0,
         "new_maps": 0,
         "new_tokens": 0,
+        "updated_books": 0,
         "indexed_pages": 0,
         "errors": 0,
     }
 
+    # --- Resolve scope (which collections to walk, and the subtree root) ---
+    scope_section: str | None = None
+    scope_dir: Path | None = None
+    if scope_path:
+        scope_section, scope_dir = resolve_scope(library_path, scope_path)
+        logger.info(f"Scoped scan: section={scope_section}, dir={scope_dir}, mode={metadata_mode}")
+
+    scan_books = scope_section in (None, "books")
+    scan_maps = scope_section in (None, "maps")
+    scan_tokens = scope_section in (None, "tokens")
+
+    # For a scoped books scan, walk only the scope dir; otherwise iterate every system.
+    books_walk_dir = scope_dir if scope_section == "books" else books_dir
+    maps_walk_dir = scope_dir if scope_section == "maps" else maps_dir
+    tokens_walk_dir = scope_dir if scope_section == "tokens" else tokens_dir
+
     total_books = (
-        _count_eligible_files(books_dir, DOC_EXTS | IMAGE_EXTS) if books_dir.exists() else 0
+        _count_eligible_files(books_walk_dir, DOC_EXTS | IMAGE_EXTS)
+        if scan_books and books_walk_dir.exists() else 0
     )
-    total_maps = _count_eligible_files(maps_dir, MAP_IMAGE_EXTS) if maps_dir.exists() else 0
-    total_tokens = _count_eligible_files(tokens_dir, IMAGE_EXTS) if tokens_dir.exists() else 0
+    total_maps = (
+        _count_eligible_files(maps_walk_dir, MAP_IMAGE_EXTS)
+        if scan_maps and maps_walk_dir.exists() else 0
+    )
+    total_tokens = (
+        _count_eligible_files(tokens_walk_dir, IMAGE_EXTS)
+        if scan_tokens and tokens_walk_dir.exists() else 0
+    )
     scanned_books = scanned_maps = scanned_tokens = 0
 
     if on_progress:
         on_progress(0, total_books, 0, total_maps, 0, total_tokens)
 
     # --- Scan /books ---
-    if books_dir.exists():
-        for system_dir in sorted(books_dir.iterdir()):
+    if scan_books and books_dir.exists():
+        # When scoped, the owning system is the first path segment under books/;
+        # otherwise iterate every top-level system folder.
+        scope_parts = Path(scope_path.replace("\\", "/").strip("/")).parts if scope_path else ()
+        if scope_section == "books" and len(scope_parts) > 1:
+            system_dirs = [books_dir / scope_parts[1]]
+        else:
+            # Whole library, or scope == "books" root: iterate every system.
+            system_dirs = sorted(books_dir.iterdir())
+        for system_dir in system_dirs:
             if not system_dir.is_dir() or system_dir.name.startswith("."):
                 continue
 
@@ -393,7 +503,10 @@ def scan_library(library_path: str, data_path: str, session: Session, on_progres
             if is_agnostic and not system.is_system_agnostic:
                 system.is_system_agnostic = True
 
-            for root, dirs, files in os.walk(system_dir):
+            # When scoped to a path deeper than the system dir, walk only that
+            # subtree; otherwise walk the whole system.
+            walk_root = scope_dir if (scope_section == "books" and len(scope_parts) > 1) else system_dir
+            for root, dirs, files in os.walk(walk_root):
                 dirs[:] = [d for d in dirs if not d.startswith(".")]
 
                 # Collect cover image filenames declared in any OPF files in this
@@ -449,6 +562,18 @@ def scan_library(library_path: str, data_path: str, session: Session, on_progres
                         stats["errors"] += 1
                         continue
                     if existing:
+                        # Re-apply sidecar metadata to already-indexed books when
+                        # requested (modes "missing"/"replace") — see _apply_opf_to_book.
+                        if metadata_mode in ("missing", "replace"):
+                            opf_meta = _find_opf_meta(root, filename)
+                            if _apply_opf_to_book(existing, opf_meta, metadata_mode):
+                                logger.info(f"Refreshing metadata for '{filename}' (mode={metadata_mode})")
+                                try:
+                                    _run_with_timeout(session.commit, _DB_TIMEOUT, f"commit metadata refresh '{filepath}'")
+                                    stats["updated_books"] += 1
+                                except (TimeoutError, IntegrityError) as e:
+                                    logger.error(f"DB hang refreshing metadata for '{filename}': {e}")
+                                    session.rollback()
                         if existing.scan_failed:
                             logger.debug(f"Already registered, skipping: {filename}")
                             continue
@@ -472,12 +597,9 @@ def scan_library(library_path: str, data_path: str, session: Session, on_progres
                             continue
 
                         # Check sibling <stem>.opf first, then Calibre's metadata.opf in the same dir.
-                        opf_path = os.path.join(root, Path(filename).stem + ".opf")
-                        if not os.path.isfile(opf_path):
-                            opf_path = os.path.join(root, "metadata.opf")
-                        opf_meta = parse_opf_metadata(opf_path) if os.path.isfile(opf_path) else {}
+                        opf_meta = _find_opf_meta(root, filename)
                         if opf_meta:
-                            logger.info(f"Applying OPF metadata to '{filename}' from '{Path(opf_path).name}'")
+                            logger.info(f"Applying OPF metadata to '{filename}'")
 
                         book = Book(
                             game_system_id=system.id,
@@ -576,8 +698,8 @@ def scan_library(library_path: str, data_path: str, session: Session, on_progres
                                 logger.error(f"DB hang saving index_error for '{filename}': {e2}")
                                 session.rollback()
 
-    if maps_dir.exists():
-        for root, dirs, files in os.walk(maps_dir):
+    if scan_maps and maps_walk_dir.exists():
+        for root, dirs, files in os.walk(maps_walk_dir):
             dirs[:] = [d for d in dirs if not d.startswith(".")]
 
             for filename in sorted(files):
@@ -659,8 +781,8 @@ def scan_library(library_path: str, data_path: str, session: Session, on_progres
                     session.rollback()
                     logger.debug(f"Map already exists, skipping: {filepath}")
 
-    if tokens_dir.exists():
-        for root, dirs, files in os.walk(tokens_dir):
+    if scan_tokens and tokens_walk_dir.exists():
+        for root, dirs, files in os.walk(tokens_walk_dir):
             dirs[:] = [d for d in dirs if not d.startswith(".")]
 
             for filename in sorted(files):
@@ -742,36 +864,46 @@ def scan_library(library_path: str, data_path: str, session: Session, on_progres
                     session.rollback()
                     logger.debug(f"Token already exists, skipping: {filepath}")
 
-    _apply_tags_from_library(library_path, session)
+    _apply_tags_from_library(library_path, session, scope_dir=scope_dir)
 
     # --- Mark / unmark missing files ---
     # After walking the filesystem, any DB record whose file is gone gets
     # is_missing=True; records that exist on disk have is_missing cleared.
+    # When scoped, only reconcile records under the scope subtree so unrelated
+    # corners of the library are left untouched.
     if should_stop and should_stop():
         return stats
 
+    def _scoped(query, model):
+        if scope_dir is not None:
+            return query.filter(model.filepath.like(f"{scope_dir}{os.sep}%"))
+        return query
+
     missing_books = missing_maps = missing_tokens = 0
-    for book in session.query(Book).all():
-        gone = not os.path.exists(book.filepath)
-        if gone != bool(book.is_missing):
-            book.is_missing = gone
-            if gone:
-                missing_books += 1
-                logger.warning(f"Missing book: '{book.title}' ({book.filepath})")
-    for m in session.query(GenericMap).all():
-        gone = not os.path.exists(m.filepath)
-        if gone != bool(m.is_missing):
-            m.is_missing = gone
-            if gone:
-                missing_maps += 1
-                logger.warning(f"Missing map: '{m.filename}' ({m.filepath})")
-    for t in session.query(Token).all():
-        gone = not os.path.exists(t.filepath)
-        if gone != bool(t.is_missing):
-            t.is_missing = gone
-            if gone:
-                missing_tokens += 1
-                logger.warning(f"Missing token: '{t.filename}' ({t.filepath})")
+    if scan_books:
+        for book in _scoped(session.query(Book), Book).all():
+            gone = not os.path.exists(book.filepath)
+            if gone != bool(book.is_missing):
+                book.is_missing = gone
+                if gone:
+                    missing_books += 1
+                    logger.warning(f"Missing book: '{book.title}' ({book.filepath})")
+    if scan_maps:
+        for m in _scoped(session.query(GenericMap), GenericMap).all():
+            gone = not os.path.exists(m.filepath)
+            if gone != bool(m.is_missing):
+                m.is_missing = gone
+                if gone:
+                    missing_maps += 1
+                    logger.warning(f"Missing map: '{m.filename}' ({m.filepath})")
+    if scan_tokens:
+        for t in _scoped(session.query(Token), Token).all():
+            gone = not os.path.exists(t.filepath)
+            if gone != bool(t.is_missing):
+                t.is_missing = gone
+                if gone:
+                    missing_tokens += 1
+                    logger.warning(f"Missing token: '{t.filename}' ({t.filepath})")
     if missing_books or missing_maps or missing_tokens:
         logger.info(f"Missing files: {missing_books} book(s), {missing_maps} map(s), {missing_tokens} token(s)")
     try:
@@ -818,13 +950,29 @@ def _load_tags_json(folder_path: str) -> dict:
         return {}
 
 
-def _apply_tags_from_library(library_path: str, session: Session) -> None:
-    """Apply tags declared in tags.json files throughout the library tree."""
+def _within_scope(path: Path, scope_dir: Path | None) -> bool:
+    """Return True if `path` is the scope dir or lives under it (or scope is None)."""
+    if scope_dir is None:
+        return True
+    try:
+        return path == scope_dir or scope_dir in path.parents
+    except Exception:
+        return False
+
+
+def _apply_tags_from_library(library_path: str, session: Session, scope_dir: Path | None = None) -> None:
+    """Apply tags declared in tags.json files throughout the library tree.
+
+    When `scope_dir` is given, only tags.json files within that subtree are applied.
+    """
     library = Path(library_path)
 
     for section in ("maps", "tokens"):
         section_dir = library / section
         if not section_dir.exists():
+            continue
+        # Skip sections the scope doesn't touch (scope under section, or == section).
+        if scope_dir is not None and not _within_scope(scope_dir, section_dir):
             continue
 
         folder_model = MapFolder if section == "maps" else TokenFolder
@@ -832,6 +980,9 @@ def _apply_tags_from_library(library_path: str, session: Session) -> None:
 
         for root, dirs, files in os.walk(section_dir):
             dirs[:] = [d for d in dirs if not d.startswith(".")]
+
+            if not _within_scope(Path(root), scope_dir):
+                continue
 
             if "tags.json" not in files:
                 continue
@@ -875,9 +1026,12 @@ def _apply_tags_from_library(library_path: str, session: Session) -> None:
 
     # --- books/ section (system-level tags only) ---
     books_dir = library / "books"
-    if books_dir.exists():
+    if books_dir.exists() and (scope_dir is None or _within_scope(scope_dir, books_dir)):
         for system_dir in sorted(books_dir.iterdir()):
             if not system_dir.is_dir() or system_dir.name.startswith("."):
+                continue
+            # System-level tags only matter when the scope includes this system dir.
+            if scope_dir is not None and not _within_scope(scope_dir, system_dir):
                 continue
 
             tag_map = _load_tags_json(str(system_dir))

--- a/backend/routers/library/_helpers.py
+++ b/backend/routers/library/_helpers.py
@@ -22,6 +22,7 @@ _DEFAULT_STATUS: dict = {
     "new_books": 0,
     "new_maps": 0,
     "new_tokens": 0,
+    "updated_books": 0,
     "indexed": 0,
     "to_index": 0,
 }
@@ -128,13 +129,16 @@ def background_indexer():
             _set_status({"running": False, "phase": None})
 
 
-def run_rescan_sync() -> None:
-    """Full library rescan — scans disk and indexes PDFs.
+def run_rescan_sync(scope_path: str | None = None, metadata_mode: str = "new") -> None:
+    """Library rescan — scans disk and indexes PDFs.
 
     Guards against concurrent calls: if a rescan is already running this call
     returns immediately.  Updates scan status (via Valkey when available, or
     in-process dict) so GET /scan-status reflects progress in real time across
     all workers.
+
+    scope_path restricts the scan to a single subtree (e.g. "books/D&D 5e/adventure");
+    metadata_mode ("new"|"missing"|"replace") controls sidecar metadata re-application.
     """
     if _get_status()["running"]:
         logger.info("Rescan already running, skipping.")
@@ -164,10 +168,15 @@ def run_rescan_sync() -> None:
                     f"File scan progress: books={sb}/{tb}, maps={sm}/{tm}, tokens={st}/{tt}"
                 )
 
-            stats = scan_library(LIBRARY_PATH, DATA_PATH, db, on_progress=on_progress, should_stop=is_stop_requested)
+            stats = scan_library(
+                LIBRARY_PATH, DATA_PATH, db,
+                on_progress=on_progress, should_stop=is_stop_requested,
+                scope_path=scope_path, metadata_mode=metadata_mode,
+            )
             logger.info(
                 f"File scan end: new_books={stats.get('new_books', 0)}, "
                 f"new_maps={stats.get('new_maps', 0)}, new_tokens={stats.get('new_tokens', 0)}, "
+                f"updated_books={stats.get('updated_books', 0)}, "
                 f"errors={stats.get('errors', 0)}"
             )
             _set_status(
@@ -175,6 +184,7 @@ def run_rescan_sync() -> None:
                     "new_books": stats.get("new_books", 0),
                     "new_maps": stats.get("new_maps", 0),
                     "new_tokens": stats.get("new_tokens", 0),
+                    "updated_books": stats.get("updated_books", 0),
                 }
             )
 

--- a/backend/routers/library/_schemas.py
+++ b/backend/routers/library/_schemas.py
@@ -1,0 +1,16 @@
+"""Request/response schemas for the library router."""
+from typing import Literal, Optional
+
+from pydantic import BaseModel
+
+
+class RescanRequest(BaseModel):
+    """Body for POST /rescan.
+
+    scope restricts the rescan to a subtree relative to the library root, e.g.
+    "books/D&D 5e/adventure" or "maps/Forests".  Omitted = whole library.
+    metadata_mode controls sidecar metadata re-application on already-indexed books.
+    """
+
+    scope: Optional[str] = None
+    metadata_mode: Literal["new", "missing", "replace"] = "new"

--- a/backend/routers/library/core.py
+++ b/backend/routers/library/core.py
@@ -5,11 +5,13 @@ from typing import Optional
 from fastapi import APIRouter, BackgroundTasks, Depends, HTTPException, Header
 from sqlalchemy import func
 
-from ...config import SessionLocal, VERSION, COMMIT_HASH
+from ...config import SessionLocal, LIBRARY_PATH, VERSION, COMMIT_HASH
 from ...models import GameSystem, Book, GenericMap, Token
 from ...auth import require_admin, optional_get_current_user, CurrentUser
+from ...indexer import resolve_scope
 from ..settings import get_stats_api_key
 from . import _helpers
+from ._schemas import RescanRequest
 
 router = APIRouter(tags=["library"])
 public_router = APIRouter(prefix="/api", tags=["library"])
@@ -27,14 +29,30 @@ def get_scan_status(_: CurrentUser = Depends(require_admin)):
 @router.post(
     "/rescan",
     summary="Rescan and reindex library",
-    description="Triggers a background rescan of the library directory, adding new files and indexing unindexed PDFs. Admin role required.",
+    description=(
+        "Triggers a background rescan, adding new files and indexing unindexed PDFs. "
+        "Optionally scope to a subtree (`scope`, e.g. \"books/D&D 5e/adventure\") and "
+        "re-apply sidecar metadata (`metadata_mode`: new|missing|replace). Admin role required."
+    ),
 )
 def rescan_library(
-    background_tasks: BackgroundTasks, _: CurrentUser = Depends(require_admin)
+    background_tasks: BackgroundTasks,
+    body: Optional[RescanRequest] = None,
+    _: CurrentUser = Depends(require_admin),
 ):
+    req = body or RescanRequest()
+    if req.scope:
+        try:
+            resolve_scope(LIBRARY_PATH, req.scope)
+        except ValueError as e:
+            raise HTTPException(status_code=400, detail=str(e))
     if _helpers._get_status()["running"]:
         return {"status": "already_running"}
-    background_tasks.add_task(_helpers.run_rescan_sync)
+    background_tasks.add_task(
+        _helpers.run_rescan_sync,
+        scope_path=req.scope,
+        metadata_mode=req.metadata_mode,
+    )
     return {"status": "scan_started"}
 
 

--- a/backend/tests/test_scoped_rescan.py
+++ b/backend/tests/test_scoped_rescan.py
@@ -1,0 +1,257 @@
+"""Tests for scoped rescan + sidecar metadata refresh (issues #109, #106)."""
+from __future__ import annotations
+
+import os
+import tempfile
+from pathlib import Path
+from textwrap import dedent
+
+import pytest
+
+from backend.config import SessionLocal
+from backend.indexer import (
+    resolve_scope,
+    scan_library,
+    _apply_opf_to_book,
+    _find_opf_meta,
+)
+from backend.models import Book
+
+
+OPF = dedent("""\
+    <?xml version='1.0' encoding='utf-8'?>
+    <package xmlns="http://www.idpf.org/2007/opf" version="2.0">
+        <metadata xmlns:dc="http://purl.org/dc/elements/1.1/" xmlns:opf="http://www.idpf.org/2007/opf">
+            <dc:title>{title}</dc:title>
+            <dc:creator opf:role="aut">{author}</dc:creator>
+            <dc:publisher>{publisher}</dc:publisher>
+            <dc:description>{desc}</dc:description>
+        </metadata>
+    </package>
+""")
+
+
+def _mk_lib():
+    tmp = tempfile.mkdtemp(prefix="grimoire_scope_")
+    lib = Path(tmp) / "library"
+    lib.mkdir()
+    return tmp, lib
+
+
+def _scan(lib, tmp, **kwargs):
+    db = SessionLocal()
+    try:
+        return scan_library(str(lib), tmp, db, **kwargs)
+    finally:
+        db.close()
+
+
+def _get_book(filename: str, system: str | None = None):
+    db = SessionLocal()
+    try:
+        q = db.query(Book).filter(Book.filename == filename)
+        if system:
+            q = q.filter(Book.relative_path.like(f"books/{system}/%"))
+        return q.first()
+    finally:
+        db.close()
+
+
+# ---------------------------------------------------------------------------
+# resolve_scope — validation / path-traversal guard
+# ---------------------------------------------------------------------------
+
+class TestResolveScope:
+    def setup_method(self):
+        self.tmp, self.lib = _mk_lib()
+
+    def test_resolves_valid_books_scope(self):
+        section, target = resolve_scope(str(self.lib), "books/D&D 5e/adventure")
+        assert section == "books"
+        # Target is library-relative (symlinks not resolved, to match stored filepaths).
+        assert target == self.lib / "books" / "D&D 5e" / "adventure"
+
+    def test_resolves_maps_and_tokens(self):
+        assert resolve_scope(str(self.lib), "maps/Forests")[0] == "maps"
+        assert resolve_scope(str(self.lib), "tokens/Goblins")[0] == "tokens"
+
+    def test_unknown_section_rejected(self):
+        with pytest.raises(ValueError):
+            resolve_scope(str(self.lib), "campaigns/secret")
+
+    def test_empty_scope_rejected(self):
+        with pytest.raises(ValueError):
+            resolve_scope(str(self.lib), "")
+
+    def test_parent_traversal_rejected(self):
+        with pytest.raises(ValueError):
+            resolve_scope(str(self.lib), "books/../../etc")
+
+    def test_absolute_path_rejected(self):
+        with pytest.raises(ValueError):
+            resolve_scope(str(self.lib), "/etc/passwd")
+
+
+# ---------------------------------------------------------------------------
+# _apply_opf_to_book — non-destructive vs replace semantics
+# ---------------------------------------------------------------------------
+
+class TestApplyOpfToBook:
+    def _book(self):
+        return Book(
+            title="Existing Title",
+            filename="b.pdf",
+            filepath="/x/b.pdf",
+            relative_path="books/s/b.pdf",
+        )
+
+    def test_new_mode_is_noop(self):
+        book = self._book()
+        assert _apply_opf_to_book(book, {"title": "From OPF"}, "new") is False
+        assert book.title == "Existing Title"
+
+    def test_missing_fills_empty_only(self):
+        book = self._book()
+        book.publisher = ""          # empty → should fill
+        book.title = "Existing Title"  # populated → protected
+        changed = _apply_opf_to_book(
+            book, {"title": "From OPF", "publisher": "Acme"}, "missing"
+        )
+        assert changed is True
+        assert book.title == "Existing Title"  # protected
+        assert book.publisher == "Acme"        # filled
+
+    def test_missing_leaves_absent_fields_untouched(self):
+        book = self._book()
+        book.description = "keep me"
+        _apply_opf_to_book(book, {"publisher": "Acme"}, "missing")
+        assert book.description == "keep me"
+
+    def test_replace_overwrites_populated(self):
+        book = self._book()
+        book.title = "Old"
+        changed = _apply_opf_to_book(book, {"title": "New"}, "replace")
+        assert changed is True
+        assert book.title == "New"
+
+    def test_replace_leaves_absent_fields_untouched(self):
+        book = self._book()
+        book.description = "keep me"
+        _apply_opf_to_book(book, {"title": "New"}, "replace")
+        assert book.description == "keep me"
+
+
+# ---------------------------------------------------------------------------
+# scan_library — scope isolation
+# ---------------------------------------------------------------------------
+
+class TestScopedScan:
+    def setup_method(self):
+        self.tmp, self.lib = _mk_lib()
+
+    def _book_folder(self, *parts) -> Path:
+        d = self.lib / "books"
+        for p in parts:
+            d = d / p
+        d.mkdir(parents=True, exist_ok=True)
+        return d
+
+    def test_scope_only_adds_files_in_subtree(self):
+        in_scope = self._book_folder("ScopeSysA", "adventure")
+        (in_scope / "scoped_only.pdf").write_bytes(b"%PDF-1.4")
+        out_scope = self._book_folder("ScopeSysB", "core")
+        (out_scope / "elsewhere.pdf").write_bytes(b"%PDF-1.4")
+
+        _scan(self.lib, self.tmp, scope_path="books/ScopeSysA/adventure")
+
+        assert _get_book("scoped_only.pdf") is not None
+        # File outside the scope must NOT have been registered.
+        assert _get_book("elsewhere.pdf") is None
+
+    def test_scope_does_not_flag_sibling_as_missing(self):
+        # First, a full scan registers both.
+        a = self._book_folder("MissSysA", "core")
+        (a / "a_book.pdf").write_bytes(b"%PDF-1.4")
+        b = self._book_folder("MissSysB", "core")
+        (b / "b_book.pdf").write_bytes(b"%PDF-1.4")
+        _scan(self.lib, self.tmp)
+        assert _get_book("a_book.pdf").is_missing is False
+        assert _get_book("b_book.pdf").is_missing is False
+
+        # Delete the out-of-scope file, then rescan only SysA.
+        (b / "b_book.pdf").unlink()
+        _scan(self.lib, self.tmp, scope_path="books/MissSysA")
+
+        # SysB's record must be untouched (not flagged missing) by the scoped scan.
+        assert _get_book("b_book.pdf").is_missing is False
+
+
+# ---------------------------------------------------------------------------
+# scan_library — metadata refresh on already-indexed books
+# ---------------------------------------------------------------------------
+
+class TestMetadataRefresh:
+    def setup_method(self):
+        self.tmp, self.lib = _mk_lib()
+
+    def _setup_book(self, system: str):
+        folder = self.lib / "books" / system / "core" / "Book"
+        folder.mkdir(parents=True, exist_ok=True)
+        (folder / "the_book.pdf").write_bytes(b"%PDF-1.4")
+        return folder
+
+    def _write_opf(self, folder, **fields):
+        (folder / "metadata.opf").write_text(
+            OPF.format(
+                title=fields.get("title", "OPF Title"),
+                author=fields.get("author", "OPF Author"),
+                publisher=fields.get("publisher", "OPF Publisher"),
+                desc=fields.get("desc", "OPF Description"),
+            ),
+            encoding="utf-8",
+        )
+
+    def _set_field(self, system, **fields):
+        db = SessionLocal()
+        try:
+            book = db.query(Book).filter(Book.filename == "the_book.pdf").filter(
+                Book.relative_path.like(f"books/{system}/%")
+            ).first()
+            for k, v in fields.items():
+                setattr(book, k, v)
+            db.commit()
+        finally:
+            db.close()
+
+    def test_missing_fills_empty_but_protects_edited(self):
+        folder = self._setup_book("RefreshMissing")
+        _scan(self.lib, self.tmp)  # initial scan, no OPF
+        # Simulate a user-edited publisher and an empty description.
+        self._set_field("RefreshMissing", publisher="User Publisher", description="")
+
+        self._write_opf(folder, publisher="OPF Publisher", desc="OPF Description")
+        _scan(self.lib, self.tmp, scope_path="books/RefreshMissing", metadata_mode="missing")
+
+        book = _get_book("the_book.pdf", system="RefreshMissing")
+        assert book.publisher == "User Publisher"   # protected (non-null)
+        assert book.description == "OPF Description"  # filled (was empty)
+
+    def test_replace_overwrites_edited(self):
+        folder = self._setup_book("RefreshReplace")
+        _scan(self.lib, self.tmp)
+        self._set_field("RefreshReplace", publisher="User Publisher")
+
+        self._write_opf(folder, publisher="OPF Publisher")
+        _scan(self.lib, self.tmp, scope_path="books/RefreshReplace", metadata_mode="replace")
+
+        assert _get_book("the_book.pdf", system="RefreshReplace").publisher == "OPF Publisher"
+
+    def test_new_mode_does_not_refresh(self):
+        folder = self._setup_book("RefreshNew")
+        _scan(self.lib, self.tmp)
+        self._set_field("RefreshNew", publisher="User Publisher")
+
+        self._write_opf(folder, publisher="OPF Publisher")
+        _scan(self.lib, self.tmp, scope_path="books/RefreshNew", metadata_mode="new")
+
+        assert _get_book("the_book.pdf", system="RefreshNew").publisher == "User Publisher"

--- a/docs/api.md
+++ b/docs/api.md
@@ -73,7 +73,7 @@ Tokens are returned by `/api/auth/login` and expire after **30 days**.
 |----------|--------|------|-------------|
 | `/api/stats` | GET | JWT **or** `X-API-Key` header | Counts, page totals, library size, version |
 | `/api/scan-status` | GET | admin | Current scan state |
-| `/api/rescan` | POST | admin | Trigger a background rescan and reindex |
+| `/api/rescan` | POST | admin | Trigger a background rescan and reindex (optionally scoped, with a metadata-refresh mode) |
 | `/api/cancel-scan` | POST | admin | Request a graceful stop of the running scan or indexing job |
 
 **Stats response:**
@@ -104,12 +104,28 @@ Tokens are returned by `/api/auth/login` and expire after **30 days**.
   "new_books": 5,
   "new_maps": 0,
   "new_tokens": 0,
+  "updated_books": 0,
   "indexed": 80,
   "to_index": 320
 }
 ```
 
-`phase` is `"scanning"`, `"indexing"`, or `null` when idle.
+`phase` is `"scanning"`, `"indexing"`, or `null` when idle. `updated_books` counts books whose metadata was re-applied from sidecar files during a metadata-refresh rescan.
+
+**Rescan request body** (all fields optional):
+```json
+{
+  "scope": "books/D&D 5e/adventure",
+  "metadata_mode": "missing"
+}
+```
+
+| Field | Default | Description |
+|-------|---------|-------------|
+| `scope` | `null` | Restrict the rescan to a subtree relative to the library root. Must begin with `books/`, `maps/`, or `tokens/`. Omit to rescan the whole library. Paths that escape the library root return `400`. |
+| `metadata_mode` | `"new"` | `"new"` adds new files and flags missing ones (existing records untouched). `"missing"` additionally fills **empty** book fields from sidecar metadata (`<stem>.opf` / `metadata.opf`), leaving fields you've already set in place. `"replace"` overwrites fields wherever the sidecar provides a value (destructive to UI-edited metadata). |
+
+Returns `{"status": "scan_started"}`, or `{"status": "already_running"}` if a scan is already in progress (scoped and global rescans share the same single-worker lock).
 
 **Cancel-scan response:**
 ```json
@@ -544,4 +560,4 @@ When a book is first indexed, the scanner looks for an OPF metadata file alongsi
 
 Fields read: `dc:title`, `dc:creator` (role=aut → authors), `dc:publisher`, `dc:date` (year), `dc:description` (HTML stripped), `dc:subject` (→ tags). Cover images referenced in the OPF `<guide>` are excluded from the book list automatically.
 
-OPF metadata is applied only on first scan. Subsequent rescans do not overwrite values edited via the API.
+By default OPF metadata is applied only on a book's first scan, and ordinary rescans (`metadata_mode: "new"`) do not overwrite values edited via the API. To re-apply sidecar metadata to already-indexed books, rescan with `metadata_mode: "missing"` (fills empty fields only, non-destructive) or `metadata_mode: "replace"` (overwrites with the sidecar's values). Combine with `scope` to refresh just one folder.

--- a/frontend/src/components/RescanButton.jsx
+++ b/frontend/src/components/RescanButton.jsx
@@ -1,0 +1,70 @@
+import { useState, useEffect } from 'react'
+import { useTranslation } from 'react-i18next'
+import { LuRefreshCw } from 'react-icons/lu'
+import Spinner from './Spinner'
+import RescanModal from './RescanModal'
+import useScanStatus from '../hooks/useScanStatus'
+
+/**
+ * Rescan control for a folder row or panel. Opens RescanModal to pick a mode,
+ * then triggers a (optionally scoped) rescan via the shared useScanStatus hook.
+ *
+ * Props:
+ *   scope   – path string under books/ maps/ tokens/, or null for whole library
+ *   compact – icon-only styling for dense folder rows (default true)
+ *   label   – optional text label shown next to the icon (non-compact)
+ */
+export default function RescanButton({ scope = null, compact = true, label }) {
+  const { t } = useTranslation()
+  const { status, startRescan } = useScanStatus()
+  const [open, setOpen] = useState(false)
+  const [triggered, setTriggered] = useState(false)
+
+  const running = status.running && triggered
+
+  const handleConfirm = (metadata_mode) => {
+    setTriggered(true)
+    startRescan({ scope, metadata_mode }).catch(() => setTriggered(false))
+  }
+
+  // Clear our "this button started it" flag once the global scan finishes.
+  useEffect(() => {
+    if (triggered && !status.running) setTriggered(false)
+  }, [triggered, status.running])
+
+  const title = t('rescan.button.title')
+
+  return (
+    <>
+      <button
+        onClick={(e) => {
+          e.stopPropagation()
+          setOpen(true)
+        }}
+        disabled={status.running}
+        title={title}
+        aria-label={title}
+        style={{
+          display: 'inline-flex',
+          alignItems: 'center',
+          gap: compact ? 0 : 6,
+          padding: compact ? '2px 7px' : '6px 12px',
+          borderRadius: compact ? 5 : 6,
+          fontSize: compact ? 12 : 14,
+          flexShrink: 0,
+          color: running ? 'var(--gold)' : 'var(--text-muted)',
+          border: '1px solid var(--border)',
+          background: 'var(--bg-card)',
+          cursor: status.running ? 'default' : 'pointer',
+        }}
+      >
+        {running ? <Spinner size={compact ? 11 : 13} /> : <LuRefreshCw size={compact ? 11 : 13} />}
+        {!compact && (label || t('rescan.button.label'))}
+      </button>
+
+      {open && (
+        <RescanModal scope={scope} onConfirm={handleConfirm} onClose={() => setOpen(false)} />
+      )}
+    </>
+  )
+}

--- a/frontend/src/components/RescanButton.test.jsx
+++ b/frontend/src/components/RescanButton.test.jsx
@@ -1,0 +1,50 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { render, screen, fireEvent, waitFor } from '@testing-library/react'
+import RescanButton from './RescanButton'
+
+vi.mock('../api', () => ({
+  default: {
+    get: vi.fn(),
+    post: vi.fn(),
+  },
+}))
+
+import api from '../api'
+
+beforeEach(() => {
+  vi.resetAllMocks()
+  api.get.mockResolvedValue({ running: false, phase: null })
+  api.post.mockResolvedValue({})
+})
+
+describe('RescanButton', () => {
+  it('opens the modal and posts the scoped rescan on confirm', async () => {
+    render(<RescanButton scope="books/D&D 5e/adventure" />)
+    fireEvent.click(screen.getByRole('button', { name: /rescan/i }))
+
+    const confirm = await screen.findByText('Start rescan')
+    fireEvent.click(confirm)
+
+    await waitFor(() => {
+      expect(api.post).toHaveBeenCalledWith('/rescan', {
+        scope: 'books/D&D 5e/adventure',
+        metadata_mode: 'new',
+      })
+    })
+  })
+
+  it('posts the selected metadata mode', async () => {
+    render(<RescanButton scope="maps/Forests" />)
+    fireEvent.click(screen.getByRole('button', { name: /rescan/i }))
+
+    fireEvent.click(await screen.findByText('Update missing metadata'))
+    fireEvent.click(screen.getByText('Start rescan'))
+
+    await waitFor(() => {
+      expect(api.post).toHaveBeenCalledWith('/rescan', {
+        scope: 'maps/Forests',
+        metadata_mode: 'missing',
+      })
+    })
+  })
+})

--- a/frontend/src/components/RescanModal.jsx
+++ b/frontend/src/components/RescanModal.jsx
@@ -1,0 +1,222 @@
+import { useState, useEffect, useRef } from 'react'
+import { useTranslation } from 'react-i18next'
+import { LuX, LuRefreshCw, LuTriangleAlert } from 'react-icons/lu'
+
+/**
+ * Mode-selection modal for a rescan. Presents the three scan modes with
+ * descriptions and (for the destructive option) a warning. Confirming calls
+ * `onConfirm(metadata_mode)`; the caller owns the actual rescan request.
+ *
+ * Props:
+ *   scope     – path string the rescan will act on, or null for the whole library
+ *   onConfirm – (metadata_mode: string) => void
+ *   onClose   – () => void
+ */
+export default function RescanModal({ scope, onConfirm, onClose }) {
+  const { t } = useTranslation()
+  const [mode, setMode] = useState('new')
+  const firstRef = useRef(null)
+
+  const MODES = [
+    {
+      id: 'new',
+      label: t('rescan.modes.new.label'),
+      description: t('rescan.modes.new.description'),
+    },
+    {
+      id: 'missing',
+      label: t('rescan.modes.missing.label'),
+      description: t('rescan.modes.missing.description'),
+    },
+    {
+      id: 'replace',
+      label: t('rescan.modes.replace.label'),
+      description: t('rescan.modes.replace.description'),
+      warning: t('rescan.modes.replace.warning'),
+    },
+  ]
+
+  useEffect(() => {
+    firstRef.current?.focus()
+    const onKey = (e) => {
+      if (e.key === 'Escape') onClose()
+    }
+    window.addEventListener('keydown', onKey)
+    return () => window.removeEventListener('keydown', onKey)
+  }, [onClose])
+
+  const handleConfirm = () => {
+    onConfirm(mode)
+    onClose()
+  }
+
+  return (
+    <div
+      role="dialog"
+      aria-modal="true"
+      aria-labelledby="rescan-modal-title"
+      style={{
+        position: 'fixed',
+        inset: 0,
+        zIndex: 1200,
+        display: 'flex',
+        alignItems: 'center',
+        justifyContent: 'center',
+        background: 'rgba(0,0,0,0.55)',
+      }}
+      onClick={(e) => {
+        if (e.target === e.currentTarget) onClose()
+      }}
+    >
+      <div
+        style={{
+          background: 'var(--bg-panel)',
+          border: '1px solid var(--border)',
+          borderRadius: 10,
+          padding: 24,
+          width: 420,
+          maxWidth: '92vw',
+          boxSizing: 'border-box',
+        }}
+      >
+        <div
+          style={{
+            display: 'flex',
+            alignItems: 'center',
+            justifyContent: 'space-between',
+            marginBottom: 4,
+          }}
+        >
+          <span id="rescan-modal-title" style={{ fontSize: 15, fontWeight: 600 }}>
+            {t('rescan.modal.title')}
+          </span>
+          <button
+            onClick={onClose}
+            style={{
+              background: 'none',
+              border: 'none',
+              cursor: 'pointer',
+              color: 'var(--text-muted)',
+              display: 'flex',
+              padding: 2,
+            }}
+            aria-label={t('common.close')}
+          >
+            <LuX size={16} />
+          </button>
+        </div>
+        <p style={{ fontSize: 13, color: 'var(--text-muted)', marginBottom: 20 }}>
+          {scope ? t('rescan.modal.scopeLabel', { scope }) : t('rescan.modal.wholeLibrary')}
+        </p>
+
+        <div style={{ display: 'flex', flexDirection: 'column', gap: 8, marginBottom: 24 }}>
+          {MODES.map((m, i) => {
+            const selected = mode === m.id
+            return (
+              <label
+                key={m.id}
+                ref={i === 0 ? firstRef : null}
+                tabIndex={0}
+                onKeyDown={(e) => {
+                  if (e.key === ' ' || e.key === 'Enter') setMode(m.id)
+                }}
+                style={{
+                  display: 'flex',
+                  alignItems: 'flex-start',
+                  gap: 12,
+                  padding: '10px 14px',
+                  borderRadius: 8,
+                  cursor: 'pointer',
+                  border: `1px solid ${selected ? 'var(--gold-dim)' : 'var(--border)'}`,
+                  background: selected ? 'rgba(201,168,76,0.07)' : 'var(--bg-card)',
+                  userSelect: 'none',
+                }}
+              >
+                <input
+                  type="radio"
+                  name="rescan-mode"
+                  value={m.id}
+                  checked={selected}
+                  onChange={() => setMode(m.id)}
+                  style={{ marginTop: 2, accentColor: 'var(--gold)', flexShrink: 0 }}
+                />
+                <div>
+                  <span
+                    style={{
+                      fontSize: 14,
+                      fontWeight: 600,
+                      color: selected ? 'var(--gold)' : 'var(--text)',
+                    }}
+                  >
+                    {m.label}
+                  </span>
+                  <div
+                    style={{
+                      fontSize: 12,
+                      color: 'var(--text-muted)',
+                      marginTop: 2,
+                      lineHeight: 1.4,
+                    }}
+                  >
+                    {m.description}
+                  </div>
+                  {m.warning && selected && (
+                    <div
+                      style={{
+                        fontSize: 12,
+                        color: '#e07070',
+                        marginTop: 6,
+                        display: 'flex',
+                        alignItems: 'center',
+                        gap: 6,
+                        lineHeight: 1.4,
+                      }}
+                    >
+                      <LuTriangleAlert size={13} style={{ flexShrink: 0 }} />
+                      {m.warning}
+                    </div>
+                  )}
+                </div>
+              </label>
+            )
+          })}
+        </div>
+
+        <div style={{ display: 'flex', gap: 8, justifyContent: 'flex-end' }}>
+          <button
+            onClick={onClose}
+            style={{
+              padding: '7px 16px',
+              borderRadius: 6,
+              background: 'var(--bg-card)',
+              border: '1px solid var(--border)',
+              color: 'var(--text-dim)',
+              fontSize: 14,
+              cursor: 'pointer',
+            }}
+          >
+            {t('rescan.modal.cancel')}
+          </button>
+          <button
+            onClick={handleConfirm}
+            style={{
+              padding: '7px 18px',
+              borderRadius: 6,
+              background: 'var(--gold-dim)',
+              border: 'none',
+              color: 'var(--bg-deep)',
+              fontSize: 14,
+              fontWeight: 600,
+              cursor: 'pointer',
+              display: 'flex',
+              alignItems: 'center',
+              gap: 6,
+            }}
+          >
+            <LuRefreshCw size={14} /> {t('rescan.modal.confirm')}
+          </button>
+        </div>
+      </div>
+    </div>
+  )
+}

--- a/frontend/src/components/RescanModal.test.jsx
+++ b/frontend/src/components/RescanModal.test.jsx
@@ -1,0 +1,46 @@
+import { describe, it, expect, vi } from 'vitest'
+import { render, screen, fireEvent } from '@testing-library/react'
+import RescanModal from './RescanModal'
+
+function renderModal(props = {}) {
+  return render(<RescanModal scope={null} onConfirm={vi.fn()} onClose={vi.fn()} {...props} />)
+}
+
+describe('RescanModal', () => {
+  it('defaults to "Find new files" and confirms with mode "new"', () => {
+    const onConfirm = vi.fn()
+    const onClose = vi.fn()
+    renderModal({ onConfirm, onClose })
+
+    fireEvent.click(screen.getByText('Start rescan'))
+    expect(onConfirm).toHaveBeenCalledWith('new')
+    expect(onClose).toHaveBeenCalled()
+  })
+
+  it('confirms the selected mode', () => {
+    const onConfirm = vi.fn()
+    renderModal({ onConfirm })
+
+    fireEvent.click(screen.getByText('Replace all metadata'))
+    fireEvent.click(screen.getByText('Start rescan'))
+    expect(onConfirm).toHaveBeenCalledWith('replace')
+  })
+
+  it('shows a destructive warning only for the replace mode', () => {
+    renderModal()
+    // Warning hidden until replace is selected.
+    expect(screen.queryByText(/overwrites fields you've edited/i)).not.toBeInTheDocument()
+    fireEvent.click(screen.getByText('Replace all metadata'))
+    expect(screen.getByText(/overwrites fields you've edited/i)).toBeInTheDocument()
+  })
+
+  it('shows the scope path when scoped', () => {
+    renderModal({ scope: 'books/D&D 5e/adventure' })
+    expect(screen.getByText(/books\/D&D 5e\/adventure/)).toBeInTheDocument()
+  })
+
+  it('shows whole-library copy when unscoped', () => {
+    renderModal({ scope: null })
+    expect(screen.getByText(/entire library/i)).toBeInTheDocument()
+  })
+})

--- a/frontend/src/components/media/MediaFolderGroup.jsx
+++ b/frontend/src/components/media/MediaFolderGroup.jsx
@@ -5,6 +5,7 @@ import MediaCard from './MediaCard'
 import FolderTagRow from './FolderTagRow'
 import FolderCheckbox from '../FolderCheckbox'
 import LazyGrid from '../LazyGrid'
+import RescanButton from '../RescanButton'
 import { toTitleCase } from '../../utils'
 
 const isMobilePhone = window.matchMedia('(max-width: 640px)').matches
@@ -164,6 +165,7 @@ export default function MediaFolderGroup({
               <LuDownload size={11} /> {t(`${i18n}.download`)}
             </button>
           )}
+          {!bulkMode && canTag && <RescanButton scope={`${i18n}/${folder}`} />}
         </div>
 
         {/* Tags row (desktop only — mobile shows tags below when expanded) */}
@@ -315,6 +317,7 @@ export default function MediaFolderGroup({
                           >
                             <LuDownload size={11} /> {t(`${i18n}.download`)}
                           </button>
+                          {canTag && <RescanButton scope={`${i18n}/${folder}/${subPath}`} />}
                         </>
                       )}
                       {editingFolder === editKey && !isMobilePhone && (

--- a/frontend/src/components/settings/MaintenanceTab.test.jsx
+++ b/frontend/src/components/settings/MaintenanceTab.test.jsx
@@ -129,11 +129,22 @@ describe('MaintenanceTab — RescanSection', () => {
     })
   })
 
-  it('calls /rescan when Rescan Library is clicked', async () => {
+  it('opens the rescan modal and posts the selected mode/scope on confirm', async () => {
     render(<MaintenanceTab />)
     fireEvent.click(screen.getByRole('button', { name: /rescan library/i }))
+    // Modal opens; confirm with the default "Find new files" mode.
+    const confirm = await screen.findByText('Start rescan')
+    fireEvent.click(confirm)
     await waitFor(() => {
-      expect(api.post).toHaveBeenCalledWith('/rescan')
+      expect(api.post).toHaveBeenCalledWith('/rescan', { scope: null, metadata_mode: 'new' })
+    })
+  })
+
+  it('shows the updated-metadata count in the completion summary', async () => {
+    api.get.mockResolvedValue({ ...idleStatus, updated_books: 4 })
+    render(<MaintenanceTab />)
+    await waitFor(() => {
+      expect(screen.getByText('4 updated')).toBeInTheDocument()
     })
   })
 })

--- a/frontend/src/components/settings/RescanSection.jsx
+++ b/frontend/src/components/settings/RescanSection.jsx
@@ -1,65 +1,17 @@
-import { useState, useEffect } from 'react'
+import { useState } from 'react'
 import { useTranslation } from 'react-i18next'
 import { LuCircleCheck, LuRefreshCw, LuSquare } from 'react-icons/lu'
-import api from '../../api'
 import Spinner from '../Spinner'
+import RescanModal from '../RescanModal'
+import useScanStatus from '../../hooks/useScanStatus'
 
 export default function RescanSection() {
   const { t } = useTranslation()
-  const [status, setStatus] = useState({
-    running: false,
-    phase: null,
-    total_books: 0,
-    scanned_books: 0,
-    total_maps: 0,
-    scanned_maps: 0,
-    total_tokens: 0,
-    scanned_tokens: 0,
-    indexed: 0,
-    to_index: 0,
-    new_books: 0,
-    new_maps: 0,
-    new_tokens: 0,
-  })
-  const [lastResult, setLastResult] = useState(null)
-  const [stopping, setStopping] = useState(false)
+  const { status, lastResult, stopping, startRescan, stopScan } = useScanStatus()
+  const [showModal, setShowModal] = useState(false)
 
-  useEffect(() => {
-    const poll = () => {
-      api
-        .get('/scan-status')
-        .then((s) => {
-          setStatus(s)
-          if (!s.running) {
-            const total = s.new_books + s.new_maps + s.new_tokens
-            if (total > 0 || s.indexed > 0) setLastResult(s)
-          }
-        })
-        .catch(() => {})
-    }
-
-    poll()
-    const id = setInterval(poll, status.running ? 1000 : 30000)
-    return () => clearInterval(id)
-  }, [status.running])
-
-  const handleRescan = async () => {
-    if (status.running) return
-    setLastResult(null)
-    setStopping(false)
-    setStatus((s) => ({ ...s, running: true, phase: 'scanning' }))
-    try {
-      await api.post('/rescan')
-    } catch (_) {
-      setStatus((s) => ({ ...s, running: false, phase: null }))
-    }
-  }
-
-  const handleStop = async () => {
-    setStopping(true)
-    try {
-      await api.post('/cancel-scan')
-    } catch (_) {}
+  const handleConfirm = (metadata_mode) => {
+    startRescan({ scope: null, metadata_mode }).catch(() => {})
   }
 
   const {
@@ -99,7 +51,7 @@ export default function RescanSection() {
       </p>
       <div style={{ display: 'flex', alignItems: 'center', gap: 8 }}>
         <button
-          onClick={handleRescan}
+          onClick={() => !running && setShowModal(true)}
           disabled={running}
           style={{
             display: 'inline-flex',
@@ -120,7 +72,7 @@ export default function RescanSection() {
         </button>
         {running && (
           <button
-            onClick={handleStop}
+            onClick={stopScan}
             disabled={stopping}
             title={t('maintenance.rescan.stop')}
             style={{
@@ -277,14 +229,22 @@ export default function RescanSection() {
               {lastResult.indexed > 0 && (
                 <span>{t('maintenance.rescan.indexed', { count: lastResult.indexed })}</span>
               )}
+              {lastResult.updated_books > 0 && (
+                <span>{t('maintenance.rescan.updated', { count: lastResult.updated_books })}</span>
+              )}
               {lastResult.new_books +
                 lastResult.new_maps +
                 lastResult.new_tokens +
-                lastResult.indexed ===
+                lastResult.indexed +
+                (lastResult.updated_books || 0) ===
                 0 && <span>{t('maintenance.rescan.noNewFiles')}</span>}
             </div>
           </div>
         </div>
+      )}
+
+      {showModal && (
+        <RescanModal scope={null} onConfirm={handleConfirm} onClose={() => setShowModal(false)} />
       )}
     </div>
   )

--- a/frontend/src/components/system/BookFolderGroup.jsx
+++ b/frontend/src/components/system/BookFolderGroup.jsx
@@ -2,6 +2,14 @@ import { LuFolder, LuChevronDown, LuChevronRight, LuDownload } from 'react-icons
 import { toTitleCase } from '../../utils'
 import BookRow from './BookRow'
 import BookEditor from './BookEditor'
+import RescanButton from '../RescanButton'
+
+/** The library-root-relative folder a group of books shares (relative_path minus filename). */
+function folderScope(books) {
+  const ref = (books || []).find((b) => b.relative_path)
+  if (!ref) return null
+  return ref.relative_path.replace(/\\/g, '/').split('/').slice(0, -1).join('/')
+}
 
 /**
  * Renders a single subfolder group within a book category section.
@@ -122,6 +130,7 @@ export default function BookFolderGroup({
         >
           <LuDownload size={11} /> Download
         </button>
+        {isEditor && <RescanButton scope={folderScope(books)} />}
       </div>
 
       {/* Book list */}

--- a/frontend/src/components/system/BookFolderGroup.test.jsx
+++ b/frontend/src/components/system/BookFolderGroup.test.jsx
@@ -23,6 +23,11 @@ vi.mock('./BookEditor', () => ({
   ),
 }))
 
+// RescanButton polls /scan-status — stub it out so these tests stay focused.
+vi.mock('../RescanButton', () => ({
+  default: () => <div data-testid="rescan-button" />,
+}))
+
 function makeBook(overrides = {}) {
   return {
     id: `book-${Math.random().toString(36).slice(2)}`,

--- a/frontend/src/hooks/useScanStatus.js
+++ b/frontend/src/hooks/useScanStatus.js
@@ -1,0 +1,81 @@
+import { useState, useEffect, useCallback } from 'react'
+import api from '../api'
+
+const EMPTY = {
+  running: false,
+  phase: null,
+  total_books: 0,
+  scanned_books: 0,
+  total_maps: 0,
+  scanned_maps: 0,
+  total_tokens: 0,
+  scanned_tokens: 0,
+  indexed: 0,
+  to_index: 0,
+  new_books: 0,
+  new_maps: 0,
+  new_tokens: 0,
+  updated_books: 0,
+}
+
+/**
+ * Polls /scan-status and exposes the current scan state plus a helper to start a
+ * (optionally scoped) rescan. Shared by the Settings maintenance panel and the
+ * per-folder rescan controls so there is a single notion of "is a scan running".
+ *
+ * Polls every second while a scan is running, every 30s when idle.
+ */
+export default function useScanStatus() {
+  const [status, setStatus] = useState(EMPTY)
+  const [lastResult, setLastResult] = useState(null)
+  const [stopping, setStopping] = useState(false)
+
+  useEffect(() => {
+    let cancelled = false
+    const poll = () => {
+      api
+        .get('/scan-status')
+        .then((s) => {
+          if (cancelled) return
+          setStatus(s)
+          if (!s.running) {
+            const total = s.new_books + s.new_maps + s.new_tokens + (s.updated_books || 0)
+            if (total > 0 || s.indexed > 0) setLastResult(s)
+          }
+        })
+        .catch(() => {})
+    }
+
+    poll()
+    const id = setInterval(poll, status.running ? 1000 : 30000)
+    return () => {
+      cancelled = true
+      clearInterval(id)
+    }
+  }, [status.running])
+
+  const startRescan = useCallback(
+    async ({ scope = null, metadata_mode = 'new' } = {}) => {
+      if (status.running) return
+      setLastResult(null)
+      setStopping(false)
+      setStatus((s) => ({ ...s, running: true, phase: 'scanning' }))
+      try {
+        await api.post('/rescan', { scope, metadata_mode })
+      } catch (_) {
+        setStatus((s) => ({ ...s, running: false, phase: null }))
+        throw _
+      }
+    },
+    [status.running]
+  )
+
+  const stopScan = useCallback(async () => {
+    setStopping(true)
+    try {
+      await api.post('/cancel-scan')
+    } catch (_) {}
+  }, [])
+
+  return { status, lastResult, stopping, startRescan, stopScan }
+}

--- a/frontend/src/locales/de-DE.json
+++ b/frontend/src/locales/de-DE.json
@@ -501,7 +501,9 @@
       "booksProgress": "{{scanned}}/{{total}} Bücher",
       "mapsProgress": "{{scanned}}/{{total}} Karten",
       "tokensProgress": "{{scanned}}/{{total}} Tokens",
-      "indexProgress": "{{pct}}% — {{indexed}} von {{total}} PDFs indiziert"
+      "indexProgress": "{{pct}}% — {{indexed}} von {{total}} PDFs indiziert",
+      "updated_one": "{{count}} updated",
+      "updated_other": "{{count}} updated"
     },
     "scheduledRescan": {
       "title": "Geplanter Rescan",
@@ -1124,5 +1126,33 @@
     "copyForDiscord": "Für Discord kopieren",
     "email": "E-Mail",
     "copied": "Kopiert!"
+  },
+  "rescan": {
+    "button": {
+      "label": "Rescan",
+      "title": "Rescan this folder"
+    },
+    "modal": {
+      "title": "Rescan",
+      "wholeLibrary": "This will rescan the entire library.",
+      "scopeLabel": "Scope: {{scope}}",
+      "confirm": "Start rescan",
+      "cancel": "Cancel"
+    },
+    "modes": {
+      "new": {
+        "label": "Find new files",
+        "description": "Add newly added files and flag any that have gone missing. Existing entries are left as-is."
+      },
+      "missing": {
+        "label": "Update missing metadata",
+        "description": "Also fill in empty fields from sidecar files (OPF, tags.json). Fields you've already set are kept."
+      },
+      "replace": {
+        "label": "Replace all metadata",
+        "description": "Overwrite metadata with whatever the sidecar files provide.",
+        "warning": "This overwrites fields you've edited in the UI."
+      }
+    }
   }
 }

--- a/frontend/src/locales/en-US.json
+++ b/frontend/src/locales/en-US.json
@@ -569,7 +569,9 @@
       "booksProgress": "{{scanned}}/{{total}} books",
       "mapsProgress": "{{scanned}}/{{total}} maps",
       "tokensProgress": "{{scanned}}/{{total}} tokens",
-      "indexProgress": "{{pct}}% — {{indexed}} of {{total}} PDFs indexed"
+      "indexProgress": "{{pct}}% — {{indexed}} of {{total}} PDFs indexed",
+      "updated_one": "{{count}} updated",
+      "updated_other": "{{count}} updated"
     },
     "scheduledRescan": {
       "title": "Scheduled Rescan",
@@ -1193,5 +1195,33 @@
     "copyForDiscord": "Copy for Discord",
     "email": "Email",
     "copied": "Copied!"
+  },
+  "rescan": {
+    "button": {
+      "label": "Rescan",
+      "title": "Rescan this folder"
+    },
+    "modal": {
+      "title": "Rescan",
+      "wholeLibrary": "This will rescan the entire library.",
+      "scopeLabel": "Scope: {{scope}}",
+      "confirm": "Start rescan",
+      "cancel": "Cancel"
+    },
+    "modes": {
+      "new": {
+        "label": "Find new files",
+        "description": "Add newly added files and flag any that have gone missing. Existing entries are left as-is."
+      },
+      "missing": {
+        "label": "Update missing metadata",
+        "description": "Also fill in empty fields from sidecar files (OPF, tags.json). Fields you've already set are kept."
+      },
+      "replace": {
+        "label": "Replace all metadata",
+        "description": "Overwrite metadata with whatever the sidecar files provide.",
+        "warning": "This overwrites fields you've edited in the UI."
+      }
+    }
   }
 }

--- a/frontend/src/locales/fr-CA.json
+++ b/frontend/src/locales/fr-CA.json
@@ -569,7 +569,9 @@
       "booksProgress": "{{scanned}}/{{total}} livres",
       "mapsProgress": "{{scanned}}/{{total}} cartes",
       "tokensProgress": "{{scanned}}/{{total}} pions",
-      "indexProgress": "{{pct}} % — {{indexed}} sur {{total}} PDF indexés"
+      "indexProgress": "{{pct}} % — {{indexed}} sur {{total}} PDF indexés",
+      "updated_one": "{{count}} updated",
+      "updated_other": "{{count}} updated"
     },
     "scheduledRescan": {
       "title": "Réanalyse planifiée",
@@ -1192,5 +1194,33 @@
     "copyForDiscord": "Copier pour Discord",
     "email": "Courriel",
     "copied": "Copié !"
+  },
+  "rescan": {
+    "button": {
+      "label": "Rescan",
+      "title": "Rescan this folder"
+    },
+    "modal": {
+      "title": "Rescan",
+      "wholeLibrary": "This will rescan the entire library.",
+      "scopeLabel": "Scope: {{scope}}",
+      "confirm": "Start rescan",
+      "cancel": "Cancel"
+    },
+    "modes": {
+      "new": {
+        "label": "Find new files",
+        "description": "Add newly added files and flag any that have gone missing. Existing entries are left as-is."
+      },
+      "missing": {
+        "label": "Update missing metadata",
+        "description": "Also fill in empty fields from sidecar files (OPF, tags.json). Fields you've already set are kept."
+      },
+      "replace": {
+        "label": "Replace all metadata",
+        "description": "Overwrite metadata with whatever the sidecar files provide.",
+        "warning": "This overwrites fields you've edited in the UI."
+      }
+    }
   }
 }

--- a/frontend/src/locales/fr-FR.json
+++ b/frontend/src/locales/fr-FR.json
@@ -569,7 +569,9 @@
       "booksProgress": "{{scanned}}/{{total}} livres",
       "mapsProgress": "{{scanned}}/{{total}} cartes",
       "tokensProgress": "{{scanned}}/{{total}} pions",
-      "indexProgress": "{{pct}} % — {{indexed}} sur {{total}} PDF indexés"
+      "indexProgress": "{{pct}} % — {{indexed}} sur {{total}} PDF indexés",
+      "updated_one": "{{count}} updated",
+      "updated_other": "{{count}} updated"
     },
     "scheduledRescan": {
       "title": "Réanalyse planifiée",
@@ -1192,5 +1194,33 @@
     "copyForDiscord": "Copier pour Discord",
     "email": "Courriel",
     "copied": "Copié !"
+  },
+  "rescan": {
+    "button": {
+      "label": "Rescan",
+      "title": "Rescan this folder"
+    },
+    "modal": {
+      "title": "Rescan",
+      "wholeLibrary": "This will rescan the entire library.",
+      "scopeLabel": "Scope: {{scope}}",
+      "confirm": "Start rescan",
+      "cancel": "Cancel"
+    },
+    "modes": {
+      "new": {
+        "label": "Find new files",
+        "description": "Add newly added files and flag any that have gone missing. Existing entries are left as-is."
+      },
+      "missing": {
+        "label": "Update missing metadata",
+        "description": "Also fill in empty fields from sidecar files (OPF, tags.json). Fields you've already set are kept."
+      },
+      "replace": {
+        "label": "Replace all metadata",
+        "description": "Overwrite metadata with whatever the sidecar files provide.",
+        "warning": "This overwrites fields you've edited in the UI."
+      }
+    }
   }
 }

--- a/frontend/src/views/SystemDetailView.jsx
+++ b/frontend/src/views/SystemDetailView.jsx
@@ -31,6 +31,7 @@ import BookRow from '../components/system/BookRow'
 import BookEditor from '../components/system/BookEditor'
 import SystemEditor from '../components/system/SystemEditor'
 import BookFolderGroup from '../components/system/BookFolderGroup'
+import RescanButton from '../components/RescanButton'
 import FavoriteButton from '../components/FavoriteButton'
 import ViewModeToggle from '../components/ViewModeToggle'
 import useViewMode from '../hooks/useViewMode'
@@ -43,6 +44,36 @@ function getBookSubfolder(book) {
   const parts = (book.relative_path || '').replace(/\\/g, '/').split('/')
   // parts[0]=books, parts[1]=SystemName, parts[2]=category dir, parts[3]=subfolder or filename
   return parts.length > 4 ? parts[3] : null
+}
+
+/** The library-root-relative folder a book lives in (its relative_path minus the
+ *  filename), e.g. "books/D&D 5e/adventure/Curse of Strahd". Used as the rescan scope. */
+function bookFolderScope(book) {
+  const parts = (book.relative_path || '').replace(/\\/g, '/').split('/')
+  return parts.slice(0, -1).join('/')
+}
+
+/** The "books/{SystemName}" scope for a whole system, derived from any of its books. */
+function systemScope(books) {
+  const ref = (books || []).find((b) => b.relative_path)
+  if (!ref) return null
+  const parts = ref.relative_path.replace(/\\/g, '/').split('/')
+  return parts.length >= 2 ? `${parts[0]}/${parts[1]}` : null
+}
+
+/** The deepest common folder scope shared by a group of books (their category or
+ *  subfolder dir). Falls back to the system scope when paths diverge. */
+function groupScope(books) {
+  const dirs = (books || []).map(bookFolderScope).filter(Boolean)
+  if (dirs.length === 0) return null
+  const split = dirs.map((d) => d.split('/'))
+  const common = []
+  for (let i = 0; i < split[0].length; i++) {
+    const seg = split[0][i]
+    if (split.every((p) => p[i] === seg)) common.push(seg)
+    else break
+  }
+  return common.length >= 2 ? common.join('/') : systemScope(books)
 }
 
 export default function SystemDetailView() {
@@ -470,6 +501,13 @@ export default function SystemDetailView() {
                 >
                   <LuDownload size={13} /> {t('systemDetail.downloadAll')}
                 </button>
+                {isEditor && (
+                  <RescanButton
+                    scope={systemScope(system.books)}
+                    compact={false}
+                    label={t('rescan.button.label')}
+                  />
+                )}
               </div>
               {/* Row 2: Collapse / Expand */}
               <div
@@ -791,6 +829,7 @@ export default function SystemDetailView() {
                     >
                       <LuDownload size={11} /> {t('systemDetail.download')}
                     </button>
+                    {isEditor && <RescanButton scope={groupScope(books)} />}
                   </div>
                   {!isCollapsed &&
                     (() => {


### PR DESCRIPTION
## Summary

Rescan is no longer all-or-nothing. The scan engine now accepts an optional path scope and a metadata-refresh mode, exposed as two orthogonal options on a single POST /rescan endpoint and surfaced in the UI via a mode-selection modal.

Scoped rescan (#109):
- scan_library accepts scope_path; only the matching collection/subtree is walked, and the missing-file sweep + tags.json application are limited to that scope so the rest of the index is untouched.
- resolve_scope guards against path traversal (400 on escape) and keeps the walk paths library-relative so scoped filepaths match unscoped ones.
- A rescan button is added to every system, category, and book subfolder, and to maps/tokens top-level groups and subfolders. Scopes are derived from each item's relative_path. Scoped and global rescans share the single-worker lock.

Metadata refresh (#106):
- Already-indexed books can re-apply sidecar metadata via metadata_mode: "new" (default, existing records untouched), "missing" (fill empty fields only, non-destructive — any non-null DB value is protected), or "replace" (sidecar wins, overwrites). Fields absent from the sidecar are never touched.
- New updated_books counter surfaced in scan status and the completion summary.


## Type of change

- [ ] Bug fix
- [x] New feature
- [ ] Refactor / cleanup
- [ ] Docs / configuration only

## Testing

<!-- How did you verify this works? Check all that apply. -->

- [x] Backend tests pass (`pytest -q`)
- [x] Frontend tests pass (`npm test`)
- [x] Tested manually in the browser

