### PR TITLE
Enhancement: Add support for managing audio

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -1,0 +1,15 @@
+# Coverage config for the backend per-changed-file coverage gate
+# (backend/scripts/check_coverage.py). Run with:
+#   pytest --cov=backend --cov-report=json
+[run]
+source = backend
+omit =
+    backend/tests/*
+    backend/scripts/*
+
+[report]
+# Lines that never need coverage (defensive branches, type-checking imports).
+exclude_lines =
+    pragma: no cover
+    if __name__ == .__main__.:
+    if TYPE_CHECKING:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -50,6 +50,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
+        with:
+          # Full history so the per-changed-file coverage gate can diff against
+          # the PR base branch.
+          fetch-depth: 0
 
       - uses: actions/setup-python@v5
         with:
@@ -67,5 +71,13 @@ jobs:
       - name: Check imports
         run: python -c "import backend.main"
 
-      - name: Run tests
-        run: pytest backend/tests/ -v
+      - name: Run tests with coverage
+        run: pytest backend/tests/ -v --cov=backend --cov-report=json --cov-report=term
+
+      - name: Check per-changed-file coverage
+        if: github.event_name == 'pull_request'
+        env:
+          BASE_REF: origin/${{ github.event.pull_request.base.ref }}
+        run: |
+          git fetch --no-tags --depth=1 origin "${{ github.event.pull_request.base.ref }}"
+          python backend/scripts/check_coverage.py

--- a/.gitignore
+++ b/.gitignore
@@ -15,3 +15,6 @@ frontend/coverage
 node_modules
 .venv
 .pytest_cache
+.coverage
+coverage.json
+htmlcov

--- a/README.md
+++ b/README.md
@@ -19,15 +19,17 @@ A Docker-based web application for managing your tabletop RPG PDF collection. Br
 ## Features
 
 - **Library Browser** — Organizes your collection by game system with automatic folder detection
-- **Full-Text Search** — Every page of every PDF is indexed with SQLite FTS5 for instant search; also finds maps and tokens by filename, folder, or tag
+- **Full-Text Search** — Every page of every PDF is indexed with SQLite FTS5 for instant search; also finds maps, tokens, and audio by filename, folder, or tag
 - **Page-by-Page Viewer** — PDFs rendered as images for fast mobile viewing with pinch-to-zoom, swipe navigation, and spread mode
 - **Map Gallery** — Browse battlemaps by directory structure with tag filtering, grid metadata, and full-res download
 - **Token Browser** — Browse and tag character tokens and portrait assets
+- **Audio Library** — Browse ambient tracks, soundscapes, music, and sound effects by directory structure with tag filtering and in-browser playback (MP3, OGG, Opus, FLAC, WAV, M4A, AAC). Reads embedded duration and title/artist/album tags, and uses folder `cover`/`folder` images or embedded album art for artwork
+- **Global Audio Player** — A persistent pop-out player that keeps playing while you navigate. Build a local queue by playing a whole folder, queueing tracks one at a time ("Play Next"), having a GM play a campaign resource group, or playing all the audio embedded in a wiki note. Expand it to see and reorder upcoming tracks, with a repeat-current-track toggle
 - **Bookmarks** — Per-user page and text-selection bookmarks with inline highlights
-- **Favorites** — Save systems, books, maps, and tokens for quick access
-- **View Modes** — Toggle the systems, books, maps, and tokens grids between card, compact, and list layouts; each content type remembers its own default (configurable in Account Settings) while the in-page toggle is a per-tab override. Cards and list rows include quick download and favorite buttons.
+- **Favorites** — Save systems, books, maps, tokens, and audio for quick access
+- **View Modes** — Toggle the systems, books, maps, tokens, and audio grids between card, compact, and list layouts; each content type remembers its own default (configurable in Account Settings) while the in-page toggle is a per-tab override. Cards and list rows include quick download and favorite buttons.
 - **Metadata Editor** — Add descriptions, tags, genre, publisher links, and character builder URLs
-- **Bulk Actions** — Multi-select books, maps, and tokens (click, shift-click for a range, ⌘/Ctrl-click to toggle) then bulk tag, add to a campaign, or edit metadata via a carousel
+- **Bulk Actions** — Multi-select books, maps, tokens, and audio (click, shift-click for a range, ⌘/Ctrl-click to toggle) then bulk tag, add to a campaign, or edit metadata via a carousel
 - **Campaigns** — Track GM-run and personal campaigns; a markdown notes wiki with deep linking, Markdown/JSON/LegendKeeper import & export, character art and sheets, linked resources, and scheduling
 - **OPDS Catalog** — Each user can generate a personal OPDS feed URL to connect e-reader apps directly to their library
 - **Docker Ready** — One command to run, mount your library directory, done
@@ -65,9 +67,13 @@ library/
 │   └── Sunken Temple (22x22)/
 │       ├── Sunken Temple Basement.png
 │       └── The Sunken Temple.png
-└── tokens/
-    └── Monsters/
-        └── goblin.png
+├── tokens/
+│   └── Monsters/
+│       └── goblin.png
+└── audio/
+    └── Ambient/
+        ├── cover.jpg
+        └── tavern-night.mp3
 ```
 
 See [Library Structure](#library-structure) for the full layout and category rules.
@@ -350,11 +356,22 @@ tokens/
     └── token-file.png
 ```
 
+### Audio — organize by category or creator
+
+```
+audio/
+└── Category or Creator/
+    ├── cover.jpg        # optional folder artwork (cover.* or folder.*)
+    └── track.mp3
+```
+
+The folder name is shown as a group header in the audio library. Supported formats: `.mp3`, `.ogg`, `.opus`, `.flac`, `.wav`, `.m4a`, `.aac`. Duration and embedded title/artist/album tags are read on scan. For artwork, Grimoire uses a `cover.*` or `folder.*` image in the track's folder if present, otherwise falls back to embedded album art.
+
 ---
 
 ## Tagging with tags.json
 
-Drop a `tags.json` file into any `maps/` or `tokens/` folder (or subfolder) to automatically apply tags when the library is scanned. You can also place one inside a game system folder under `books/` to tag the system itself.
+Drop a `tags.json` file into any `maps/`, `tokens/`, or `audio/` folder (or subfolder) to automatically apply tags when the library is scanned. You can also place one inside a game system folder under `books/` to tag the system itself.
 
 `tags.json` is a plain JSON object. Keys are paths resolved relative to the folder the file lives in:
 
@@ -511,7 +528,7 @@ docker compose up -d
 | `admin` | Everything — user management, app settings, metadata editing, rescan |
 | `gm` | Read everything, edit metadata, create GM campaigns |
 | `player` | Read-only access, personal campaigns, session notes |
-| `guest` | Code-only account scoped to a single campaign. No access to the library, maps, tokens, or search. See [Guest invites](#guest-invites). |
+| `guest` | Code-only account scoped to a single campaign. No access to the library, maps, tokens, audio, or search. See [Guest invites](#guest-invites). |
 
 Create additional accounts in **Settings → Users** after logging in as admin.
 
@@ -540,7 +557,7 @@ When OIDC is configured, this flag can be driven by the provider's [permissions 
 
 ### Guest invites
 
-Guests let you share a single campaign with people who don't have full accounts — for example a player who's only joining one game. A guest is a code-only account: no password, no OIDC, and no access to the library, maps, tokens, or search. They can only see the campaign they were invited to (and its shared resources, wiki, and schedule), and can edit only their **own** character name, character art, character sheet, session notes, and availability.
+Guests let you share a single campaign with people who don't have full accounts — for example a player who's only joining one game. A guest is a code-only account: no password, no OIDC, and no access to the library, maps, tokens, audio, or search. They can only see the campaign they were invited to (and its shared resources, wiki, and schedule), and can edit only their **own** character name, character art, character sheet, session notes, and availability.
 
 - **Enable it server-wide** in **Settings → Authentication → Guest Access**, or pin it with the `GUEST_ACCESS_ENABLED` environment variable. It's off by default.
 - **Invite from a GM campaign** — open the members roster and use **Guests** (admins and GMs only). Add a guest with a nickname; each guest gets a unique 10-character invite code. A campaign can have multiple guests.
@@ -557,12 +574,12 @@ Each campaign has a full-page markdown **wiki** (opened from the campaign overvi
 - **GM secrets inline** — wrap text in `||double pipes||` (or use the **GM secret** button) to hide just that span inside an otherwise shared page. The GM sees it highlighted; players never receive it — it's stripped on the server before the page is sent. (Personal campaigns keep everything, since only you can read them.)
 - **Nested pages** — organize the sidebar as a tree: any page can hold subpages, to any depth (a "category" is just a page with children). Drag pages to re-nest them, add a subpage from the parent row, and collapse/expand branches. Deleting a page lifts its subpages up to the parent rather than removing them.
 - **Page links** — write `[[Page Title]]` to link pages; missing targets are auto-created as stubs, and each page shows what links back to it.
-- **Grimoire embeds** — drop a book (optionally at a page), map, token, or campaign file straight into a page. The embed picker lists the campaign's **linked resources** (link new library content in the Resources panel first). You can also **upload an image** right from the picker — it's embedded inline and added to your linked resources, filed under an existing category or a new one you name on the spot (e.g. *NPC art*).
+- **Grimoire embeds** — drop a book (optionally at a page), map, token, audio track (plays in the global player; a note with several can be played as a playlist via "Play all"), or campaign file straight into a page. The embed picker lists the campaign's **linked resources** (link new library content in the Resources panel first). You can also **upload an image** right from the picker — it's embedded inline and added to your linked resources, filed under an existing category or a new one you name on the spot (e.g. *NPC art*).
 - **Import & export** (GM only) — export the whole wiki as a Markdown `.zip` (one file per page with YAML frontmatter — an Obsidian-style vault) or a JSON bundle, and import pages from Markdown, a Grimoire JSON bundle, or a **LegendKeeper** export (`.json`, `.lk`, or `.zip` — both the per-page export and the current `{version, resources}` bundle). LegendKeeper HTML and ProseMirror page bodies are converted to Markdown and the page hierarchy is preserved; LegendKeeper-only block types (e.g. secrets, embeds) are dropped, matching LegendKeeper's own export caveats. Imports are non-destructive — pages are always added, never overwritten.
 
 Existing session notes are automatically rolled into wiki pages (nested under a "Session Notes" page) the first time the new version starts; empty notes are discarded.
 
-**Resources** — link books, maps, and tokens, or upload campaign files (handouts, images, etc.) the GM keeps with the campaign. Each resource has a visibility: **Public** (all players), **Private** (shared with specific players — e.g. a handout for 2 of 4), or **GM only**. Resources group under their type by default, but the GM can create custom categories (e.g. *Player Handouts*), drag items between categories and reorder them, and delete categories (keeping items uncategorized or unlinking them). Each group can be **collapsed or expanded** (remembered per campaign), and the GM can **reorder all the groups** — custom categories and the built-in Books / Maps / Tokens / Files groups together — from the category manager.
+**Resources** — link books, maps, tokens, and audio, or upload campaign files (handouts, images, etc.) the GM keeps with the campaign. Each resource has a visibility: **Public** (all players), **Private** (shared with specific players — e.g. a handout for 2 of 4), or **GM only**. Resources group under their type by default, but the GM can create custom categories (e.g. *Player Handouts*), drag items between categories and reorder them, and delete categories (keeping items uncategorized or unlinking them). Each group can be **collapsed or expanded** (remembered per campaign), and the GM can **reorder all the groups** — custom categories and the built-in Books / Maps / Tokens / Audio / Files groups together — from the category manager.
 
 Uploaded campaign files live in the data directory, separate from the library. Admins can disable these uploads app-wide or cap them by per-file and per-campaign size in **Settings → App** (admins themselves are exempt).
 

--- a/backend/indexer.py
+++ b/backend/indexer.py
@@ -14,7 +14,7 @@ from sqlalchemy import text
 from sqlalchemy.exc import IntegrityError
 from sqlalchemy.orm import Session
 
-from .models import GameSystem, Book, GenericMap, MapFolder, Token, TokenFolder
+from .models import GameSystem, Book, GenericMap, MapFolder, Token, TokenFolder, Audio, AudioFolder
 
 logger = logging.getLogger("grimoire.indexer")
 
@@ -104,6 +104,9 @@ IMAGE_EXTS = {".png", ".jpg", ".jpeg", ".gif", ".webp", ".bmp", ".tiff", ".svg"}
 PDF_EXTS = {".pdf"}
 DOC_EXTS = {".pdf", ".epub", ".djvu"}
 MAP_IMAGE_EXTS = IMAGE_EXTS | PDF_EXTS
+AUDIO_EXTS = {".mp3", ".ogg", ".opus", ".flac", ".wav", ".m4a", ".aac"}
+# Basenames (sans extension) treated as folder cover art for audio tracks.
+_AUDIO_COVER_STEMS = {"cover", "folder"}
 
 
 def slugify(name: str) -> str:
@@ -240,6 +243,103 @@ def _count_eligible_files(directory: Path, extensions: set) -> int:
     return count
 
 
+def _read_audio_metadata(filepath: str) -> dict:
+    """Read duration and embedded tags from an audio file (best-effort).
+
+    Returns a dict with ``duration`` (float seconds), ``title``, ``artist``,
+    ``album`` (strings, blank when absent) and ``embedded_art`` (bool — whether
+    the file carries embedded cover art).  Never raises; on any failure it
+    returns zeroed/empty values so scanning continues.
+    """
+    info = {"duration": 0.0, "title": "", "artist": "", "album": "", "embedded_art": False}
+    try:
+        from mutagen import File as MutagenFile  # local import keeps startup light
+
+        easy = MutagenFile(filepath, easy=True)
+        if easy is not None:
+            if getattr(easy, "info", None) is not None:
+                length = getattr(easy.info, "length", 0) or 0
+                info["duration"] = round(float(length), 3)
+
+            def _first(key: str) -> str:
+                val = easy.get(key) if hasattr(easy, "get") else None
+                if isinstance(val, (list, tuple)) and val:
+                    return str(val[0]).strip()
+                return str(val).strip() if val else ""
+
+            info["title"] = _first("title")
+            info["artist"] = _first("artist")
+            info["album"] = _first("album")
+
+        info["embedded_art"] = _has_embedded_art(filepath)
+    except Exception as exc:
+        logger.debug(f"Could not read audio metadata for '{filepath}': {exc}")
+    return info
+
+
+def _has_embedded_art(filepath: str) -> bool:
+    """Return True if the audio file carries embedded cover art."""
+    try:
+        return _extract_embedded_art(filepath) is not None
+    except Exception:
+        return False
+
+
+def _extract_embedded_art(filepath: str):
+    """Return ``(image_bytes, mime)`` for embedded cover art, or None.
+
+    Handles ID3 APIC (MP3), FLAC/Opus PICTURE blocks, and MP4/M4A ``covr`` atoms.
+    """
+    try:
+        from mutagen import File as MutagenFile
+
+        audio = MutagenFile(filepath)
+        if audio is None:
+            return None
+
+        # FLAC / OggOpus expose .pictures
+        pics = getattr(audio, "pictures", None)
+        if pics:
+            pic = pics[0]
+            return (bytes(pic.data), getattr(pic, "mime", "") or "image/jpeg")
+
+        tags = getattr(audio, "tags", None)
+        if not tags:
+            return None
+
+        # ID3 APIC frames (MP3, sometimes WAV/AIFF)
+        if hasattr(tags, "getall"):
+            apics = tags.getall("APIC")
+            if apics:
+                apic = apics[0]
+                return (bytes(apic.data), getattr(apic, "mime", "") or "image/jpeg")
+
+        # MP4 / M4A cover atoms
+        covr = tags.get("covr") if hasattr(tags, "get") else None
+        if covr:
+            cover = covr[0]
+            fmt = getattr(cover, "imageformat", None)
+            mime = "image/png" if fmt == 14 else "image/jpeg"  # 14 == PNG in MP4Cover
+            return (bytes(cover), mime)
+    except Exception as exc:
+        logger.debug(f"Could not extract embedded art from '{filepath}': {exc}")
+    return None
+
+
+def _find_folder_artwork(folder: str):
+    """Return the path of a ``cover.*`` / ``folder.*`` image in ``folder``, or None."""
+    try:
+        for entry in os.scandir(folder):
+            if not entry.is_file():
+                continue
+            p = Path(entry.name)
+            if p.stem.lower() in _AUDIO_COVER_STEMS and p.suffix.lower() in IMAGE_EXTS:
+                return entry.path
+    except OSError:
+        pass
+    return None
+
+
 _OPF_NS = {
     "dc": "http://purl.org/dc/elements/1.1/",
     "opf": "http://www.idpf.org/2007/opf",
@@ -327,7 +427,7 @@ def resolve_scope(library_path: str, scope_path: str) -> tuple[str, Path]:
     """Resolve a user-supplied scope path against the library root.
 
     `scope_path` is a path relative to the library root and must begin with one
-    of the known collection folders (``books``/``maps``/``tokens``).  Returns a
+    of the known collection folders (``books``/``maps``/``tokens``/``audio``).  Returns a
     tuple of (section, absolute_dir).  Raises ValueError if the scope escapes the
     library root or names an unknown collection.
     """
@@ -337,8 +437,10 @@ def resolve_scope(library_path: str, scope_path: str) -> tuple[str, Path]:
         raise ValueError("scope path is empty")
 
     section = cleaned.split("/", 1)[0]
-    if section not in ("books", "maps", "tokens"):
-        raise ValueError(f"scope must start with books/, maps/, or tokens/: {scope_path!r}")
+    if section not in ("books", "maps", "tokens", "audio"):
+        raise ValueError(
+            f"scope must start with books/, maps/, tokens/, or audio/: {scope_path!r}"
+        )
 
     # Build the target without resolving symlinks so the walked paths match the
     # filepaths stored by an unscoped scan (which uses library_path verbatim).
@@ -389,8 +491,8 @@ def scan_library(library_path: str, data_path: str, session: Session, on_progres
                  should_stop=None, scope_path: str | None = None, metadata_mode: str = "new"):
     """Scan the library directory and register all files in the database.
 
-    on_progress(scanned_books, total_books, scanned_maps, total_maps, scanned_tokens, total_tokens)
-    is called after each file is processed if provided.
+    on_progress(scanned_books, total_books, scanned_maps, total_maps, scanned_tokens,
+    total_tokens, scanned_audio, total_audio) is called after each file is processed if provided.
 
     should_stop() is an optional callable that returns True when the scan should abort early.
 
@@ -406,12 +508,14 @@ def scan_library(library_path: str, data_path: str, session: Session, on_progres
     books_dir = library / "books"
     maps_dir = library / "maps"
     tokens_dir = library / "tokens"
+    audio_dir = library / "audio"
     thumb_dir = Path(data_path) / "thumbnails"
     stats = {
         "new_systems": 0,
         "new_books": 0,
         "new_maps": 0,
         "new_tokens": 0,
+        "new_audio": 0,
         "updated_books": 0,
         "indexed_pages": 0,
         "errors": 0,
@@ -427,11 +531,13 @@ def scan_library(library_path: str, data_path: str, session: Session, on_progres
     scan_books = scope_section in (None, "books")
     scan_maps = scope_section in (None, "maps")
     scan_tokens = scope_section in (None, "tokens")
+    scan_audio = scope_section in (None, "audio")
 
     # For a scoped books scan, walk only the scope dir; otherwise iterate every system.
     books_walk_dir = scope_dir if scope_section == "books" else books_dir
     maps_walk_dir = scope_dir if scope_section == "maps" else maps_dir
     tokens_walk_dir = scope_dir if scope_section == "tokens" else tokens_dir
+    audio_walk_dir = scope_dir if scope_section == "audio" else audio_dir
 
     total_books = (
         _count_eligible_files(books_walk_dir, DOC_EXTS | IMAGE_EXTS)
@@ -445,10 +551,14 @@ def scan_library(library_path: str, data_path: str, session: Session, on_progres
         _count_eligible_files(tokens_walk_dir, IMAGE_EXTS)
         if scan_tokens and tokens_walk_dir.exists() else 0
     )
-    scanned_books = scanned_maps = scanned_tokens = 0
+    total_audio = (
+        _count_eligible_files(audio_walk_dir, AUDIO_EXTS)
+        if scan_audio and audio_walk_dir.exists() else 0
+    )
+    scanned_books = scanned_maps = scanned_tokens = scanned_audio = 0
 
     if on_progress:
-        on_progress(0, total_books, 0, total_maps, 0, total_tokens)
+        on_progress(0, total_books, 0, total_maps, 0, total_tokens, 0, total_audio)
 
     # --- Scan /books ---
     if scan_books and books_dir.exists():
@@ -543,6 +653,8 @@ def scan_library(library_path: str, data_path: str, session: Session, on_progres
                             total_maps,
                             scanned_tokens,
                             total_tokens,
+                            scanned_audio,
+                            total_audio,
                         )
                     if should_stop and should_stop():
                         logger.info("scan_library: stop requested during books scan.")
@@ -721,6 +833,8 @@ def scan_library(library_path: str, data_path: str, session: Session, on_progres
                         total_maps,
                         scanned_tokens,
                         total_tokens,
+                        scanned_audio,
+                        total_audio,
                     )
                 if should_stop and should_stop():
                     logger.info("scan_library: stop requested during maps scan.")
@@ -804,6 +918,8 @@ def scan_library(library_path: str, data_path: str, session: Session, on_progres
                         total_maps,
                         scanned_tokens,
                         total_tokens,
+                        scanned_audio,
+                        total_audio,
                     )
                 if should_stop and should_stop():
                     logger.info("scan_library: stop requested during tokens scan.")
@@ -864,6 +980,88 @@ def scan_library(library_path: str, data_path: str, session: Session, on_progres
                     session.rollback()
                     logger.debug(f"Token already exists, skipping: {filepath}")
 
+    if scan_audio and audio_walk_dir.exists():
+        for root, dirs, files in os.walk(audio_walk_dir):
+            dirs[:] = [d for d in dirs if not d.startswith(".")]
+
+            for filename in sorted(files):
+                if filename.startswith("."):
+                    continue
+
+                filepath = os.path.join(root, filename)
+                ext = Path(filename).suffix.lower()
+
+                if ext not in AUDIO_EXTS:
+                    continue
+
+                scanned_audio += 1
+                if on_progress:
+                    on_progress(
+                        scanned_books,
+                        total_books,
+                        scanned_maps,
+                        total_maps,
+                        scanned_tokens,
+                        total_tokens,
+                        scanned_audio,
+                        total_audio,
+                    )
+                if should_stop and should_stop():
+                    logger.info("scan_library: stop requested during audio scan.")
+                    return stats
+
+                relative_path = os.path.relpath(filepath, library_path)
+
+                logger.info(f"Scanning audio ({scanned_audio}/{total_audio}): {filepath}")
+                logger.debug(f"DB: querying existing audio '{filepath}'")
+                try:
+                    existing = _run_with_timeout(
+                        lambda fp=filepath: session.query(Audio).filter_by(filepath=fp).first(),
+                        _DB_TIMEOUT, f"query audio '{filepath}'"
+                    )
+                except TimeoutError as e:
+                    logger.error(f"DB hang: {e} — skipping '{filename}'")
+                    stats["errors"] += 1
+                    continue
+                if existing:
+                    logger.debug(f"Already registered, skipping: {filename}")
+                    continue
+
+                try:
+                    file_size = os.path.getsize(filepath)
+                except OSError:
+                    logger.warning(f"Cannot stat file, skipping: {filepath}")
+                    continue
+
+                meta = _read_audio_metadata(filepath)
+                has_artwork = bool(meta["embedded_art"]) or _find_folder_artwork(root) is not None
+
+                track = Audio(
+                    filename=filename,
+                    filepath=filepath,
+                    relative_path=relative_path,
+                    file_size=file_size,
+                    duration=meta["duration"],
+                    title=meta["title"],
+                    artist=meta["artist"],
+                    album=meta["album"],
+                    has_artwork=has_artwork,
+                )
+
+                session.add(track)
+                logger.debug(f"DB: committing new audio '{filename}'")
+                try:
+                    _run_with_timeout(session.commit, _DB_TIMEOUT, f"commit audio '{filepath}'")
+                    stats["new_audio"] += 1
+                    logger.info(f"New audio saved: {meta['title'] or filename}")
+                except TimeoutError as e:
+                    logger.error(f"DB hang: {e} — rolling back '{filename}'")
+                    session.rollback()
+                    stats["errors"] += 1
+                except IntegrityError:
+                    session.rollback()
+                    logger.debug(f"Audio already exists, skipping: {filepath}")
+
     _apply_tags_from_library(library_path, session, scope_dir=scope_dir)
 
     # --- Mark / unmark missing files ---
@@ -879,7 +1077,7 @@ def scan_library(library_path: str, data_path: str, session: Session, on_progres
             return query.filter(model.filepath.like(f"{scope_dir}{os.sep}%"))
         return query
 
-    missing_books = missing_maps = missing_tokens = 0
+    missing_books = missing_maps = missing_tokens = missing_audio = 0
     if scan_books:
         for book in _scoped(session.query(Book), Book).all():
             gone = not os.path.exists(book.filepath)
@@ -904,8 +1102,19 @@ def scan_library(library_path: str, data_path: str, session: Session, on_progres
                 if gone:
                     missing_tokens += 1
                     logger.warning(f"Missing token: '{t.filename}' ({t.filepath})")
-    if missing_books or missing_maps or missing_tokens:
-        logger.info(f"Missing files: {missing_books} book(s), {missing_maps} map(s), {missing_tokens} token(s)")
+    if scan_audio:
+        for a in _scoped(session.query(Audio), Audio).all():
+            gone = not os.path.exists(a.filepath)
+            if gone != bool(a.is_missing):
+                a.is_missing = gone
+                if gone:
+                    missing_audio += 1
+                    logger.warning(f"Missing audio: '{a.filename}' ({a.filepath})")
+    if missing_books or missing_maps or missing_tokens or missing_audio:
+        logger.info(
+            f"Missing files: {missing_books} book(s), {missing_maps} map(s), "
+            f"{missing_tokens} token(s), {missing_audio} audio"
+        )
     try:
         _run_with_timeout(session.commit, _DB_TIMEOUT, "commit missing flags")
     except (TimeoutError, Exception) as e:
@@ -915,6 +1124,7 @@ def scan_library(library_path: str, data_path: str, session: Session, on_progres
     stats["missing_books"] = missing_books
     stats["missing_maps"] = missing_maps
     stats["missing_tokens"] = missing_tokens
+    stats["missing_audio"] = missing_audio
 
     return stats
 
@@ -967,7 +1177,12 @@ def _apply_tags_from_library(library_path: str, session: Session, scope_dir: Pat
     """
     library = Path(library_path)
 
-    for section in ("maps", "tokens"):
+    _section_models = {
+        "maps": (MapFolder, GenericMap),
+        "tokens": (TokenFolder, Token),
+        "audio": (AudioFolder, Audio),
+    }
+    for section in ("maps", "tokens", "audio"):
         section_dir = library / section
         if not section_dir.exists():
             continue
@@ -975,8 +1190,7 @@ def _apply_tags_from_library(library_path: str, session: Session, scope_dir: Pat
         if scope_dir is not None and not _within_scope(scope_dir, section_dir):
             continue
 
-        folder_model = MapFolder if section == "maps" else TokenFolder
-        file_model = GenericMap if section == "maps" else Token
+        folder_model, file_model = _section_models[section]
 
         for root, dirs, files in os.walk(section_dir):
             dirs[:] = [d for d in dirs if not d.startswith(".")]

--- a/backend/main.py
+++ b/backend/main.py
@@ -12,6 +12,7 @@ from . import scheduler, session_creator
 from .auth import get_current_user
 from .config import DATA_PATH, LIBRARY_PATH, OPDS_ENABLED, SessionLocal, VERSION, logger
 from .routers import (
+    audio as audio_router,
     auth as auth_router,
     bookmarks as bookmarks_router,
     books as books_router,
@@ -62,6 +63,7 @@ _TAGS = [
         "description": "Book catalog — browse, read, download, and edit book metadata.",
     },
     {"name": "maps", "description": "Map gallery — browse, tag, and download battle maps."},
+    {"name": "audio", "description": "Audio library — browse, tag, stream, and download tracks."},
     {"name": "search", "description": "Full-text search across all indexed book pages."},
     {
         "name": "campaigns",
@@ -163,6 +165,7 @@ api.include_router(systems_router.router)
 api.include_router(books_router.router)
 api.include_router(maps_router.router)
 api.include_router(tokens_router.router)
+api.include_router(audio_router.router)
 api.include_router(library_router.router)
 api.include_router(search_router.router)
 api.include_router(campaigns_router.router)

--- a/backend/models/__init__.py
+++ b/backend/models/__init__.py
@@ -23,7 +23,7 @@ from .campaigns import (
 )
 from .db import init_db
 from .library import Book, BookFolder, GameSystem
-from .media import GenericMap, MapFolder, Token, TokenFolder
+from .media import Audio, AudioFolder, GenericMap, MapFolder, Token, TokenFolder
 from .settings import AppSetting
 from .users import Bookmark, Favorite, User
 
@@ -39,6 +39,8 @@ __all__ = [
     "MapFolder",
     "Token",
     "TokenFolder",
+    "Audio",
+    "AudioFolder",
     # Users
     "User",
     "Bookmark",

--- a/backend/models/db.py
+++ b/backend/models/db.py
@@ -17,6 +17,8 @@ def _normalize_tags_in_db(conn) -> None:
         "map_folders",
         "tokens",
         "token_folders",
+        "audio",
+        "audio_folders",
     ]
     for table in tables:
         rows = conn.execute(

--- a/backend/models/media.py
+++ b/backend/models/media.py
@@ -1,5 +1,5 @@
-"""Media models — generic maps and tokens, plus their folder tag tables."""
-from sqlalchemy import Boolean, Column, DateTime, Integer, JSON, String, Text
+"""Media models — generic maps, tokens, and audio, plus their folder tag tables."""
+from sqlalchemy import Boolean, Column, DateTime, Float, Integer, JSON, String, Text
 
 from .base import Base, _utcnow, _uuid
 
@@ -55,6 +55,39 @@ class TokenFolder(Base):
     """Tags applied to a token folder path."""
 
     __tablename__ = "token_folders"
+
+    id = Column(String(36), primary_key=True, default=_uuid)
+    path = Column(String(1000), nullable=False, unique=True)
+    tags = Column(JSON, default=list)
+
+
+class Audio(Base):
+    """An audio track (ambient music, soundscape, sound effect)."""
+
+    __tablename__ = "audio"
+
+    id = Column(String(36), primary_key=True, default=_uuid)
+    filename = Column(String(500), nullable=False)
+    filepath = Column(String(1000), nullable=False, unique=True)
+    relative_path = Column(String(1000), nullable=False)
+    description = Column(Text, default="")
+    tags = Column(JSON, default=list)
+    # Embedded metadata (best-effort; populated by the indexer via mutagen).
+    duration = Column(Float, default=0.0)  # seconds
+    title = Column(String(500), default="")
+    artist = Column(String(500), default="")
+    album = Column(String(500), default="")
+    # True when folder cover art or embedded album art is available.
+    has_artwork = Column(Boolean, default=False)
+    file_size = Column(Integer, default=0)
+    is_missing = Column(Boolean, default=False)
+    created_at = Column(DateTime, default=_utcnow)
+
+
+class AudioFolder(Base):
+    """Tags applied to an audio folder path."""
+
+    __tablename__ = "audio_folders"
 
     id = Column(String(36), primary_key=True, default=_uuid)
     path = Column(String(1000), nullable=False, unique=True)

--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -14,3 +14,4 @@ PyJWT==2.13.0
 authlib>=1.3,<2
 redis>=5.0.0
 markdownify==0.14.1
+mutagen==1.47.0

--- a/backend/routers/audio/__init__.py
+++ b/backend/routers/audio/__init__.py
@@ -1,0 +1,69 @@
+"""Audio package — registers all audio routes on a single router."""
+from fastapi import APIRouter, Depends
+
+from ...auth import require_not_guest
+from .core import (
+    list_audio,
+    list_audio_folders,
+    update_audio_folder,
+    get_audio,
+    serve_audio_file,
+    serve_audio_artwork,
+    update_audio,
+)
+
+router = APIRouter(tags=["audio"])
+
+# Browsing the whole audio library is blocked for guests; serving an individual
+# track/artwork by id is not, so shared campaign resources still play.
+router.add_api_route(
+    "/audio",
+    list_audio,
+    methods=["GET"],
+    summary="List audio",
+    description="Returns a paginated list of audio tracks.",
+    dependencies=[Depends(require_not_guest)],
+)
+router.add_api_route(
+    "/audio-folders",
+    list_audio_folders,
+    methods=["GET"],
+    summary="List audio folders",
+    description="Returns all known audio folder paths and their associated tags.",
+    dependencies=[Depends(require_not_guest)],
+)
+router.add_api_route(
+    "/audio-folders",
+    update_audio_folder,
+    methods=["PATCH"],
+    summary="Set tags on an audio folder",
+    description="Creates or replaces the tag list for a folder path. GM or admin role required.",
+)
+router.add_api_route(
+    "/audio/{audio_id}",
+    get_audio,
+    methods=["GET"],
+    summary="Get an audio track",
+    description="Returns full track metadata including duration, embedded tags, and folder tags.",
+)
+router.add_api_route(
+    "/audio/{audio_id}/file",
+    serve_audio_file,
+    methods=["GET"],
+    summary="Stream/download audio file",
+    description="Streams the original audio file (supports HTTP range requests). Accepts `?token=`.",
+)
+router.add_api_route(
+    "/audio/{audio_id}/artwork",
+    serve_audio_artwork,
+    methods=["GET"],
+    summary="Audio artwork",
+    description="Returns folder cover art or embedded album art for a track. 404 if none.",
+)
+router.add_api_route(
+    "/audio/{audio_id}",
+    update_audio,
+    methods=["PATCH"],
+    summary="Update audio metadata",
+    description="Updates editable fields on a track (description, tags). GM or admin role required.",
+)

--- a/backend/routers/audio/_schemas.py
+++ b/backend/routers/audio/_schemas.py
@@ -1,0 +1,34 @@
+"""Pydantic schemas for the audio API."""
+from typing import Optional
+from pydantic import BaseModel, field_validator
+
+
+def _normalize_tags(tags: list[str]) -> list[str]:
+    seen = set()
+    result = []
+    for t in tags:
+        lowered = t.strip().lower()
+        if lowered and lowered not in seen:
+            seen.add(lowered)
+            result.append(lowered)
+    return result
+
+
+class AudioUpdate(BaseModel):
+    description: Optional[str] = None
+    tags: Optional[list[str]] = None
+
+    @field_validator("tags", mode="before")
+    @classmethod
+    def lowercase_tags(cls, v):
+        return _normalize_tags(v) if v is not None else v
+
+
+class FolderTagsUpdate(BaseModel):
+    path: str
+    tags: list[str]
+
+    @field_validator("tags", mode="before")
+    @classmethod
+    def lowercase_tags(cls, v):
+        return _normalize_tags(v)

--- a/backend/routers/audio/core.py
+++ b/backend/routers/audio/core.py
@@ -1,0 +1,145 @@
+"""Audio CRUD, file-serving, and folder-tagging endpoints."""
+import os
+from pathlib import Path
+from typing import Optional
+
+from fastapi import Depends, HTTPException, Query
+from fastapi.responses import FileResponse, Response
+
+from ...config import SessionLocal
+from ...models import Audio, AudioFolder
+from ...auth import require_gm_or_admin, CurrentUser
+from ...indexer import _extract_embedded_art, _find_folder_artwork
+from ._schemas import AudioUpdate, FolderTagsUpdate
+
+# Map audio extensions to the mimetype the browser <audio> element expects.
+_AUDIO_MIME = {
+    ".mp3": "audio/mpeg",
+    ".ogg": "audio/ogg",
+    ".opus": "audio/ogg",
+    ".flac": "audio/flac",
+    ".wav": "audio/wav",
+    ".m4a": "audio/mp4",
+    ".aac": "audio/aac",
+}
+
+
+def _serialize(a: Audio) -> dict:
+    return {
+        "id": a.id,
+        "filename": a.filename,
+        "relative_path": a.relative_path,
+        "description": a.description,
+        "tags": a.tags or [],
+        "duration": a.duration or 0.0,
+        "title": a.title or "",
+        "artist": a.artist or "",
+        "album": a.album or "",
+        "has_artwork": bool(a.has_artwork),
+        "file_size": a.file_size,
+        "is_missing": bool(a.is_missing),
+    }
+
+
+def list_audio(limit: int = Query(100000), offset: int = 0):
+    db = SessionLocal()
+    try:
+        q = db.query(Audio)
+        total = q.count()
+        tracks = q.order_by(Audio.filename).offset(offset).limit(limit).all()
+        return {"total": total, "audio": [_serialize(a) for a in tracks]}
+    finally:
+        db.close()
+
+
+def list_audio_folders():
+    db = SessionLocal()
+    try:
+        folders = db.query(AudioFolder).all()
+        return {"folders": [{"path": f.path, "tags": f.tags or []} for f in folders]}
+    finally:
+        db.close()
+
+
+def update_audio_folder(data: FolderTagsUpdate, _: CurrentUser = Depends(require_gm_or_admin)):
+    db = SessionLocal()
+    try:
+        folder = db.query(AudioFolder).filter_by(path=data.path).first()
+        if folder:
+            folder.tags = data.tags
+        else:
+            db.add(AudioFolder(path=data.path, tags=data.tags))
+        db.commit()
+        return {"path": data.path, "tags": data.tags}
+    finally:
+        db.close()
+
+
+def get_audio(audio_id: str):
+    db = SessionLocal()
+    try:
+        a = db.query(Audio).filter_by(id=audio_id).first()
+        if not a:
+            raise HTTPException(404)
+        folder_path = "/".join(Path(a.relative_path).parts[1:-1])
+        folder = db.query(AudioFolder).filter_by(path=folder_path).first()
+        return {
+            **_serialize(a),
+            "folder_path": folder_path,
+            "folder_tags": folder.tags if folder else [],
+        }
+    finally:
+        db.close()
+
+
+def serve_audio_file(audio_id: str):
+    db = SessionLocal()
+    try:
+        a = db.query(Audio).filter_by(id=audio_id).first()
+        if not a:
+            raise HTTPException(404)
+        if not os.path.exists(a.filepath):
+            if not a.is_missing:
+                a.is_missing = True
+                db.commit()
+            raise HTTPException(404, "File not found on disk")
+        ext = Path(a.filepath).suffix.lower()
+        media = _AUDIO_MIME.get(ext, "application/octet-stream")
+        # FileResponse honours HTTP Range requests, so browsers can seek/stream.
+        return FileResponse(a.filepath, media_type=media, filename=a.filename)
+    finally:
+        db.close()
+
+
+def serve_audio_artwork(audio_id: str):
+    db = SessionLocal()
+    try:
+        a = db.query(Audio).filter_by(id=audio_id).first()
+        if not a:
+            raise HTTPException(404)
+        # Prefer a folder cover image, then fall back to embedded album art.
+        cover = _find_folder_artwork(os.path.dirname(a.filepath))
+        if cover and os.path.exists(cover):
+            ext = Path(cover).suffix.lower().lstrip(".")
+            return FileResponse(cover, media_type=f"image/{ext}")
+        embedded = _extract_embedded_art(a.filepath)
+        if embedded:
+            data, mime = embedded
+            return Response(content=data, media_type=mime or "image/jpeg")
+        raise HTTPException(404)
+    finally:
+        db.close()
+
+
+def update_audio(audio_id: str, data: AudioUpdate, _: CurrentUser = Depends(require_gm_or_admin)):
+    db = SessionLocal()
+    try:
+        a = db.query(Audio).filter_by(id=audio_id).first()
+        if not a:
+            raise HTTPException(404)
+        for field, value in data.model_dump(exclude_none=True).items():
+            setattr(a, field, value)
+        db.commit()
+        return {"status": "ok"}
+    finally:
+        db.close()

--- a/backend/routers/campaigns/_schemas.py
+++ b/backend/routers/campaigns/_schemas.py
@@ -5,7 +5,7 @@ from pydantic import BaseModel
 
 
 class CampaignResourceInput(BaseModel):
-    resource_type: str  # book | map | token | file
+    resource_type: str  # book | map | token | audio | file
     resource_id: str
     visibility: str = "gm"  # public | private | gm
     shared_user_ids: Optional[List[str]] = None  # for private visibility
@@ -48,7 +48,7 @@ class MemberStatusUpdate(BaseModel):
 
 
 class ResourceAdd(BaseModel):
-    resource_type: str  # book | map | token | file
+    resource_type: str  # book | map | token | audio | file
     resource_id: str
     visibility: str = "gm"  # public | private | gm
     shared_user_ids: Optional[List[str]] = None  # for private visibility
@@ -87,7 +87,7 @@ class CategoryReorder(BaseModel):
 
 
 class ResourceGroupOrder(BaseModel):
-    # Ordered list of group keys ("type:book"/"type:map"/"type:token"/"type:file"
+    # Ordered list of group keys ("type:book"/"type:map"/"type:token"/"type:audio"/"type:file"
     # and "cat:<category_id>") defining the resource panel's group display order.
     ordered_keys: List[str]
 

--- a/backend/routers/campaigns/categories.py
+++ b/backend/routers/campaigns/categories.py
@@ -23,7 +23,7 @@ from ._schemas import (
 )
 
 _KINDS = ("note", "resource")
-_TYPE_GROUP_KEYS = ("type:book", "type:map", "type:token", "type:file")
+_TYPE_GROUP_KEYS = ("type:book", "type:map", "type:token", "type:audio", "type:file")
 
 
 def _serialize(cat: CampaignCategory) -> dict:

--- a/backend/routers/campaigns/core.py
+++ b/backend/routers/campaigns/core.py
@@ -7,6 +7,7 @@ from fastapi import Depends, HTTPException
 from ...auth import CurrentUser, get_current_user, require_admin
 from ...config import SessionLocal
 from ...models import (
+    Audio,
     Book,
     Campaign,
     CampaignMember,
@@ -123,7 +124,7 @@ def create_campaign(data: CampaignCreate, current_user: CurrentUser = Depends(ge
             seen = set()
             order = 0
             for r in data.resources:
-                if r.resource_type not in ("book", "map", "token", "file"):
+                if r.resource_type not in ("book", "map", "token", "audio", "file"):
                     continue
                 key = (r.resource_type, r.resource_id)
                 if key in seen:
@@ -244,11 +245,11 @@ def search_resources_global(
     limit: int = 30,
     current_user: CurrentUser = Depends(get_current_user),
 ):
-    """Search across books, maps, and tokens for the resource picker.
+    """Search across books, maps, tokens, and audio for the resource picker.
 
-    Books match on title and can be narrowed by game system. Maps and tokens
-    match on their folder path *first*, then filename, so a folder name like
-    "Abyssal Fall (30x49)" surfaces every map inside it. Folder-path matches are
+    Books match on title and can be narrowed by game system. Maps, tokens, and
+    audio match on their folder path *first*, then filename, so a folder name like
+    "Abyssal Fall (30x49)" surfaces every item inside it. Folder-path matches are
     ranked above filename-only matches.
     """
     if current_user.role == "guest":
@@ -274,23 +275,30 @@ def search_resources_global(
                         }
                     )
 
-        # Maps/tokens: prefer folder-path matches, then filename matches.
+        # Maps/tokens/audio: prefer folder-path matches, then filename matches.
         def _media_results(rtype, model):
             folder_hits, name_hits = [], []
             for item in db.query(model).order_by(model.filename).limit(1000).all():
                 folder = _resource_folder(item.relative_path)
+                # Audio has no thumbnail; use its artwork flag and prefer its title.
+                if rtype == "audio":
+                    name = item.title or item.filename
+                    has_thumb = bool(item.has_artwork)
+                else:
+                    name = item.filename
+                    has_thumb = item.has_thumbnail
                 row = {
                     "resource_type": rtype,
                     "resource_id": item.id,
-                    "name": item.filename,
+                    "name": name,
                     "subtitle": folder,
-                    "has_thumbnail": item.has_thumbnail,
+                    "has_thumbnail": has_thumb,
                 }
                 if not q:
                     name_hits.append(row)
                 elif q_lower in folder.lower():
                     folder_hits.append(row)
-                elif q_lower in (item.filename or "").lower():
+                elif q_lower in (name or "").lower():
                     name_hits.append(row)
             return folder_hits + name_hits
 
@@ -299,6 +307,9 @@ def search_resources_global(
 
         if not resource_type or resource_type == "token":
             results.extend(_media_results("token", Token))
+
+        if not resource_type or resource_type == "audio":
+            results.extend(_media_results("audio", Audio))
 
         return results[:limit]
     finally:

--- a/backend/routers/campaigns/resources.py
+++ b/backend/routers/campaigns/resources.py
@@ -13,6 +13,7 @@ from fastapi import Depends, HTTPException
 from ...auth import CurrentUser, get_current_user
 from ...config import SessionLocal
 from ...models import (
+    Audio,
     Book,
     CampaignFile,
     CampaignResource,
@@ -42,6 +43,9 @@ def _resource_meta(db, rtype: str, rid: str):
     if rtype == "token":
         obj = db.query(Token).filter_by(id=rid).first()
         return (obj.filename, obj.has_thumbnail, False) if obj else (rid, False, False)
+    if rtype == "audio":
+        obj = db.query(Audio).filter_by(id=rid).first()
+        return (obj.title or obj.filename, bool(obj.has_artwork), False) if obj else (rid, False, False)
     if rtype == "file":
         obj = db.query(CampaignFile).filter_by(id=rid).first()
         if not obj:
@@ -146,7 +150,7 @@ def add_resource(
     try:
         c = get_campaign_or_404(db, campaign_id)
         assert_can_manage(c, current_user, db)
-        if data.resource_type not in ("book", "map", "token", "file"):
+        if data.resource_type not in ("book", "map", "token", "audio", "file"):
             raise HTTPException(400, "Invalid resource_type")
 
         existing = (
@@ -205,7 +209,7 @@ def bulk_add_resources(
         order = len(existing_keys)
         created = []
         for item in data.resources:
-            if item.resource_type not in ("book", "map", "token", "file"):
+            if item.resource_type not in ("book", "map", "token", "audio", "file"):
                 continue
             key = (item.resource_type, item.resource_id)
             if key in existing_keys:

--- a/backend/routers/campaigns/wiki.py
+++ b/backend/routers/campaigns/wiki.py
@@ -2,7 +2,7 @@
 
 Pages hold markdown bodies and link to each other with `[[Page Title]]` syntax.
 Grimoire content is embedded inline as `[[book:<id>]]`, `[[book:<id>:<page>]]`,
-`[[map:<id>]]`, or `[[token:<id>]]` — those are rendered by the frontend and are
+`[[map:<id>]]`, `[[token:<id>]]`, or `[[audio:<id>]]` — those are rendered by the frontend and are
 not tracked as page-to-page links. On every save we re-parse the body, auto-create
 stub pages for any unknown `[[Page Title]]` targets, and rebuild backlink rows.
 """
@@ -25,7 +25,7 @@ from ._helpers import (
 from ._schemas import WikiPageCreate, WikiPageUpdate, WikiReorder
 
 # Reserved prefixes for Grimoire content embeds — not page-title links.
-_EMBED_PREFIXES = ("book:", "map:", "token:", "file:", "image:")
+_EMBED_PREFIXES = ("book:", "map:", "token:", "audio:", "file:", "image:")
 
 # Matches [[target]] or [[target|label]]; target/label captured separately.
 _LINK_RE = re.compile(r"\[\[([^\]|]+?)(?:\|([^\]]+))?\]\]")

--- a/backend/routers/campaigns/wiki_io.py
+++ b/backend/routers/campaigns/wiki_io.py
@@ -563,7 +563,7 @@ def _parse_upload(filename: str, data: bytes) -> tuple:
 
 # [[target]] / [[target|label]] for link remapping (embeds left untouched).
 _WIKILINK_RE = re.compile(r"\[\[([^\]|]+?)(?:\|([^\]]+))?\]\]")
-_EMBED_PREFIXES = ("book:", "map:", "token:")
+_EMBED_PREFIXES = ("book:", "map:", "token:", "audio:")
 
 
 def _remap_links(body: str, key_to_title: dict) -> str:

--- a/backend/routers/downloads/_helpers.py
+++ b/backend/routers/downloads/_helpers.py
@@ -8,7 +8,7 @@ from typing import Optional
 from fastapi import HTTPException
 from fastapi.responses import StreamingResponse
 
-from ...models import Book, GameSystem, GenericMap, Token, User
+from ...models import Audio, Book, GameSystem, GenericMap, Token, User
 
 
 _FORMATS = {
@@ -240,3 +240,22 @@ def _files_for_token_folder(db, folder: str, see_explicit: bool) -> tuple[list, 
         and (safe := _safe_filepath(t.filepath))
     ]
     return files, f"tokens_{_safe_name(folder)}"
+
+
+def _files_for_audio_folder(db, folder: str) -> tuple[list, str]:
+    prefix = folder.strip("/") + "/"
+    tracks = db.query(Audio).all()
+
+    def _arcname(a: Audio) -> str:
+        rp = a.relative_path.replace("\\", "/")
+        rel = rp.split("/", 1)[1] if "/" in rp else rp
+        raw = rel[len(prefix):] if rel.startswith(prefix) else (rel or a.filename)
+        return _safe_arcname(raw)
+
+    files = [
+        (safe, _arcname(a))
+        for a in tracks
+        if a.relative_path.replace("\\", "/").lstrip("/").startswith("audio/" + prefix)
+        and (safe := _safe_filepath(a.filepath))
+    ]
+    return files, f"audio_{_safe_name(folder)}"

--- a/backend/routers/downloads/core.py
+++ b/backend/routers/downloads/core.py
@@ -8,6 +8,7 @@ from ...config import SessionLocal
 from ._helpers import (
     _archive_response,
     _can_see_explicit,
+    _files_for_audio_folder,
     _files_for_book_folder,
     _files_for_map_folder,
     _files_for_system,
@@ -19,7 +20,7 @@ from ._helpers import (
 def download_archive(
     type: str = Query(
         ...,
-        description="Scope: system | system_category | book_folder | map_folder | token_folder",
+        description="Scope: system | system_category | book_folder | map_folder | token_folder | audio_folder",
     ),
     fmt: str = Query("zip", description="Archive format: zip | tar | tar.gz | tar.bz2"),
     id: Optional[str] = Query(
@@ -27,7 +28,7 @@ def download_archive(
     ),
     category: Optional[str] = Query(None, description="Book category slug (system_category)"),
     folder: Optional[str] = Query(
-        None, description="Folder path (book_folder / map_folder / token_folder)"
+        None, description="Folder path (book_folder / map_folder / token_folder / audio_folder)"
     ),
     current_user: CurrentUser = Depends(get_current_user),
 ):
@@ -63,6 +64,11 @@ def download_archive(
             if not folder:
                 raise HTTPException(400, "folder is required for type=token_folder")
             files, base = _files_for_token_folder(db, folder, see_explicit)
+
+        elif type == "audio_folder":
+            if not folder:
+                raise HTTPException(400, "folder is required for type=audio_folder")
+            files, base = _files_for_audio_folder(db, folder)
 
         else:
             raise HTTPException(400, f"Unknown type: {type!r}")

--- a/backend/routers/export/core.py
+++ b/backend/routers/export/core.py
@@ -7,13 +7,24 @@ from fastapi.responses import Response
 
 from ...auth import CurrentUser, require_admin
 from ...config import SessionLocal
-from ...models import Book, BookFolder, GameSystem, GenericMap, MapFolder, Token, TokenFolder
+from ...models import (
+    Audio,
+    AudioFolder,
+    Book,
+    BookFolder,
+    GameSystem,
+    GenericMap,
+    MapFolder,
+    Token,
+    TokenFolder,
+)
 
 
 def export_tags(
     include_library: bool = True,
     include_maps: bool = True,
     include_tokens: bool = True,
+    include_audio: bool = True,
     _: CurrentUser = Depends(require_admin),
 ):
     db = SessionLocal()
@@ -78,6 +89,22 @@ def export_tags(
                 for f in db.query(TokenFolder).order_by(TokenFolder.path).all()
             ]
             payload["tokens"] = {"items": tokens, "folders": token_folders}
+
+        if include_audio:
+            audio = [
+                {
+                    "id": a.id,
+                    "name": a.filename,
+                    "folder": "/".join(a.relative_path.split("/")[:-1]),
+                    "tags": a.tags or [],
+                }
+                for a in db.query(Audio).order_by(Audio.filename).all()
+            ]
+            audio_folders = [
+                {"path": f.path, "tags": f.tags or []}
+                for f in db.query(AudioFolder).order_by(AudioFolder.path).all()
+            ]
+            payload["audio"] = {"items": audio, "folders": audio_folders}
 
         date_str = datetime.datetime.now(datetime.timezone.utc).strftime("%Y-%m-%d")
         filename = f"grimoire-tags-{date_str}.json"

--- a/backend/routers/favorites/core.py
+++ b/backend/routers/favorites/core.py
@@ -4,13 +4,13 @@ from sqlalchemy.exc import IntegrityError
 
 from ...config import SessionLocal
 from ...auth import get_current_user, CurrentUser
-from ...models import Favorite, Book, GenericMap, Token, GameSystem
+from ...models import Favorite, Book, GenericMap, Token, Audio, GameSystem
 from ..systems._helpers import resolve_cover_book_id
 from ._schemas import FavoriteIn
 
 router = APIRouter()
 
-VALID_TYPES = {"book", "map", "token", "system"}
+VALID_TYPES = {"book", "map", "token", "audio", "system"}
 
 
 def list_favorites(user: CurrentUser = Depends(get_current_user)):
@@ -21,11 +21,13 @@ def list_favorites(user: CurrentUser = Depends(get_current_user)):
         book_ids = [r.item_id for r in rows if r.item_type == "book"]
         map_ids = [r.item_id for r in rows if r.item_type == "map"]
         token_ids = [r.item_id for r in rows if r.item_type == "token"]
+        audio_ids = [r.item_id for r in rows if r.item_type == "audio"]
         system_ids = [r.item_id for r in rows if r.item_type == "system"]
 
         books = {b.id: b for b in db.query(Book).filter(Book.id.in_(book_ids))}
         maps = {m.id: m for m in db.query(GenericMap).filter(GenericMap.id.in_(map_ids))}
         tokens = {t.id: t for t in db.query(Token).filter(Token.id.in_(token_ids))}
+        audio = {a.id: a for a in db.query(Audio).filter(Audio.id.in_(audio_ids))}
         systems = {s.id: s for s in db.query(GameSystem).filter(GameSystem.id.in_(system_ids))}
 
         enriched = []
@@ -66,6 +68,20 @@ def list_favorites(user: CurrentUser = Depends(get_current_user)):
                         "has_thumbnail": t.has_thumbnail,
                         "file_size": t.file_size,
                         "tags": t.tags or [],
+                    }
+                )
+            elif r.item_type == "audio" and r.item_id in audio:
+                a = audio[r.item_id]
+                enriched.append(
+                    {
+                        "item_type": "audio",
+                        "item_id": a.id,
+                        "filename": a.filename,
+                        "title": a.title or "",
+                        "duration": a.duration or 0.0,
+                        "has_artwork": bool(a.has_artwork),
+                        "file_size": a.file_size,
+                        "tags": a.tags or [],
                     }
                 )
             elif r.item_type == "system" and r.item_id in systems:

--- a/backend/routers/library/_helpers.py
+++ b/backend/routers/library/_helpers.py
@@ -19,9 +19,12 @@ _DEFAULT_STATUS: dict = {
     "scanned_maps": 0,
     "total_tokens": 0,
     "scanned_tokens": 0,
+    "total_audio": 0,
+    "scanned_audio": 0,
     "new_books": 0,
     "new_maps": 0,
     "new_tokens": 0,
+    "new_audio": 0,
     "updated_books": 0,
     "indexed": 0,
     "to_index": 0,
@@ -153,7 +156,7 @@ def run_rescan_sync(scope_path: str | None = None, metadata_mode: str = "new") -
             # --- Phase 1: file scan ---
             logger.info("File scan start")
 
-            def on_progress(sb, tb, sm, tm, st, tt):
+            def on_progress(sb, tb, sm, tm, st, tt, sa, ta):
                 _set_status(
                     {
                         "scanned_books": sb,
@@ -162,10 +165,13 @@ def run_rescan_sync(scope_path: str | None = None, metadata_mode: str = "new") -
                         "total_maps": tm,
                         "scanned_tokens": st,
                         "total_tokens": tt,
+                        "scanned_audio": sa,
+                        "total_audio": ta,
                     }
                 )
                 logger.debug(
-                    f"File scan progress: books={sb}/{tb}, maps={sm}/{tm}, tokens={st}/{tt}"
+                    f"File scan progress: books={sb}/{tb}, maps={sm}/{tm}, "
+                    f"tokens={st}/{tt}, audio={sa}/{ta}"
                 )
 
             stats = scan_library(
@@ -176,6 +182,7 @@ def run_rescan_sync(scope_path: str | None = None, metadata_mode: str = "new") -
             logger.info(
                 f"File scan end: new_books={stats.get('new_books', 0)}, "
                 f"new_maps={stats.get('new_maps', 0)}, new_tokens={stats.get('new_tokens', 0)}, "
+                f"new_audio={stats.get('new_audio', 0)}, "
                 f"updated_books={stats.get('updated_books', 0)}, "
                 f"errors={stats.get('errors', 0)}"
             )
@@ -184,6 +191,7 @@ def run_rescan_sync(scope_path: str | None = None, metadata_mode: str = "new") -
                     "new_books": stats.get("new_books", 0),
                     "new_maps": stats.get("new_maps", 0),
                     "new_tokens": stats.get("new_tokens", 0),
+                    "new_audio": stats.get("new_audio", 0),
                     "updated_books": stats.get("updated_books", 0),
                 }
             )

--- a/backend/routers/library/core.py
+++ b/backend/routers/library/core.py
@@ -6,7 +6,7 @@ from fastapi import APIRouter, BackgroundTasks, Depends, HTTPException, Header
 from sqlalchemy import func
 
 from ...config import SessionLocal, LIBRARY_PATH, VERSION, COMMIT_HASH
-from ...models import GameSystem, Book, GenericMap, Token
+from ...models import GameSystem, Book, GenericMap, Token, Audio
 from ...auth import require_admin, optional_get_current_user, CurrentUser
 from ...indexer import resolve_scope
 from ..settings import get_stats_api_key
@@ -88,6 +88,7 @@ def get_stats(
             "books": db.query(Book).count(),
             "maps": db.query(GenericMap).count(),
             "tokens": db.query(Token).count(),
+            "audio": db.query(Audio).count(),
             "indexed_books": db.query(Book).filter_by(indexed=True).count(),
             "total_pages": db.query(func.sum(Book.page_count)).scalar() or 0,
             "total_size_mb": round((db.query(func.sum(Book.file_size)).scalar() or 0) / 1048576, 1),

--- a/backend/routers/search/_helpers.py
+++ b/backend/routers/search/_helpers.py
@@ -1,7 +1,7 @@
 """Shared search helpers and category prioritization for the search router."""
 from sqlalchemy import String, cast, or_
 
-from ...models import GenericMap, MapFolder, Token, TokenFolder
+from ...models import Audio, AudioFolder, GenericMap, MapFolder, Token, TokenFolder
 
 
 # Lower number = shown first in results
@@ -43,8 +43,10 @@ def _search_maps(db, q: str) -> list:
     )
     extra = []
     for folder in matching_folders:
+        # Folder paths are stored relative to the collection dir (e.g. "Swamps"),
+        # while relative_path keeps the collection prefix ("maps/Swamps/...").
         for m in (
-            db.query(GenericMap).filter(GenericMap.relative_path.ilike(f"{folder.path}%")).all()
+            db.query(GenericMap).filter(GenericMap.relative_path.ilike(f"%/{folder.path}/%")).all()
         ):
             if m.id not in seen:
                 seen.add(m.id)
@@ -83,7 +85,7 @@ def _search_tokens(db, q: str) -> list:
     )
     extra = []
     for folder in matching_folders:
-        for t in db.query(Token).filter(Token.relative_path.ilike(f"{folder.path}%")).all():
+        for t in db.query(Token).filter(Token.relative_path.ilike(f"%/{folder.path}/%")).all():
             if t.id not in seen:
                 seen.add(t.id)
                 extra.append(t)
@@ -91,4 +93,51 @@ def _search_tokens(db, q: str) -> list:
     return [
         {"id": t.id, "filename": t.filename, "relative_path": t.relative_path, "tags": t.tags}
         for t in (direct + extra)[:50]
+    ]
+
+
+def _search_audio(db, q: str) -> list:
+    term = f"%{q}%"
+    direct = (
+        db.query(Audio)
+        .filter(
+            or_(
+                Audio.filename.ilike(term),
+                Audio.title.ilike(term),
+                Audio.artist.ilike(term),
+                Audio.album.ilike(term),
+                cast(Audio.tags, String).ilike(term),
+            )
+        )
+        .limit(50)
+        .all()
+    )
+    seen = {a.id for a in direct}
+
+    matching_folders = (
+        db.query(AudioFolder)
+        .filter(
+            or_(
+                AudioFolder.path.ilike(term),
+                cast(AudioFolder.tags, String).ilike(term),
+            )
+        )
+        .all()
+    )
+    extra = []
+    for folder in matching_folders:
+        for a in db.query(Audio).filter(Audio.relative_path.ilike(f"%/{folder.path}/%")).all():
+            if a.id not in seen:
+                seen.add(a.id)
+                extra.append(a)
+
+    return [
+        {
+            "id": a.id,
+            "filename": a.filename,
+            "relative_path": a.relative_path,
+            "title": a.title,
+            "tags": a.tags,
+        }
+        for a in (direct + extra)[:50]
     ]

--- a/backend/routers/search/core.py
+++ b/backend/routers/search/core.py
@@ -6,7 +6,7 @@ from sqlalchemy import text
 
 from ...config import SessionLocal
 from ...models import Book, GameSystem
-from ._helpers import _CATEGORY_PRIORITY, _search_maps, _search_tokens
+from ._helpers import _CATEGORY_PRIORITY, _search_maps, _search_tokens, _search_audio
 
 
 def search_library(
@@ -89,16 +89,19 @@ def search_library(
 
         maps = []
         tokens = []
+        audio = []
         if not book_id and not system_id:
             maps = _search_maps(db, q)
             tokens = _search_tokens(db, q)
+            audio = _search_audio(db, q)
 
         return {
             "query": q,
-            "total": len(enriched) + len(maps) + len(tokens),
+            "total": len(enriched) + len(maps) + len(tokens) + len(audio),
             "results": enriched,
             "maps": maps,
             "tokens": tokens,
+            "audio": audio,
         }
     finally:
         db.close()

--- a/backend/routers/settings/_helpers.py
+++ b/backend/routers/settings/_helpers.py
@@ -23,6 +23,7 @@ _DEFAULTS = {
     "stats_api_key": "",
     "hide_maps": "false",
     "hide_tokens": "false",
+    "hide_audio": "false",
     "hide_campaigns": "false",
     # Sidebar stats visibility (true = shown)
     "show_stat_systems": "true",
@@ -106,6 +107,7 @@ def _to_typed(raw: dict) -> dict:
         "stats_api_key": raw["stats_api_key"],
         "hide_maps": raw["hide_maps"] == "true",
         "hide_tokens": raw["hide_tokens"] == "true",
+        "hide_audio": raw["hide_audio"] == "true",
         "hide_campaigns": raw["hide_campaigns"] == "true",
         "show_stat_systems": raw["show_stat_systems"] == "true",
         "show_stat_books": raw["show_stat_books"] == "true",

--- a/backend/routers/settings/_schemas.py
+++ b/backend/routers/settings/_schemas.py
@@ -13,6 +13,7 @@ class SettingsPatch(BaseModel):
     stats_api_key: Optional[str] = None  # set to "" to clear
     hide_maps: Optional[bool] = None
     hide_tokens: Optional[bool] = None
+    hide_audio: Optional[bool] = None
     hide_campaigns: Optional[bool] = None
     show_stat_systems: Optional[bool] = None
     show_stat_books: Optional[bool] = None

--- a/backend/routers/settings/core.py
+++ b/backend/routers/settings/core.py
@@ -66,6 +66,8 @@ def update_settings(data: SettingsPatch, _: CurrentUser = Depends(require_admin)
             _set(db, "hide_maps", "true" if data.hide_maps else "false")
         if data.hide_tokens is not None:
             _set(db, "hide_tokens", "true" if data.hide_tokens else "false")
+        if data.hide_audio is not None:
+            _set(db, "hide_audio", "true" if data.hide_audio else "false")
         if data.hide_campaigns is not None:
             _set(db, "hide_campaigns", "true" if data.hide_campaigns else "false")
         for key in (
@@ -194,6 +196,7 @@ def get_ui_settings(_: CurrentUser = Depends(get_current_user)):
         return {
             "hide_maps": raw["hide_maps"] == "true",
             "hide_tokens": raw["hide_tokens"] == "true",
+            "hide_audio": raw["hide_audio"] == "true",
             "hide_campaigns": raw["hide_campaigns"] == "true",
             "show_stat_systems": raw["show_stat_systems"] == "true",
             "show_stat_books": raw["show_stat_books"] == "true",

--- a/backend/scripts/check_coverage.py
+++ b/backend/scripts/check_coverage.py
@@ -1,0 +1,153 @@
+#!/usr/bin/env python3
+"""Per-changed-file backend coverage gate.
+
+Mirrors frontend/scripts/check-coverage.mjs: fails if any changed backend source
+file (backend/**.py, excluding tests) has line coverage below MIN_PCT. This
+enforces the "each change brings coverage up" goal without imposing a hard global
+threshold.
+
+Strict by design: a changed source file absent from the coverage report (i.e. no
+test exercises it at all) is treated as 0% and fails.
+
+Reads coverage.json (coverage.py's JSON report) from the repo root — run
+``pytest --cov=backend --cov-report=json`` first.
+
+Base ref for the diff comes from $BASE_REF (CI sets this), falling back to
+origin/dev, then dev. Override the threshold with $MIN_COVERAGE.
+"""
+import json
+import os
+import re
+import subprocess
+import sys
+from pathlib import Path
+
+MIN_PCT = float(os.environ.get("MIN_COVERAGE", "80"))
+
+
+def git(args, cwd=None):
+    return subprocess.run(
+        ["git", *args], capture_output=True, text=True, cwd=cwd, check=True
+    ).stdout.strip()
+
+
+def git_lines(args, cwd=None):
+    try:
+        out = git(args, cwd=cwd)
+    except subprocess.CalledProcessError:
+        return []
+    return out.split("\n") if out else []
+
+
+def repo_root():
+    return git(["rev-parse", "--show-toplevel"])
+
+
+def resolve_base(root):
+    candidates = [c for c in (os.environ.get("BASE_REF"), "origin/dev", "dev") if c]
+    for ref in candidates:
+        try:
+            git(["rev-parse", "--verify", "--quiet", f"{ref}^{{commit}}"], cwd=root)
+            return ref
+        except subprocess.CalledProcessError:
+            continue
+    return None
+
+
+_TEST_RE = re.compile(r"(^|/)(test_[^/]+|conftest)\.py$")
+
+
+def changed_source_files(base, root):
+    """Backend .py files changed vs base, excluding tests/conftest/scripts.
+
+    Unions three changesets so it works in CI and locally before committing:
+      1. committed changes the branch introduces (base...HEAD, PR semantics),
+      2. uncommitted tracked changes (git diff HEAD),
+      3. untracked new files.
+    Returns paths relative to the repo root (matching coverage.json keys).
+    """
+    files = set()
+    files.update(
+        git_lines(
+            ["diff", "--name-only", "--diff-filter=ACMR", f"{base}...HEAD", "--", "backend"],
+            cwd=root,
+        )
+    )
+    files.update(
+        git_lines(["diff", "--name-only", "--diff-filter=ACMR", "HEAD", "--", "backend"], cwd=root)
+    )
+    files.update(git_lines(["ls-files", "--others", "--exclude-standard", "--", "backend"], cwd=root))
+
+    result = []
+    for p in files:
+        p = p.strip()
+        if not p or not p.endswith(".py"):
+            continue
+        if "/tests/" in p or _TEST_RE.search(p):
+            continue
+        if p.startswith("backend/scripts/"):
+            continue
+        result.append(p)
+    return sorted(result)
+
+
+def lookup(summary_files, rel):
+    for key in (rel, f"./{rel}"):
+        if key in summary_files:
+            return summary_files[key]
+    return None
+
+
+def main():
+    root = repo_root()
+    base = resolve_base(root)
+    if not base:
+        print("⚠ check-coverage: no base ref resolvable; skipping gate.")
+        return 0
+
+    changed = changed_source_files(base, root)
+    if not changed:
+        print(f"✓ check-coverage: no changed backend source files vs {base}.")
+        return 0
+
+    report_path = Path(root) / "coverage.json"
+    if not report_path.exists():
+        print(
+            f"✗ check-coverage: {report_path} not found. "
+            'Run "pytest --cov=backend --cov-report=json" first.',
+            file=sys.stderr,
+        )
+        return 1
+
+    files = json.loads(report_path.read_text())["files"]
+
+    failures = []
+    passes = []
+    for rel in changed:
+        entry = lookup(files, rel)
+        pct = entry["summary"]["percent_covered"] if entry else 0.0
+        if pct < MIN_PCT:
+            failures.append((rel, pct, entry is None))
+        else:
+            passes.append((rel, pct))
+
+    for rel, pct in passes:
+        print(f"✓ {pct:6.2f}%  {rel}")
+    for rel, pct, untested in failures:
+        note = " (no coverage — needs tests)" if untested else ""
+        print(f"✗ {pct:6.2f}%  {rel}{note}", file=sys.stderr)
+
+    if failures:
+        print(
+            f"\n✗ check-coverage: {len(failures)} changed file(s) below "
+            f"{MIN_PCT:.0f}% line coverage.",
+            file=sys.stderr,
+        )
+        return 1
+
+    print(f"\n✓ check-coverage: all {len(passes)} changed file(s) ≥ {MIN_PCT:.0f}%.")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/backend/tests/conftest.py
+++ b/backend/tests/conftest.py
@@ -25,6 +25,7 @@ from backend.models import (  # noqa: E402
     Book,
     GenericMap,
     Token,
+    Audio,
     Favorite,
     Campaign,
 )
@@ -234,6 +235,25 @@ def make_token(**kwargs) -> Token:
     db.refresh(t)
     db.close()
     return t
+
+
+def make_audio(**kwargs) -> Audio:
+    uid = str(uuid.uuid4())[:8]
+    defaults = dict(
+        filename=f"track-{uid}.mp3",
+        filepath=f"/tmp/track-{uid}.mp3",
+        relative_path=f"track-{uid}.mp3",
+        duration=123.5,
+        title=f"Track {uid}",
+    )
+    defaults.update(kwargs)
+    db = SessionLocal()
+    a = Audio(**defaults)
+    db.add(a)
+    db.commit()
+    db.refresh(a)
+    db.close()
+    return a
 
 
 def make_campaign(owner_id: str, **kwargs) -> Campaign:

--- a/backend/tests/test_audio.py
+++ b/backend/tests/test_audio.py
@@ -1,0 +1,239 @@
+"""Tests for audio and audio folder endpoints."""
+import os
+import struct
+import tempfile
+import wave
+
+import pytest
+from PIL import Image
+
+from backend.tests.conftest import make_audio
+from backend.config import SessionLocal
+from backend.models import Audio, AudioFolder
+
+
+def _write_wav(path):
+    with wave.open(path, "w") as w:
+        w.setnchannels(1)
+        w.setsampwidth(2)
+        w.setframerate(8000)
+        w.writeframes(b"".join(struct.pack("<h", 0) for _ in range(800)))
+
+
+@pytest.fixture(scope="module")
+def audio_entry():
+    return make_audio(tags=["ambient", "tavern"], artist="Bardcore", album="Taverns")
+
+
+class TestListAudio:
+    def test_returns_list(self, client, admin_headers, audio_entry):
+        resp = client.get("/api/audio", headers=admin_headers)
+        assert resp.status_code == 200
+        body = resp.json()
+        assert "audio" in body
+        assert "total" in body
+
+    def test_contains_created_track(self, client, admin_headers, audio_entry):
+        resp = client.get("/api/audio", headers=admin_headers)
+        ids = [a["id"] for a in resp.json()["audio"]]
+        assert audio_entry.id in ids
+
+    def test_list_includes_audio_fields(self, client, admin_headers, audio_entry):
+        resp = client.get("/api/audio", headers=admin_headers)
+        assert resp.status_code == 200
+        tracks = resp.json()["audio"]
+        assert len(tracks) > 0
+        for a in tracks:
+            assert "duration" in a
+            assert "title" in a
+            assert "has_artwork" in a
+            assert "is_missing" in a
+            assert isinstance(a["is_missing"], bool)
+
+    def test_player_can_list_audio(self, client, player_headers, audio_entry):
+        resp = client.get("/api/audio", headers=player_headers)
+        assert resp.status_code == 200
+
+    def test_unauthenticated_denied(self, client):
+        resp = client.get("/api/audio")
+        assert resp.status_code == 401
+
+    def test_pagination(self, client, admin_headers, audio_entry):
+        resp = client.get("/api/audio?limit=1&offset=0", headers=admin_headers)
+        assert resp.status_code == 200
+        assert len(resp.json()["audio"]) <= 1
+
+
+class TestGetAudio:
+    def test_get_existing_track(self, client, admin_headers, audio_entry):
+        resp = client.get(f"/api/audio/{audio_entry.id}", headers=admin_headers)
+        assert resp.status_code == 200
+        body = resp.json()
+        assert body["id"] == audio_entry.id
+        assert body["duration"] == 123.5
+        assert body["artist"] == "Bardcore"
+        assert "folder_tags" in body
+
+    def test_get_nonexistent_track(self, client, admin_headers):
+        resp = client.get("/api/audio/does-not-exist", headers=admin_headers)
+        assert resp.status_code == 404
+
+
+class TestUpdateAudio:
+    def test_gm_can_update_audio(self, client, gm_headers, audio_entry):
+        resp = client.patch(
+            f"/api/audio/{audio_entry.id}",
+            json={"description": "A cozy tavern loop", "tags": ["ambient", "cozy"]},
+            headers=gm_headers,
+        )
+        assert resp.status_code == 200
+        assert resp.json() == {"status": "ok"}
+
+    def test_tags_are_lowercased_on_update(self, client, gm_headers):
+        a = make_audio()
+        resp = client.patch(
+            f"/api/audio/{a.id}",
+            json={"tags": ["Ambient", "TAVERN", "loop"]},
+            headers=gm_headers,
+        )
+        assert resp.status_code == 200
+        detail = client.get(f"/api/audio/{a.id}", headers=gm_headers).json()
+        assert detail["tags"] == ["ambient", "tavern", "loop"]
+
+    def test_duplicate_tags_deduplicated_on_update(self, client, gm_headers):
+        a = make_audio()
+        resp = client.patch(
+            f"/api/audio/{a.id}",
+            json={"tags": ["ambient", "Ambient", "AMBIENT"]},
+            headers=gm_headers,
+        )
+        assert resp.status_code == 200
+        detail = client.get(f"/api/audio/{a.id}", headers=gm_headers).json()
+        assert detail["tags"] == ["ambient"]
+
+    def test_player_cannot_update_audio(self, client, player_headers, audio_entry):
+        resp = client.patch(
+            f"/api/audio/{audio_entry.id}",
+            json={"description": "Player edit attempt"},
+            headers=player_headers,
+        )
+        assert resp.status_code == 403
+
+
+class TestAudioFolders:
+    @pytest.fixture(scope="class")
+    def folder(self):
+        db = SessionLocal()
+        try:
+            f = AudioFolder(path="audio/Ambient", tags=["ambient"])
+            db.add(f)
+            db.commit()
+            db.refresh(f)
+            return {"id": f.id, "path": f.path}
+        finally:
+            db.close()
+
+    def test_list_audio_folders(self, client, admin_headers, folder):
+        resp = client.get("/api/audio-folders", headers=admin_headers)
+        assert resp.status_code == 200
+        body = resp.json()
+        assert "folders" in body
+        assert isinstance(body["folders"], list)
+
+    def test_contains_created_folder(self, client, admin_headers, folder):
+        resp = client.get("/api/audio-folders", headers=admin_headers)
+        paths = [f["path"] for f in resp.json()["folders"]]
+        assert "audio/Ambient" in paths
+
+    def test_gm_can_update_folder_tags(self, client, gm_headers, folder):
+        resp = client.patch(
+            "/api/audio-folders",
+            json={"path": "audio/Ambient", "tags": ["ambient", "soundscape"]},
+            headers=gm_headers,
+        )
+        assert resp.status_code == 200
+
+    def test_folder_tags_are_lowercased(self, client, gm_headers):
+        resp = client.patch(
+            "/api/audio-folders",
+            json={"path": "audio/case-test", "tags": ["Ambient", "TAVERN"]},
+            headers=gm_headers,
+        )
+        assert resp.status_code == 200
+        assert resp.json()["tags"] == ["ambient", "tavern"]
+
+    def test_player_cannot_update_folder_tags(self, client, player_headers):
+        resp = client.patch(
+            "/api/audio-folders",
+            json={"path": "audio/test", "tags": ["test"]},
+            headers=player_headers,
+        )
+        assert resp.status_code == 403
+
+
+class TestServeAudioFile:
+    @pytest.fixture(scope="class")
+    def real_track(self):
+        """An Audio row backed by a real .wav on disk, plus a folder cover image."""
+        tmp = tempfile.mkdtemp()
+        wav = os.path.join(tmp, "tone.wav")
+        _write_wav(wav)
+        Image.new("RGB", (16, 16), (10, 20, 30)).save(os.path.join(tmp, "cover.jpg"))
+        a = make_audio(filename="tone.wav", filepath=wav, relative_path="audio/Ambient/tone.wav")
+        return a
+
+    def test_streams_existing_file(self, client, admin_headers, real_track):
+        resp = client.get(f"/api/audio/{real_track.id}/file", headers=admin_headers)
+        assert resp.status_code == 200
+        assert resp.headers["content-type"] == "audio/wav"
+        assert len(resp.content) > 0
+
+    def test_404_for_unknown_id(self, client, admin_headers):
+        resp = client.get("/api/audio/does-not-exist/file", headers=admin_headers)
+        assert resp.status_code == 404
+
+    def test_missing_file_marks_record_and_404s(self, client, admin_headers):
+        a = make_audio(
+            filename="gone.mp3",
+            filepath="/tmp/definitely-missing-xyz.mp3",
+            relative_path="audio/gone.mp3",
+        )
+        resp = client.get(f"/api/audio/{a.id}/file", headers=admin_headers)
+        assert resp.status_code == 404
+        db = SessionLocal()
+        try:
+            assert db.query(Audio).filter_by(id=a.id).first().is_missing is True
+        finally:
+            db.close()
+
+    def test_artwork_serves_folder_cover(self, client, admin_headers, real_track):
+        resp = client.get(f"/api/audio/{real_track.id}/artwork", headers=admin_headers)
+        assert resp.status_code == 200
+        assert resp.headers["content-type"].startswith("image/")
+        assert len(resp.content) > 0
+
+    def test_artwork_404_when_none(self, client, admin_headers):
+        # A row with no real file/folder cover and no embedded art.
+        a = make_audio(filename="bare.mp3", filepath="/tmp/no-such-bare.mp3")
+        resp = client.get(f"/api/audio/{a.id}/artwork", headers=admin_headers)
+        assert resp.status_code == 404
+
+    def test_artwork_404_for_unknown_id(self, client, admin_headers):
+        resp = client.get("/api/audio/does-not-exist/artwork", headers=admin_headers)
+        assert resp.status_code == 404
+
+    def test_update_description_persists(self, client, gm_headers, real_track):
+        resp = client.patch(
+            f"/api/audio/{real_track.id}",
+            json={"description": "A gentle tone"},
+            headers=gm_headers,
+        )
+        assert resp.status_code == 200
+        detail = client.get(f"/api/audio/{real_track.id}", headers=gm_headers).json()
+        assert detail["description"] == "A gentle tone"
+
+    def test_update_unknown_id_404s(self, client, gm_headers):
+        resp = client.patch(
+            "/api/audio/does-not-exist", json={"description": "x"}, headers=gm_headers
+        )
+        assert resp.status_code == 404

--- a/backend/tests/test_campaign_wiki.py
+++ b/backend/tests/test_campaign_wiki.py
@@ -274,6 +274,13 @@ class TestWikiLinks:
         # File/image embeds must not auto-create stub pages.
         assert not any(p["slug"].startswith(("image", "file")) for p in listed)
 
+    def test_audio_embed_not_page_link(self, client, gm_headers, gm_campaign):
+        cid = gm_campaign["id"]
+        _create(client, gm_headers, cid, title="WithAudioEmbed", body="[[audio:track789]]")
+        listed = client.get(f"/api/campaigns/{cid}/wiki", headers=gm_headers).json()
+        # An audio embed must not auto-create a stub page.
+        assert not any(p["slug"].startswith("audio") for p in listed)
+
     def test_stub_inherits_source_visibility(self, client, gm_headers, gm_campaign):
         cid = gm_campaign["id"]
         _create(client, gm_headers, cid, title="GroupHub", body="[[Sub Page]]", visibility="group")

--- a/backend/tests/test_db_migrations.py
+++ b/backend/tests/test_db_migrations.py
@@ -1,0 +1,173 @@
+"""Tests for DB initialisation and the tag-normalization migration.
+
+Exercises models/db.py against throwaway SQLite files so the runtime migrations
+and tag normalization run end-to-end (including the audio tables).
+"""
+import json
+import os
+import tempfile
+
+from sqlalchemy import create_engine, text
+
+from backend.models.db import init_db, _normalize_tags_in_db
+
+
+def _fresh_db():
+    path = os.path.join(tempfile.mkdtemp(), "t.db")
+    init_db(path)
+    return path
+
+
+class TestInitDb:
+    def test_init_db_creates_audio_tables(self):
+        path = _fresh_db()
+        engine = create_engine(f"sqlite:///{path}")
+        with engine.connect() as conn:
+            names = {
+                r[0]
+                for r in conn.execute(
+                    text("SELECT name FROM sqlite_master WHERE type='table'")
+                ).fetchall()
+            }
+        assert "audio" in names
+        assert "audio_folders" in names
+
+    def test_init_db_is_idempotent(self):
+        # Running init_db twice on the same file must not raise — the runtime
+        # migrations all swallow "already exists" errors.
+        path = _fresh_db()
+        init_db(path)  # second run
+        engine = create_engine(f"sqlite:///{path}")
+        with engine.connect() as conn:
+            cnt = conn.execute(text("SELECT COUNT(*) FROM audio")).scalar()
+        assert cnt == 0
+
+
+class TestNormalizeTags:
+    def test_normalizes_audio_table_tags(self):
+        path = _fresh_db()
+        engine = create_engine(f"sqlite:///{path}")
+        with engine.connect() as conn:
+            conn.execute(
+                text(
+                    "INSERT INTO audio (id, filename, filepath, relative_path, tags) "
+                    "VALUES ('a1', 'x.mp3', '/x.mp3', 'audio/x.mp3', :tags)"
+                ),
+                {"tags": json.dumps(["Ambient", "AMBIENT", "  Tavern  "])},
+            )
+            conn.commit()
+            _normalize_tags_in_db(conn)
+            raw = conn.execute(text("SELECT tags FROM audio WHERE id='a1'")).scalar()
+        assert json.loads(raw) == ["ambient", "tavern"]
+
+    def test_normalizes_audio_folder_tags(self):
+        path = _fresh_db()
+        engine = create_engine(f"sqlite:///{path}")
+        with engine.connect() as conn:
+            conn.execute(
+                text(
+                    "INSERT INTO audio_folders (id, path, tags) VALUES ('f1', 'Ambient', :tags)"
+                ),
+                {"tags": json.dumps(["Soundscape", "soundscape"])},
+            )
+            conn.commit()
+            _normalize_tags_in_db(conn)
+            raw = conn.execute(text("SELECT tags FROM audio_folders WHERE id='f1'")).scalar()
+        assert json.loads(raw) == ["soundscape"]
+
+    def test_skips_non_list_tags_without_raising(self):
+        # A row whose tags column is not a JSON list is skipped silently
+        # (covers the `not isinstance(tags, list)` continue branch).
+        path = _fresh_db()
+        engine = create_engine(f"sqlite:///{path}")
+        with engine.connect() as conn:
+            conn.execute(
+                text(
+                    "INSERT INTO audio (id, filename, filepath, relative_path, tags) "
+                    "VALUES ('a2', 'y.mp3', '/y.mp3', 'audio/y.mp3', :tags)"
+                ),
+                {"tags": json.dumps({"not": "a list"})},
+            )
+            conn.commit()
+            _normalize_tags_in_db(conn)  # must not raise
+            raw = conn.execute(text("SELECT tags FROM audio WHERE id='a2'")).scalar()
+        assert json.loads(raw) == {"not": "a list"}
+
+    def test_already_normalized_tags_unchanged(self):
+        path = _fresh_db()
+        engine = create_engine(f"sqlite:///{path}")
+        with engine.connect() as conn:
+            conn.execute(
+                text(
+                    "INSERT INTO audio (id, filename, filepath, relative_path, tags) "
+                    "VALUES ('a3', 'z.mp3', '/z.mp3', 'audio/z.mp3', :tags)"
+                ),
+                {"tags": json.dumps(["already", "clean"])},
+            )
+            conn.commit()
+            _normalize_tags_in_db(conn)
+            raw = conn.execute(text("SELECT tags FROM audio WHERE id='a3'")).scalar()
+        assert json.loads(raw) == ["already", "clean"]
+
+    def test_malformed_json_tags_are_skipped(self):
+        # A tags value that isn't valid JSON triggers the inner except branch,
+        # which swallows the error and leaves the row untouched.
+        path = _fresh_db()
+        engine = create_engine(f"sqlite:///{path}")
+        with engine.connect() as conn:
+            conn.execute(
+                text(
+                    "INSERT INTO audio (id, filename, filepath, relative_path, tags) "
+                    "VALUES ('a4', 'b.mp3', '/b.mp3', 'audio/b.mp3', 'not-json{')"
+                )
+            )
+            conn.commit()
+            _normalize_tags_in_db(conn)  # must not raise
+            raw = conn.execute(text("SELECT tags FROM audio WHERE id='a4'")).scalar()
+        assert raw == "not-json{"
+
+
+class TestLegacyUserMigration:
+    def test_rebuilds_users_table_with_nullable_password(self):
+        """A pre-existing users table with NOT NULL hashed_password is rebuilt so
+        the column becomes nullable (needed for OIDC-only accounts)."""
+        path = os.path.join(tempfile.mkdtemp(), "legacy.db")
+        engine = create_engine(f"sqlite:///{path}")
+        with engine.connect() as conn:
+            conn.execute(
+                text(
+                    """
+                    CREATE TABLE users (
+                        id VARCHAR(36) PRIMARY KEY,
+                        username VARCHAR(100) NOT NULL UNIQUE,
+                        display_name VARCHAR(100),
+                        email VARCHAR(254),
+                        hashed_password VARCHAR(255) NOT NULL,
+                        role VARCHAR(20),
+                        allow_explicit BOOLEAN,
+                        opds_token VARCHAR(64),
+                        oidc_subject VARCHAR(255),
+                        created_at DATETIME
+                    )
+                    """
+                )
+            )
+            conn.execute(
+                text(
+                    "INSERT INTO users (id, username, hashed_password, role) "
+                    "VALUES ('u1', 'admin', 'hash', 'admin')"
+                )
+            )
+            conn.commit()
+        engine.dispose()
+
+        # init_db detects the NOT NULL column and rebuilds the table.
+        init_db(path)
+
+        engine = create_engine(f"sqlite:///{path}")
+        with engine.connect() as conn:
+            cols = conn.execute(text("PRAGMA table_info(users)")).fetchall()
+            hp = next(c for c in cols if c[1] == "hashed_password")
+            assert hp[3] == 0  # notnull is now 0 (nullable)
+            # The existing row survived the rebuild.
+            assert conn.execute(text("SELECT username FROM users WHERE id='u1'")).scalar() == "admin"

--- a/backend/tests/test_indexer_audio.py
+++ b/backend/tests/test_indexer_audio.py
@@ -1,0 +1,162 @@
+"""Tests for the audio-specific indexer helpers and scan path.
+
+Covers the metadata reader, folder/embedded-artwork lookup, and the audio scan
+loop in scan_library (the code added for the audio library feature).
+"""
+import os
+import struct
+import tempfile
+import uuid
+import wave
+
+from PIL import Image
+
+from backend.config import SessionLocal
+from backend.models import Audio, AudioFolder
+from backend.indexer import (
+    AUDIO_EXTS,
+    _read_audio_metadata,
+    _find_folder_artwork,
+    _extract_embedded_art,
+    _has_embedded_art,
+    scan_library,
+)
+
+
+def _write_wav(path, seconds=1):
+    with wave.open(path, "w") as w:
+        w.setnchannels(1)
+        w.setsampwidth(2)
+        w.setframerate(8000)
+        w.writeframes(b"\x00\x00" * (8000 * seconds))
+
+
+def _write_wav_with_id3(path, *, title="", artist="", album="", with_art=False):
+    _write_wav(path)
+    from mutagen.wave import WAVE
+    from mutagen.id3 import TIT2, TPE1, TALB, APIC
+
+    f = WAVE(path)
+    f.add_tags()
+    if title:
+        f.tags.add(TIT2(encoding=3, text=title))
+    if artist:
+        f.tags.add(TPE1(encoding=3, text=artist))
+    if album:
+        f.tags.add(TALB(encoding=3, text=album))
+    if with_art:
+        png = b"\x89PNG\r\n\x1a\n" + b"x" * 32
+        f.tags.add(APIC(encoding=3, mime="image/png", type=3, desc="cover", data=png))
+    f.save()
+
+
+class TestReadAudioMetadata:
+    def test_reads_duration_from_wav(self):
+        tmp = tempfile.mkdtemp()
+        wav = os.path.join(tmp, "tone.wav")
+        _write_wav(wav, seconds=2)
+        meta = _read_audio_metadata(wav)
+        assert round(meta["duration"]) == 2
+        assert meta["embedded_art"] is False
+
+    def test_detects_embedded_art(self):
+        tmp = tempfile.mkdtemp()
+        wav = os.path.join(tmp, "art.wav")
+        _write_wav_with_id3(wav, with_art=True)
+        meta = _read_audio_metadata(wav)
+        assert meta["embedded_art"] is True
+
+    def test_unreadable_file_returns_blank_metadata(self):
+        meta = _read_audio_metadata("/tmp/does-not-exist-xyz.mp3")
+        assert meta["duration"] == 0.0
+        assert meta["title"] == ""
+        assert meta["embedded_art"] is False
+
+
+class TestFolderArtwork:
+    def test_finds_cover_image(self):
+        tmp = tempfile.mkdtemp()
+        Image.new("RGB", (8, 8), (1, 2, 3)).save(os.path.join(tmp, "cover.jpg"))
+        assert _find_folder_artwork(tmp).endswith("cover.jpg")
+
+    def test_finds_folder_image(self):
+        tmp = tempfile.mkdtemp()
+        Image.new("RGB", (8, 8), (1, 2, 3)).save(os.path.join(tmp, "folder.png"))
+        assert _find_folder_artwork(tmp).endswith("folder.png")
+
+    def test_returns_none_when_no_cover(self):
+        tmp = tempfile.mkdtemp()
+        Image.new("RGB", (8, 8), (1, 2, 3)).save(os.path.join(tmp, "random.png"))
+        assert _find_folder_artwork(tmp) is None
+
+    def test_missing_dir_returns_none(self):
+        assert _find_folder_artwork("/tmp/no-such-dir-xyz") is None
+
+
+class TestEmbeddedArt:
+    def test_extracts_apic_art(self):
+        tmp = tempfile.mkdtemp()
+        wav = os.path.join(tmp, "art.wav")
+        _write_wav_with_id3(wav, with_art=True)
+        data, mime = _extract_embedded_art(wav)
+        assert data and mime == "image/png"
+        assert _has_embedded_art(wav) is True
+
+    def test_no_art_returns_none(self):
+        tmp = tempfile.mkdtemp()
+        wav = os.path.join(tmp, "plain.wav")
+        _write_wav(wav)
+        assert _extract_embedded_art(wav) is None
+        assert _has_embedded_art(wav) is False
+
+    def test_bad_file_returns_none(self):
+        assert _extract_embedded_art("/tmp/no-such-xyz.flac") is None
+
+
+class TestAudioScanLoop:
+    def _mk_lib(self):
+        tmp = tempfile.mkdtemp()
+        lib = os.path.join(tmp, "library")
+        os.makedirs(os.path.join(lib, "audio", "Ambient"))
+        return tmp, lib
+
+    def test_scan_registers_audio_with_metadata_and_artwork(self):
+        tmp, lib = self._mk_lib()
+        adir = os.path.join(lib, "audio", "Ambient")
+        wav = os.path.join(adir, "tavern.wav")
+        _write_wav_with_id3(wav, title="Tavern Night", artist="Bard", album="Inn")
+        Image.new("RGB", (8, 8), (1, 2, 3)).save(os.path.join(adir, "cover.jpg"))
+
+        db = SessionLocal()
+        try:
+            stats = scan_library(lib, tempfile.mkdtemp(), db)
+            assert stats["new_audio"] >= 1
+            row = (
+                db.query(Audio)
+                .filter(Audio.filepath == wav)
+                .first()
+            )
+            assert row is not None
+            assert row.duration > 0
+            assert row.has_artwork is True
+        finally:
+            db.close()
+
+    def test_rescan_skips_already_indexed_audio(self):
+        tmp, lib = self._mk_lib()
+        wav = os.path.join(lib, "audio", "Ambient", f"loop-{uuid.uuid4().hex[:6]}.wav")
+        _write_wav(wav)
+        data = tempfile.mkdtemp()
+        db = SessionLocal()
+        try:
+            first = scan_library(lib, data, db)
+            assert first["new_audio"] >= 1
+            second = scan_library(lib, data, db)
+            # The track is already registered, so the second pass adds nothing.
+            assert second["new_audio"] == 0
+        finally:
+            db.close()
+
+    def test_audio_exts_cover_target_formats(self):
+        for ext in (".mp3", ".ogg", ".opus", ".flac", ".wav", ".m4a", ".aac"):
+            assert ext in AUDIO_EXTS

--- a/backend/tests/test_library_helpers.py
+++ b/backend/tests/test_library_helpers.py
@@ -1,0 +1,133 @@
+"""Direct unit tests for the library rescan/indexer helpers.
+
+These call the helper functions in-process (not via the background-task HTTP
+route) so the scan/stop/status orchestration is actually exercised.
+"""
+from unittest.mock import MagicMock, patch
+
+from backend.routers.library import _helpers
+from backend.tests.conftest import make_book, make_game_system
+
+
+class TestScanStatusState:
+    def test_set_and_get_status_roundtrip(self):
+        _helpers._set_status({**_helpers._DEFAULT_STATUS, "running": False})
+        _helpers._set_status({"total_audio": 7, "scanned_audio": 3})
+        status = _helpers._get_status()
+        assert status["total_audio"] == 7
+        assert status["scanned_audio"] == 3
+
+    def test_default_status_includes_audio_fields(self):
+        for key in ("total_audio", "scanned_audio", "new_audio"):
+            assert key in _helpers._DEFAULT_STATUS
+
+
+class TestStopSignal:
+    def test_request_and_clear_stop(self):
+        _helpers.clear_stop()
+        assert _helpers.is_stop_requested() is False
+        _helpers.request_stop()
+        assert _helpers.is_stop_requested() is True
+        _helpers.clear_stop()
+        assert _helpers.is_stop_requested() is False
+
+
+class TestRunRescanSync:
+    def test_rescan_runs_and_resets_status(self):
+        _helpers.clear_stop()
+        # Ensure not flagged as already-running from a prior test.
+        _helpers._set_status({**_helpers._DEFAULT_STATUS})
+        _helpers.run_rescan_sync()
+        status = _helpers._get_status()
+        assert status["running"] is False
+        assert status["phase"] is None
+        # Audio counters are part of the reported status.
+        assert "new_audio" in status
+
+    def test_rescan_skips_when_already_running(self):
+        _helpers._set_status({**_helpers._DEFAULT_STATUS, "running": True, "phase": "scanning"})
+        # Should early-return without touching the scan; status stays "running".
+        _helpers.run_rescan_sync()
+        assert _helpers._get_status()["running"] is True
+        # Reset for other tests.
+        _helpers._set_status({**_helpers._DEFAULT_STATUS})
+
+    def test_rescan_aborts_after_scan_when_stop_requested(self):
+        _helpers._set_status({**_helpers._DEFAULT_STATUS})
+        _helpers.clear_stop()
+        # Force the post-scan stop check to short-circuit the indexing phase.
+        with patch.object(_helpers, "is_stop_requested", return_value=True):
+            _helpers.run_rescan_sync()
+        # The outer finally still resets running/phase.
+        assert _helpers._get_status()["running"] is False
+
+
+class TestBackgroundIndexer:
+    def test_background_indexer_no_books_exits_cleanly(self):
+        # No unindexed PDF books in the test DB → early exit after the sleep.
+        with patch.object(_helpers.time, "sleep", return_value=None):
+            _helpers.background_indexer()
+        # Did not flip the global status into an indexing run.
+        assert _helpers._get_status()["phase"] in (None, "scanning", "indexing")
+
+    def test_background_indexer_processes_unindexed_book(self):
+        # An unindexed PDF whose file is missing on disk → index_book_text raises,
+        # which is caught and the book is flagged index_failed. This exercises the
+        # indexer loop + error branch.
+        _helpers._set_status({**_helpers._DEFAULT_STATUS})
+        _helpers.clear_stop()
+        sys = make_game_system()
+        book = make_book(
+            system_id=sys.id,
+            filepath="/tmp/no-such-indexable.pdf",
+            mime_type="application/pdf",
+            indexed=False,
+        )
+        with patch.object(_helpers.time, "sleep", return_value=None):
+            _helpers.background_indexer()
+        from backend.config import SessionLocal
+        from backend.models import Book
+
+        db = SessionLocal()
+        try:
+            refreshed = db.query(Book).filter_by(id=book.id).first()
+            # Either indexed or flagged failed — in both cases it was processed.
+            assert refreshed.indexed or refreshed.index_failed
+        finally:
+            db.close()
+        _helpers._set_status({**_helpers._DEFAULT_STATUS})
+
+
+class TestValkeyBranches:
+    """Exercise the Valkey-backed code paths by injecting a fake client."""
+
+    def test_status_and_stop_via_valkey(self):
+        fake = MagicMock()
+        store = {}
+        fake.set.side_effect = lambda k, v, **kw: store.__setitem__(k, v)
+        fake.get.side_effect = lambda k: store.get(k)
+        fake.delete.side_effect = lambda k: store.pop(k, None)
+        fake.exists.side_effect = lambda k: k in store
+
+        with patch.object(_helpers, "_valkey", fake):
+            _helpers._set_status({**_helpers._DEFAULT_STATUS, "running": True})
+            assert _helpers._get_status()["running"] is True
+            _helpers.request_stop()
+            assert _helpers.is_stop_requested() is True
+            _helpers.clear_stop()
+            assert _helpers.is_stop_requested() is False
+
+    def test_valkey_errors_fall_back_to_in_process(self):
+        fake = MagicMock()
+        fake.get.side_effect = Exception("boom")
+        fake.set.side_effect = Exception("boom")
+        fake.exists.side_effect = Exception("boom")
+        fake.delete.side_effect = Exception("boom")
+
+        with patch.object(_helpers, "_valkey", fake):
+            # None of these should raise despite the Valkey client failing.
+            _helpers._set_status({"running": False})
+            _helpers._get_status()
+            _helpers.request_stop()
+            _helpers.is_stop_requested()
+            _helpers.clear_stop()

--- a/backend/tests/test_search.py
+++ b/backend/tests/test_search.py
@@ -2,6 +2,7 @@
 import pytest
 from backend.tests.conftest import make_game_system, make_book
 from backend.config import SessionLocal
+from backend.models import MapFolder, TokenFolder, AudioFolder
 from sqlalchemy import text
 
 
@@ -109,6 +110,63 @@ class TestSearch:
         resp = client.get("/api/search?q=shadowgoblintoken", headers=admin_headers)
         body = resp.json()
         assert any(item["id"] == t.id for item in body["tokens"])
+
+    def test_global_search_includes_audio_key(self, client, admin_headers, indexed_book):
+        resp = client.get("/api/search?q=fireball", headers=admin_headers)
+        body = resp.json()
+        assert "audio" in body
+        assert isinstance(body["audio"], list)
+
+    def test_global_search_finds_audio_by_title(self, client, admin_headers):
+        from backend.tests.conftest import make_audio
+
+        a = make_audio(
+            filename="track-xyz.mp3",
+            relative_path="track-xyz.mp3",
+            title="Mystic Cavern Drone",
+        )
+        resp = client.get("/api/search?q=mystic+cavern", headers=admin_headers)
+        body = resp.json()
+        assert any(item["id"] == a.id for item in body["audio"])
+
+    def test_global_search_finds_map_via_folder_tag(self, client, admin_headers):
+        from backend.tests.conftest import make_map
+
+        db = SessionLocal()
+        try:
+            db.add(MapFolder(path="Swamplands", tags=["bayoutag"]))
+            db.commit()
+        finally:
+            db.close()
+        m = make_map(filename="nondescript.png", relative_path="maps/Swamplands/nondescript.png")
+        resp = client.get("/api/search?q=bayoutag", headers=admin_headers)
+        assert any(item["id"] == m.id for item in resp.json()["maps"])
+
+    def test_global_search_finds_token_via_folder_path(self, client, admin_headers):
+        from backend.tests.conftest import make_token
+
+        db = SessionLocal()
+        try:
+            db.add(TokenFolder(path="Gnolltribe", tags=["pack"]))
+            db.commit()
+        finally:
+            db.close()
+        tk = make_token(filename="plain.png", relative_path="tokens/Gnolltribe/plain.png")
+        resp = client.get("/api/search?q=gnolltribe", headers=admin_headers)
+        assert any(item["id"] == tk.id for item in resp.json()["tokens"])
+
+    def test_global_search_finds_audio_via_folder_tag(self, client, admin_headers):
+        from backend.tests.conftest import make_audio
+
+        db = SessionLocal()
+        try:
+            db.add(AudioFolder(path="Soundscapes", tags=["windswept"]))
+            db.commit()
+        finally:
+            db.close()
+        a = make_audio(filename="plain.mp3", relative_path="audio/Soundscapes/plain.mp3", title="")
+        resp = client.get("/api/search?q=windswept", headers=admin_headers)
+        assert any(item["id"] == a.id for item in resp.json()["audio"])
 
     def test_scoped_search_returns_empty_maps_tokens(self, client, admin_headers, indexed_book):
         """When scoped to a system or book, maps and tokens are always empty."""

--- a/backend/tests/test_settings_maintenance.py
+++ b/backend/tests/test_settings_maintenance.py
@@ -356,3 +356,97 @@ class TestRunCleanupSync:
 
         assert db.query(Book).filter_by(id=book_id).first() is None
         db.close()
+
+
+# ---------------------------------------------------------------------------
+# PATCH /api/settings — broad field coverage + UI settings + API key
+# ---------------------------------------------------------------------------
+
+
+class TestSettingsBroadPatch:
+    def test_patch_many_fields_persists_and_clamps(self, client, admin_headers):
+        resp = client.patch(
+            "/api/settings",
+            json={
+                "rescan_schedule_enabled": True,
+                "rescan_schedule_interval": "weekly",
+                "rescan_schedule_hour": 99,  # clamped to 23
+                "rescan_schedule_minute": 200,  # clamped to 59
+                "rescan_schedule_weekday": 9,  # clamped to 6
+                "hide_maps": True,
+                "hide_tokens": True,
+                "hide_audio": True,
+                "hide_campaigns": True,
+                "show_stat_systems": False,
+                "show_stat_books": True,
+                "campaign_uploads_disabled": True,
+                "campaign_upload_max_file_mb": -5,  # clamped to 0
+                "campaign_upload_max_total_mb": 50,
+                "custom_login_message_enabled": True,
+                "custom_login_message": "Welcome adventurers",
+            },
+            headers=admin_headers,
+        )
+        assert resp.status_code == 200
+        body = resp.json()
+        assert body["rescan_schedule_hour"] == 23
+        assert body["rescan_schedule_minute"] == 59
+        assert body["rescan_schedule_weekday"] == 6
+        assert body["hide_audio"] is True
+        # Campaign upload limits surface on the /ui endpoint (clamped to >= 0).
+        ui = client.get("/api/settings/ui", headers=admin_headers).json()
+        assert ui["campaign_upload_max_file_mb"] == 0
+        assert ui["campaign_upload_max_total_mb"] == 50
+
+    def test_invalid_interval_rejected(self, client, admin_headers):
+        resp = client.patch(
+            "/api/settings",
+            json={"rescan_schedule_interval": "fortnightly"},
+            headers=admin_headers,
+        )
+        assert resp.status_code == 400
+
+    def test_player_cannot_patch(self, client, player_headers):
+        resp = client.patch(
+            "/api/settings", json={"hide_audio": True}, headers=player_headers
+        )
+        assert resp.status_code == 403
+
+
+class TestUiSettings:
+    def test_ui_settings_shape(self, client, admin_headers):
+        client.patch("/api/settings", json={"hide_audio": True}, headers=admin_headers)
+        body = client.get("/api/settings/ui", headers=admin_headers).json()
+        for key in (
+            "hide_maps",
+            "hide_tokens",
+            "hide_audio",
+            "hide_campaigns",
+            "campaign_upload_max_file_mb",
+            "guest_access_enabled",
+        ):
+            assert key in body
+        assert body["hide_audio"] is True
+
+    def test_ui_settings_available_to_player(self, client, player_headers):
+        assert client.get("/api/settings/ui", headers=player_headers).status_code == 200
+
+    def test_ui_settings_requires_auth(self, client):
+        assert client.get("/api/settings/ui").status_code == 401
+
+
+class TestStatsApiKey:
+    def test_generate_then_revoke(self, client, admin_headers):
+        gen = client.post("/api/settings/api-key/generate", headers=admin_headers)
+        assert gen.status_code == 200
+        assert len(gen.json()["stats_api_key"]) > 0
+
+        rev = client.delete("/api/settings/api-key", headers=admin_headers)
+        assert rev.status_code == 200
+        assert rev.json()["stats_api_key"] == ""
+
+    def test_generate_requires_admin(self, client, player_headers):
+        assert (
+            client.post("/api/settings/api-key/generate", headers=player_headers).status_code
+            == 403
+        )

--- a/backend/tests/test_tags_json.py
+++ b/backend/tests/test_tags_json.py
@@ -10,7 +10,15 @@ from pathlib import Path
 import pytest
 
 from backend.config import SessionLocal
-from backend.models import GenericMap, MapFolder, Token, TokenFolder, GameSystem
+from backend.models import (
+    GenericMap,
+    MapFolder,
+    Token,
+    TokenFolder,
+    Audio,
+    AudioFolder,
+    GameSystem,
+)
 from backend.indexer import _load_tags_json, _apply_tags_from_library
 
 
@@ -116,6 +124,41 @@ def _get_token_folder(path: str) -> TokenFolder | None:
     db = SessionLocal()
     try:
         return db.query(TokenFolder).filter_by(path=path).first()
+    finally:
+        db.close()
+
+
+def _add_audio(lib: Path, rel: str, tags=None) -> Audio:
+    full = str(lib / rel)
+    db = SessionLocal()
+    try:
+        a = Audio(
+            id=str(uuid.uuid4()),
+            filename=Path(rel).name,
+            filepath=full,
+            relative_path=rel,
+            tags=tags or [],
+        )
+        db.add(a)
+        db.commit()
+        db.refresh(a)
+        return a
+    finally:
+        db.close()
+
+
+def _get_audio(audio_id: str) -> Audio | None:
+    db = SessionLocal()
+    try:
+        return db.query(Audio).filter_by(id=audio_id).first()
+    finally:
+        db.close()
+
+
+def _get_audio_folder(path: str) -> AudioFolder | None:
+    db = SessionLocal()
+    try:
+        return db.query(AudioFolder).filter_by(path=path).first()
     finally:
         db.close()
 
@@ -333,6 +376,53 @@ def test_apply_sets_tags_on_token_subfolder():
     folder = _get_token_folder("Heroes/warriors")
     assert folder is not None
     assert folder.tags == ["melee", "fighter"]
+
+
+# ---------------------------------------------------------------------------
+# _apply_tags_from_library — audio
+# ---------------------------------------------------------------------------
+
+
+def test_apply_sets_tags_on_audio_file():
+    _, lib = _mk_lib()
+    audio_dir = lib / "audio" / "Ambient"
+    audio_dir.mkdir(parents=True)
+    (audio_dir / "tavern.mp3").touch()
+
+    rel = "audio/Ambient/tavern.mp3"
+    a = _add_audio(lib, rel)
+
+    _write_json(audio_dir / "tags.json", {"tavern.mp3": ["ambient", "tavern"]})
+    _run(lib)
+
+    assert _get_audio(a.id).tags == ["ambient", "tavern"]
+
+
+def test_apply_sets_tags_on_audio_folder():
+    _, lib = _mk_lib()
+    audio_dir = lib / "audio" / "Soundscapes"
+    audio_dir.mkdir(parents=True)
+
+    _write_json(audio_dir / "tags.json", {".": ["soundscape", "atmosphere"]})
+    _run(lib)
+
+    folder = _get_audio_folder("Soundscapes")
+    assert folder is not None
+    assert folder.tags == ["soundscape", "atmosphere"]
+
+
+def test_apply_sets_tags_on_audio_subfolder():
+    _, lib = _mk_lib()
+    audio_dir = lib / "audio" / "Creator"
+    sub = audio_dir / "battle"
+    sub.mkdir(parents=True)
+
+    _write_json(audio_dir / "tags.json", {"battle": ["combat", "intense"]})
+    _run(lib)
+
+    folder = _get_audio_folder("Creator/battle")
+    assert folder is not None
+    assert folder.tags == ["combat", "intense"]
 
 
 # ---------------------------------------------------------------------------

--- a/docs/api.md
+++ b/docs/api.md
@@ -83,6 +83,7 @@ Tokens are returned by `/api/auth/login` and expire after **30 days**.
   "books": 340,
   "maps": 1500,
   "tokens": 800,
+  "audio": 250,
   "indexed_books": 320,
   "total_pages": 45000,
   "total_size_mb": 18240.5,
@@ -101,9 +102,12 @@ Tokens are returned by `/api/auth/login` and expire after **30 days**.
   "total_maps": 1500,
   "scanned_tokens": 0,
   "total_tokens": 800,
+  "scanned_audio": 0,
+  "total_audio": 250,
   "new_books": 5,
   "new_maps": 0,
   "new_tokens": 0,
+  "new_audio": 0,
   "updated_books": 0,
   "indexed": 80,
   "to_index": 320
@@ -122,7 +126,7 @@ Tokens are returned by `/api/auth/login` and expire after **30 days**.
 
 | Field | Default | Description |
 |-------|---------|-------------|
-| `scope` | `null` | Restrict the rescan to a subtree relative to the library root. Must begin with `books/`, `maps/`, or `tokens/`. Omit to rescan the whole library. Paths that escape the library root return `400`. |
+| `scope` | `null` | Restrict the rescan to a subtree relative to the library root. Must begin with `books/`, `maps/`, `tokens/`, or `audio/`. Omit to rescan the whole library. Paths that escape the library root return `400`. |
 | `metadata_mode` | `"new"` | `"new"` adds new files and flags missing ones (existing records untouched). `"missing"` additionally fills **empty** book fields from sidecar metadata (`<stem>.opf` / `metadata.opf`), leaving fields you've already set in place. `"replace"` overwrites fields wherever the sidecar provides a value (destructive to UI-edited metadata). |
 
 Returns `{"status": "scan_started"}`, or `{"status": "already_running"}` if a scan is already in progress (scoped and global rescans share the same single-worker lock).
@@ -187,6 +191,20 @@ Returns `{"status": "not_running"}` if no scan is in progress. Cancellation is c
 | `/api/token-folders` | GET | any | List folder tag assignments |
 | `/api/token-folders` | PATCH | gm/admin | Set tags on a folder path. Body: `{path, tags}` |
 
+### Audio
+
+Audio tracks behave like maps/tokens, with embedded metadata. Supported formats: `.mp3`, `.ogg`, `.opus`, `.flac`, `.wav`, `.m4a`, `.aac`.
+
+| Endpoint | Method | Auth | Description |
+|----------|--------|------|-------------|
+| `/api/audio` | GET | any | Paginated audio list (collection key `audio`). Query: `limit`, `offset`. Items include `duration`, `title`, `artist`, `album`, `has_artwork` |
+| `/api/audio/:id` | GET | any | Track detail incl. `folder_path` and `folder_tags` |
+| `/api/audio/:id` | PATCH | gm/admin | Update `description`, `tags` |
+| `/api/audio/:id/file` | GET | any | Stream/download the audio file (supports HTTP range requests) |
+| `/api/audio/:id/artwork` | GET | any | Folder cover art or embedded album art. 404 if none |
+| `/api/audio-folders` | GET | any | List folder tag assignments |
+| `/api/audio-folders` | PATCH | gm/admin | Set tags on a folder path. Body: `{path, tags}` |
+
 ### Favorites
 
 | Endpoint | Method | Auth | Description |
@@ -195,7 +213,7 @@ Returns `{"status": "not_running"}` if no scan is in progress. Cancellation is c
 | `/api/favorites` | POST | any | Add a favorite (idempotent). Body: `{item_type, item_id}` |
 | `/api/favorites/:type/:id` | DELETE | any | Remove a favorite (silent 204 if not found) |
 
-Item types: `book`, `map`, `token`, `system`
+Item types: `book`, `map`, `token`, `audio`, `system`
 
 ### Bookmarks
 
@@ -214,7 +232,7 @@ Bookmarks are per-user — users cannot see or modify each other's bookmarks.
 
 | Endpoint | Method | Auth | Description |
 |----------|--------|------|-------------|
-| `/api/search?q=` | GET | any | FTS5 full-text search. Required: `q` (min 2 chars). Optional: `book_id`, `system_id`, `limit` (default 20). Global search also matches maps and tokens by filename. |
+| `/api/search?q=` | GET | any | FTS5 full-text search. Required: `q` (min 2 chars). Optional: `book_id`, `system_id`, `limit` (default 20). Global search also matches maps, tokens, and audio by filename/folder/tag (audio additionally matches embedded title/artist/album). |
 
 **Response:**
 ```json
@@ -223,7 +241,8 @@ Bookmarks are per-user — users cannot see or modify each other's bookmarks.
   "total": 42,
   "results": [{"id": "uuid", "title": "...", "game_system": "...", "page_number": 42, "snippet": "...", "category": "core"}],
   "maps":    [{"id": "uuid", "filename": "...", "relative_path": "...", "tags": [...]}],
-  "tokens":  [{"id": "uuid", "filename": "...", "relative_path": "...", "tags": [...]}]
+  "tokens":  [{"id": "uuid", "filename": "...", "relative_path": "...", "tags": [...]}],
+  "audio":   [{"id": "uuid", "filename": "...", "relative_path": "...", "title": "...", "tags": [...]}]
 }
 ```
 
@@ -291,7 +310,7 @@ Files are stored on disk under `DATA_PATH/campaign_uploads/`. Banners are keyed 
 
 | Endpoint | Method | Auth | Description |
 |----------|--------|------|-------------|
-| `/api/campaigns/resources/search` | GET | any | Search books/maps/tokens. Books match on title (filter with `system_id?`); maps/tokens match on folder path first then filename, with the folder in `subtitle`. Query: `q`, `resource_type?`, `system_id?`, `limit?` (default 30) |
+| `/api/campaigns/resources/search` | GET | any | Search books/maps/tokens/audio. Books match on title (filter with `system_id?`); maps/tokens/audio match on folder path first then filename, with the folder in `subtitle`. Query: `q`, `resource_type?`, `system_id?`, `limit?` (default 30) |
 | `/api/campaigns/resources/suggested/:system_id` | GET | any | Books in a game system for the create wizard. Core-category books are flagged `suggested` and ordered first. |
 | `/api/campaigns/:id/resources` | GET | member or owner | List linked resources (each with `visibility`, `category_id`, `sort_order`, `has_thumbnail`; owner items also include `shared_user_ids`). Ordered public → private → gm, then by `sort_order`. Players see only what their visibility allows. |
 | `/api/campaigns/:id/resources` | POST | owner | Link a resource. Body: `{resource_type, resource_id, visibility?, shared_user_ids?, category_id?}` |
@@ -303,7 +322,7 @@ Files are stored on disk under `DATA_PATH/campaign_uploads/`. Banners are keyed 
 | `/api/campaigns/:id/images` | POST | owner | Upload an image (multipart `file`, image types only) to embed in a wiki note; links it as a `file` resource with `is_image: true`. Optional multipart fields: `category_id` (file it under an existing resource category) or `new_category_name` (create a category and file it there). |
 | `/api/campaigns/:id/files/:file_id` | GET | per visibility | Download a campaign file (honours the linking resource's visibility); for an image this also serves it inline/as its thumbnail |
 
-Resource types: `book`, `map`, `token`, `file` (a GM-uploaded file stored under `DATA_PATH/campaign_uploads/files/`, separate from the library). Listed/serialized resources include `is_image` (true for `file` resources that hold an image upload — those render inline with a thumbnail instead of as a download card).
+Resource types: `book`, `map`, `token`, `audio`, `file` (a GM-uploaded file stored under `DATA_PATH/campaign_uploads/files/`, separate from the library). Listed/serialized resources include `is_image` (true for `file` resources that hold an image upload — those render inline with a thumbnail instead of as a download card).
 
 Resource **visibility** is one of: `public` (every accepted member), `private` (the owner plus the users in `shared_user_ids`), or `gm` (owner only). The character-sheet upload endpoints also accept a URL alternative via the member PATCH: `PATCH /api/campaigns/:id/members/:user_id` with `{character_sheet_url}` (`""` clears it; setting a URL clears any uploaded sheet, and uploading a sheet clears the URL).
 
@@ -326,7 +345,7 @@ The resource panel's **group display order** (custom categories interleaved with
 
 #### Wiki (notes)
 
-The campaign notebook is a set of markdown **wiki pages**. Pages link to one another with `[[Page Title]]` (or `[[Page Title|label]]`) syntax and embed campaign content inline with `[[book:ID]]`, `[[book:ID:PAGE]]`, `[[map:ID]]`, `[[token:ID]]`, `[[file:ID]]` (a download card for a campaign file), or `[[image:ID]]` (an uploaded image rendered inline). `ID` is the resource's underlying id; the embed picker lists only resources already linked to the campaign (and offers an image upload). On save the body is re-parsed: unknown `[[Page Title]]` targets auto-create a stub page (inheriting the source page's visibility), embed tokens are skipped (never create stubs), and backlink rows are rebuilt.
+The campaign notebook is a set of markdown **wiki pages**. Pages link to one another with `[[Page Title]]` (or `[[Page Title|label]]`) syntax and embed campaign content inline with `[[book:ID]]`, `[[book:ID:PAGE]]`, `[[map:ID]]`, `[[token:ID]]`, `[[audio:ID]]` (an inline audio player), `[[file:ID]]` (a download card for a campaign file), or `[[image:ID]]` (an uploaded image rendered inline). `ID` is the resource's underlying id; the embed picker lists only resources already linked to the campaign (and offers an image upload). On save the body is re-parsed: unknown `[[Page Title]]` targets auto-create a stub page (inheriting the source page's visibility), embed tokens are skipped (never create stubs), and backlink rows are rebuilt.
 
 Pages nest: each page has an optional `parent_id` (null = top level), forming a tree of arbitrary depth (a "category" is just a page with children). Deleting a page re-parents its children to the deleted page's parent rather than removing the subtree. A page may not be its own parent or be moved under one of its own descendants (400).
 
@@ -421,6 +440,7 @@ Availability statuses: `available`, `tentative`, `unavailable`
 | `rescan_schedule_weekday` | int | Weekday (0–6) for weekly rescans |
 | `hide_maps` | bool | Hide the maps section in the UI |
 | `hide_tokens` | bool | Hide the tokens section in the UI |
+| `hide_audio` | bool | Hide the audio section in the UI |
 | `hide_campaigns` | bool | Hide the campaigns section in the UI |
 | `show_stat_systems` | bool | Show/hide game system count in sidebar |
 | `show_stat_books` | bool | Show/hide book count in sidebar |

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -22,6 +22,7 @@
         "@testing-library/react": "^16.3.2",
         "@testing-library/user-event": "^14.6.1",
         "@vitejs/plugin-react": "^6.0.2",
+        "@vitest/coverage-istanbul": "^4.1.9",
         "@vitest/coverage-v8": "^4.1.9",
         "eslint": "^9.39.4",
         "eslint-plugin-react": "^7.37.5",
@@ -102,19 +103,135 @@
       "license": "MIT"
     },
     "node_modules/@babel/code-frame": {
-      "version": "7.29.0",
-      "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.29.0.tgz",
-      "integrity": "sha512-9NhCeYjq9+3uxgdtp20LSiJXJvN0FeCtNGpJxuMFZ1Kv3cWUNb6DOhJwUvcVCzKGR66cw4njwM6hrJLqgOwbcw==",
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.29.7.tgz",
+      "integrity": "sha512-Aup7aUOfpbAUg2ROOJN6Iw5f9DMBlzu0mIkm/malLQFN/YQgO48wCj0Kxa3sEHJvPVFg7siR+qRInwXd2qhQKw==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
-        "@babel/helper-validator-identifier": "^7.28.5",
+        "@babel/helper-validator-identifier": "^7.29.7",
         "js-tokens": "^4.0.0",
         "picocolors": "^1.1.1"
       },
       "engines": {
         "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/compat-data": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/compat-data/-/compat-data-7.29.7.tgz",
+      "integrity": "sha512-locTkQyKvwIEgBzVrn8693ebc97F2U8ZHjbXwDXJ5Fn2TCpNwTlKcaKLkdHop5c/icOFE7qt7Q9JC5hnKNa6Gg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/core": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/core/-/core-7.29.7.tgz",
+      "integrity": "sha512-RgHBCvtjbOK2gXSNBNIkNoEc9qoVEtau3hj8gEqKQuL3HZAibKarWFEI3Lfm6EYKkLalOh8eSrj9b+ch9H/VBA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/code-frame": "^7.29.7",
+        "@babel/generator": "^7.29.7",
+        "@babel/helper-compilation-targets": "^7.29.7",
+        "@babel/helper-module-transforms": "^7.29.7",
+        "@babel/helpers": "^7.29.7",
+        "@babel/parser": "^7.29.7",
+        "@babel/template": "^7.29.7",
+        "@babel/traverse": "^7.29.7",
+        "@babel/types": "^7.29.7",
+        "@jridgewell/remapping": "^2.3.5",
+        "convert-source-map": "^2.0.0",
+        "debug": "^4.1.0",
+        "gensync": "^1.0.0-beta.2",
+        "json5": "^2.2.3",
+        "semver": "^6.3.1"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/babel"
+      }
+    },
+    "node_modules/@babel/generator": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.29.7.tgz",
+      "integrity": "sha512-DkXD5OJQaAQIdZ1bt3UZdEnHAn9Imd3IVBdX03UFe+ony9Ojw5pzr9YVKGDY1jt+Gcn/FnGkNf8r+Vj5NOJWtQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/parser": "^7.29.7",
+        "@babel/types": "^7.29.7",
+        "@jridgewell/gen-mapping": "^0.3.12",
+        "@jridgewell/trace-mapping": "^0.3.28",
+        "jsesc": "^3.0.2"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/helper-compilation-targets": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/helper-compilation-targets/-/helper-compilation-targets-7.29.7.tgz",
+      "integrity": "sha512-wem6WaBj4NaVYVdNhLPPVacES6ZJ+KBBfSkTMD3YZxbP3rm3Di85tJU5ljaUNhaOynt+Aj0xruhYuzQBt8n71g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/compat-data": "^7.29.7",
+        "@babel/helper-validator-option": "^7.29.7",
+        "browserslist": "^4.24.0",
+        "lru-cache": "^5.1.1",
+        "semver": "^6.3.1"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/helper-globals": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/helper-globals/-/helper-globals-7.29.7.tgz",
+      "integrity": "sha512-3nQVUAtvkKH9zahfWgw96Jc/uFOmjACE1kQz82E2lqWmHBgjzbNlsC22nuQTfahmWeQtTq5nQ/4Nnd2A1wj4zA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/helper-module-imports": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/helper-module-imports/-/helper-module-imports-7.29.7.tgz",
+      "integrity": "sha512-ejHwrQQYcm9xnTivShn2IDOlIzInN34AXskvq9QicvCtEzq1Vzclu/tKF8Jq1Cg8JG2GL6/EmjgsCT7lXepE3g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/traverse": "^7.29.7",
+        "@babel/types": "^7.29.7"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/helper-module-transforms": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/helper-module-transforms/-/helper-module-transforms-7.29.7.tgz",
+      "integrity": "sha512-UPUVSyXbOh627KiCIGQSgwWzGeBKLkaJ9PJEdrngIwMSzxLR4jS4+f1f1jb7VzBbg8nFLaYotvVPFCTqdrmTAg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-module-imports": "^7.29.7",
+        "@babel/helper-validator-identifier": "^7.29.7",
+        "@babel/traverse": "^7.29.7"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0"
       }
     },
     "node_modules/@babel/helper-string-parser": {
@@ -133,6 +250,30 @@
       "integrity": "sha512-qehxGkRj55h/ff8EMaJ+cYhyaKlHIxqYDn682wQD7RNp9UujOQsHog2uS0r2vzr4pW+sXf90NeeayjcNaX3fFg==",
       "dev": true,
       "license": "MIT",
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/helper-validator-option": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/helper-validator-option/-/helper-validator-option-7.29.7.tgz",
+      "integrity": "sha512-N9ZErrD+yW5geCDtBqnOoxmR8+tNKiGuxKlDpuJxfsqpa2dFcexaziGAE/qoHLiDDreVNMupxGmSoNlyvsA3gw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/helpers": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/helpers/-/helpers-7.29.7.tgz",
+      "integrity": "sha512-1k2lAGRMfHTcwuNYcCNUmaUffmQv8KWMfh2iJUUeRlwlwH4FdNG7mfPI10NPfLHJFThE4Tyr4mv7kTNZOiPuBg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/template": "^7.29.7",
+        "@babel/types": "^7.29.7"
+      },
       "engines": {
         "node": ">=6.9.0"
       }
@@ -158,6 +299,40 @@
       "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.29.2.tgz",
       "integrity": "sha512-JiDShH45zKHWyGe4ZNVRrCjBz8Nh9TMmZG1kh4QTK8hCBTWBi8Da+i7s1fJw7/lYpM4ccepSNfqzZ/QvABBi5g==",
       "license": "MIT",
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/template": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/template/-/template-7.29.7.tgz",
+      "integrity": "sha512-puq+Gf35oI24FeN11LkoUQFqv9uwNeWpxXZi/Ji3rRIoKAzKnxRaZ+Gkj0vKS9ZCiTESfng1N9LyOyXvo+m+Gg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/code-frame": "^7.29.7",
+        "@babel/parser": "^7.29.7",
+        "@babel/types": "^7.29.7"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/traverse": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.29.7.tgz",
+      "integrity": "sha512-EhlfNQtZ+NK22w5BM61ciuiq1m58ed33Wr1Xan//ZRTy6hgjnwyCffRYwzsGXdASJSUJ1guZILsErh1eQcl+zw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/code-frame": "^7.29.7",
+        "@babel/generator": "^7.29.7",
+        "@babel/helper-globals": "^7.29.7",
+        "@babel/parser": "^7.29.7",
+        "@babel/template": "^7.29.7",
+        "@babel/types": "^7.29.7",
+        "debug": "^4.3.1"
+      },
       "engines": {
         "node": ">=6.9.0"
       }
@@ -612,6 +787,38 @@
       "funding": {
         "type": "github",
         "url": "https://github.com/sponsors/nzakas"
+      }
+    },
+    "node_modules/@istanbuljs/schema": {
+      "version": "0.1.6",
+      "resolved": "https://registry.npmjs.org/@istanbuljs/schema/-/schema-0.1.6.tgz",
+      "integrity": "sha512-+Sg6GCR/wy1oSmQDFq4LQDAhm3ETKnorxN+y5nbLULOR3P0c14f2Wurzj3/xqPXtasLFfHd5iRFQ7AJt4KH2cw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/@jridgewell/gen-mapping": {
+      "version": "0.3.13",
+      "resolved": "https://registry.npmjs.org/@jridgewell/gen-mapping/-/gen-mapping-0.3.13.tgz",
+      "integrity": "sha512-2kkt/7niJ6MgEPxF0bYdQ6etZaA+fQvDcLKckhy1yIQOzaoKjBBjSj63/aLVjYE3qhRt5dvM+uUyfCg6UKCBbA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/sourcemap-codec": "^1.5.0",
+        "@jridgewell/trace-mapping": "^0.3.24"
+      }
+    },
+    "node_modules/@jridgewell/remapping": {
+      "version": "2.3.5",
+      "resolved": "https://registry.npmjs.org/@jridgewell/remapping/-/remapping-2.3.5.tgz",
+      "integrity": "sha512-LI9u/+laYG4Ds1TDKSJW2YPrIlcVYOwi2fUC6xB43lueCjgxV4lffOCZCtYFiH6TNOX+tQKXx97T4IKHbhyHEQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/gen-mapping": "^0.3.5",
+        "@jridgewell/trace-mapping": "^0.3.24"
       }
     },
     "node_modules/@jridgewell/resolve-uri": {
@@ -1181,6 +1388,31 @@
         }
       }
     },
+    "node_modules/@vitest/coverage-istanbul": {
+      "version": "4.1.9",
+      "resolved": "https://registry.npmjs.org/@vitest/coverage-istanbul/-/coverage-istanbul-4.1.9.tgz",
+      "integrity": "sha512-4a7DsIwycTf4eYwEDtnMfMV8H80KSKH9PuMHhqL5SwPZzDyUKq2X/TPCVZ7NqIuSz7UbZckmEmkip6iZBI/gEA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/core": "^7.29.0",
+        "@istanbuljs/schema": "^0.1.3",
+        "@jridgewell/gen-mapping": "^0.3.13",
+        "@jridgewell/trace-mapping": "0.3.31",
+        "istanbul-lib-coverage": "^3.2.2",
+        "istanbul-lib-report": "^3.0.1",
+        "istanbul-reports": "^3.2.0",
+        "magicast": "^0.5.2",
+        "obug": "^2.1.1",
+        "tinyrainbow": "^3.1.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      },
+      "peerDependencies": {
+        "vitest": "4.1.9"
+      }
+    },
     "node_modules/@vitest/coverage-v8": {
       "version": "4.1.9",
       "resolved": "https://registry.npmjs.org/@vitest/coverage-v8/-/coverage-v8-4.1.9.tgz",
@@ -1617,6 +1849,19 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/baseline-browser-mapping": {
+      "version": "2.10.40",
+      "resolved": "https://registry.npmjs.org/baseline-browser-mapping/-/baseline-browser-mapping-2.10.40.tgz",
+      "integrity": "sha512-BSSLZ9/Cjjv7Gtj5B68ZzXcXUg8iOf3fme+FCuh8rC/Go+Kmh8cox7M3A8dolou16s64QjLPOSdngh7GxXvkSw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "baseline-browser-mapping": "dist/cli.cjs"
+      },
+      "engines": {
+        "node": ">=6.0.0"
+      }
+    },
     "node_modules/bidi-js": {
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/bidi-js/-/bidi-js-1.0.3.tgz",
@@ -1636,6 +1881,40 @@
       "dependencies": {
         "balanced-match": "^1.0.0",
         "concat-map": "0.0.1"
+      }
+    },
+    "node_modules/browserslist": {
+      "version": "4.28.4",
+      "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.28.4.tgz",
+      "integrity": "sha512-MTc8i/x9jBQd1iMw2CFGS+rwMa07eYjLR0CCTLDACl9xhxy+nIs3KeML/biicXtk9JrZ6dnnTatmc7ErPXIxqw==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/browserslist"
+        },
+        {
+          "type": "tidelift",
+          "url": "https://tidelift.com/funding/github/npm/browserslist"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "baseline-browser-mapping": "^2.10.38",
+        "caniuse-lite": "^1.0.30001799",
+        "electron-to-chromium": "^1.5.376",
+        "node-releases": "^2.0.48",
+        "update-browserslist-db": "^1.2.3"
+      },
+      "bin": {
+        "browserslist": "cli.js"
+      },
+      "engines": {
+        "node": "^6 || ^7 || ^8 || ^9 || ^10 || ^11 || ^12 || >=13.7"
       }
     },
     "node_modules/call-bind": {
@@ -1697,6 +1976,27 @@
       "engines": {
         "node": ">=6"
       }
+    },
+    "node_modules/caniuse-lite": {
+      "version": "1.0.30001799",
+      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001799.tgz",
+      "integrity": "sha512-hG1bReV+OUU+MOqK4t/ZWI0tZOyz3rqS9XuhOUz1cIcbwBKjOyJEJuw9ER5JuNyqxNk8u/JUVbGibBOL1yrjFw==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/browserslist"
+        },
+        {
+          "type": "tidelift",
+          "url": "https://tidelift.com/funding/github/npm/caniuse-lite"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "license": "CC-BY-4.0"
     },
     "node_modules/ccount": {
       "version": "2.0.1",
@@ -2094,6 +2394,13 @@
         "node": ">= 0.4"
       }
     },
+    "node_modules/electron-to-chromium": {
+      "version": "1.5.381",
+      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.5.381.tgz",
+      "integrity": "sha512-n9Wa6yB+vDsGuA8AKbl/0z7HbvWqt5jxIdvr1IUicd0ryPrk7/xzwqLv8D9AbbvZ6avVNtXYLTfmgFHkwkyelg==",
+      "dev": true,
+      "license": "ISC"
+    },
     "node_modules/entities": {
       "version": "6.0.1",
       "resolved": "https://registry.npmjs.org/entities/-/entities-6.0.1.tgz",
@@ -2310,6 +2617,16 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/escalade": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/escalade/-/escalade-3.2.0.tgz",
+      "integrity": "sha512-WUj2qlxaQtO4g6Pq5c29GTcWGDyd8itL8zTlipgECz3JesAiiOKotd8JU6otB3PACgG6xkJUyVhboMS+bje/jA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
       }
     },
     "node_modules/escape-string-regexp": {
@@ -2746,6 +3063,16 @@
       "license": "MIT",
       "engines": {
         "node": ">= 0.4"
+      }
+    },
+    "node_modules/gensync": {
+      "version": "1.0.0-beta.2",
+      "resolved": "https://registry.npmjs.org/gensync/-/gensync-1.0.0-beta.2.tgz",
+      "integrity": "sha512-3hN7NaskYvMDLQY55gnW3NQ+mesEAepTqlg+VEbj7zzqEMBVNhzcGYYeqFo/TlYz6eQiFcp1HcsCZO+nGgS8zg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.9.0"
       }
     },
     "node_modules/get-intrinsic": {
@@ -3745,6 +4072,19 @@
         "node": "20 || >=22"
       }
     },
+    "node_modules/jsesc": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/jsesc/-/jsesc-3.1.0.tgz",
+      "integrity": "sha512-/sM3dO2FOzXjKQhJuo0Q173wf2KOo8t4I8vHy6lF9poUp7bKT0/NHE8fPX23PwfhnykfqnC2xRxOnVw5XuGIaA==",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "jsesc": "bin/jsesc"
+      },
+      "engines": {
+        "node": ">=6"
+      }
+    },
     "node_modules/json-buffer": {
       "version": "3.0.1",
       "resolved": "https://registry.npmjs.org/json-buffer/-/json-buffer-3.0.1.tgz",
@@ -3765,6 +4105,19 @@
       "integrity": "sha512-Bdboy+l7tA3OGW6FjyFHWkP5LuByj1Tk33Ljyq0axyzdk9//JSi2u3fP1QSmd1KNwq6VOKYGlAu87CisVir6Pw==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/json5": {
+      "version": "2.2.3",
+      "resolved": "https://registry.npmjs.org/json5/-/json5-2.2.3.tgz",
+      "integrity": "sha512-XmOWe7eyHYH14cLdVPoyg+GOH3rYX++KpzrylJwSW98t3Nk+U8XOl8FWKOgwtzdb8lXGf6zYwDUzeHMWfxasyg==",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "json5": "lib/cli.js"
+      },
+      "engines": {
+        "node": ">=6"
+      }
     },
     "node_modules/jsx-ast-utils": {
       "version": "3.3.5",
@@ -4110,6 +4463,16 @@
       },
       "bin": {
         "loose-envify": "cli.js"
+      }
+    },
+    "node_modules/lru-cache": {
+      "version": "5.1.1",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-5.1.1.tgz",
+      "integrity": "sha512-KpNARQA3Iwv+jTA0utUVVbrh+Jlrr1Fv0e56GGzAFOXN7dk/FviaDW8LHmK52DlcH4WP2n6gI8vN1aesBFgo9w==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "yallist": "^3.0.2"
       }
     },
     "node_modules/lz-string": {
@@ -5106,6 +5469,16 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/node-releases": {
+      "version": "2.0.50",
+      "resolved": "https://registry.npmjs.org/node-releases/-/node-releases-2.0.50.tgz",
+      "integrity": "sha512-J6l92tKHX6w8Jy5nO1Vuc01NoIiRGi/d6qBKVxh+IQ8Cr3b6HbVNfKiF8ZpFKufTwpwxMmce2W3iQZ861ZRyTg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
       }
     },
     "node_modules/object-assign": {
@@ -6655,6 +7028,37 @@
         "url": "https://opencollective.com/unified"
       }
     },
+    "node_modules/update-browserslist-db": {
+      "version": "1.2.3",
+      "resolved": "https://registry.npmjs.org/update-browserslist-db/-/update-browserslist-db-1.2.3.tgz",
+      "integrity": "sha512-Js0m9cx+qOgDxo0eMiFGEueWztz+d4+M3rGlmKPT+T4IS/jP4ylw3Nwpu6cpTTP8R1MAC1kF4VbdLt3ARf209w==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/browserslist"
+        },
+        {
+          "type": "tidelift",
+          "url": "https://tidelift.com/funding/github/npm/browserslist"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "escalade": "^3.2.0",
+        "picocolors": "^1.1.1"
+      },
+      "bin": {
+        "update-browserslist-db": "cli.js"
+      },
+      "peerDependencies": {
+        "browserslist": ">= 4.21.0"
+      }
+    },
     "node_modules/uri-js": {
       "version": "4.4.1",
       "resolved": "https://registry.npmjs.org/uri-js/-/uri-js-4.4.1.tgz",
@@ -7075,6 +7479,13 @@
       "integrity": "sha512-JZnDKK8B0RCDw84FNdDAIpZK+JuJw+s7Lz8nksI7SIuU3UXJJslUthsi+uWBUYOwPFwW7W7PRLRfUKpxjtjFCw==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/yallist": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/yallist/-/yallist-3.1.1.tgz",
+      "integrity": "sha512-a4UGQaWPH59mOXUYnAG2ewncQS4i4F43Tv3JoAM+s2VDAmS9NsK8GpDMLrCHPksFT7h3K6TOoUNn2pb7RoXx4g==",
+      "dev": true,
+      "license": "ISC"
     },
     "node_modules/yocto-queue": {
       "version": "0.1.0",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -30,6 +30,7 @@
     "@testing-library/react": "^16.3.2",
     "@testing-library/user-event": "^14.6.1",
     "@vitejs/plugin-react": "^6.0.2",
+    "@vitest/coverage-istanbul": "^4.1.9",
     "@vitest/coverage-v8": "^4.1.9",
     "eslint": "^9.39.4",
     "eslint-plugin-react": "^7.37.5",

--- a/frontend/scripts/check-coverage.mjs
+++ b/frontend/scripts/check-coverage.mjs
@@ -42,7 +42,7 @@ function repoRoot() {
 
 // Pick the first base ref that git can resolve.
 function resolveBase(root) {
-  const candidates = [process.env.BASE_REF, 'origin/main', 'main'].filter(Boolean)
+  const candidates = [process.env.BASE_REF, 'origin/dev', 'dev'].filter(Boolean)
   for (const ref of candidates) {
     try {
       git(['rev-parse', '--verify', '--quiet', `${ref}^{commit}`], root)

--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -1,5 +1,6 @@
 import { useAuth } from './context/AuthContext'
 import { FavoritesProvider } from './context/FavoritesContext'
+import { AudioPlayerProvider } from './context/AudioPlayerContext'
 import SetupView from './views/SetupView'
 import LoginView from './views/LoginView'
 import LoadingScreen from './components/LoadingScreen'
@@ -13,7 +14,9 @@ export default function App() {
   if (status === 'unauthenticated') return <LoginView onLogin={login} />
   return (
     <FavoritesProvider>
-      <AppShell />
+      <AudioPlayerProvider>
+        <AppShell />
+      </AudioPlayerProvider>
     </FavoritesProvider>
   )
 }

--- a/frontend/src/App.test.jsx
+++ b/frontend/src/App.test.jsx
@@ -1,0 +1,40 @@
+import { describe, it, expect, vi } from 'vitest'
+import { render, screen } from '@testing-library/react'
+import App from './App'
+
+let authStatus = 'loading'
+vi.mock('./context/AuthContext', () => ({
+  useAuth: () => ({ status: authStatus, login: vi.fn() }),
+}))
+vi.mock('./context/FavoritesContext', () => ({ FavoritesProvider: ({ children }) => children }))
+vi.mock('./context/AudioPlayerContext', () => ({ AudioPlayerProvider: ({ children }) => children }))
+vi.mock('./views/SetupView', () => ({ default: () => <div>setup</div> }))
+vi.mock('./views/LoginView', () => ({ default: () => <div>login</div> }))
+vi.mock('./components/LoadingScreen', () => ({ default: () => <div>loading</div> }))
+vi.mock('./components/AppShell', () => ({ default: () => <div>shell</div> }))
+
+describe('App auth gating', () => {
+  it('shows the loading screen while auth is resolving', () => {
+    authStatus = 'loading'
+    render(<App />)
+    expect(screen.getByText('loading')).toBeInTheDocument()
+  })
+
+  it('shows setup when uninitialized', () => {
+    authStatus = 'uninitialized'
+    render(<App />)
+    expect(screen.getByText('setup')).toBeInTheDocument()
+  })
+
+  it('shows login when unauthenticated', () => {
+    authStatus = 'unauthenticated'
+    render(<App />)
+    expect(screen.getByText('login')).toBeInTheDocument()
+  })
+
+  it('renders the app shell (wrapped in providers) when authenticated', () => {
+    authStatus = 'authenticated'
+    render(<App />)
+    expect(screen.getByText('shell')).toBeInTheDocument()
+  })
+})

--- a/frontend/src/components/AppShell.jsx
+++ b/frontend/src/components/AppShell.jsx
@@ -3,6 +3,8 @@ import { Routes, Route, Navigate, useLocation, useNavigate } from 'react-router-
 import useScrollRestoration from '../hooks/useScrollRestoration'
 import { useAuth } from '../context/AuthContext'
 import { UISettingsProvider } from '../context/UISettingsContext'
+import { useAudioPlayer } from '../context/AudioPlayerContext'
+import GlobalAudioPlayer, { PLAYER_HEIGHT } from './audio/GlobalAudioPlayer'
 import api, { settings as settingsApi } from '../api'
 import Sidebar from './Sidebar'
 import MobileSidebar from './MobileSidebar'
@@ -13,6 +15,8 @@ import MapsView from '../views/MapsView'
 import MapDetailView from './maps/MapDetailView'
 import TokensView from '../views/TokensView'
 import TokenDetailView from './tokens/TokenDetailView'
+import AudioView from '../views/AudioView'
+import AudioDetailView from './audio/AudioDetailView'
 import SearchView from '../views/SearchView'
 import SettingsView from '../views/SettingsView'
 import FavoritesView from '../views/FavoritesView'
@@ -29,6 +33,7 @@ export default function AppShell() {
   const [uiSettings, setUiSettings] = useState({
     hide_maps: false,
     hide_tokens: false,
+    hide_audio: false,
     hide_campaigns: false,
   })
   const [isMobile, setIsMobile] = useState(window.innerWidth < 768)
@@ -49,6 +54,8 @@ export default function AppShell() {
     location.pathname.startsWith('/maps/') ||
     location.pathname.startsWith('/tokens/')
   const mainRef = useScrollRestoration()
+  const { queue } = useAudioPlayer()
+  const playerActive = queue.length > 0
 
   const refreshUiSettings = () =>
     settingsApi
@@ -103,7 +110,7 @@ export default function AppShell() {
             minWidth: 0,
             height: '100%',
             overflow: isReader ? 'hidden' : 'auto',
-            paddingBottom: isMobile ? 64 : 0,
+            paddingBottom: (isMobile ? 64 : 0) + (playerActive ? PLAYER_HEIGHT : 0),
           }}
         >
           {isGuest ? (
@@ -125,6 +132,8 @@ export default function AppShell() {
               <Route path="/maps/:mapId" element={<MapDetailView />} />
               <Route path="/tokens" element={<TokensView />} />
               <Route path="/tokens/:tokenId" element={<TokenDetailView />} />
+              <Route path="/audio" element={<AudioView />} />
+              <Route path="/audio/:audioId" element={<AudioDetailView />} />
               <Route path="/search" element={<SearchView />} />
               <Route path="/favorites" element={<FavoritesView />} />
               <Route path="/campaigns" element={<CampaignsView />} />
@@ -141,6 +150,8 @@ export default function AppShell() {
         </main>
 
         {isMobile && <MobileSidebar user={user} onLogout={logout} uiSettings={uiSettings} />}
+
+        <GlobalAudioPlayer isMobile={isMobile} />
       </div>
     </UISettingsProvider>
   )

--- a/frontend/src/components/AppShell.test.jsx
+++ b/frontend/src/components/AppShell.test.jsx
@@ -1,0 +1,81 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { render, screen, waitFor } from '@testing-library/react'
+import { MemoryRouter } from 'react-router-dom'
+import AppShell from './AppShell'
+
+vi.mock('../api', () => ({
+  default: { get: vi.fn().mockResolvedValue({ books: 1 }) },
+  settings: { getUi: vi.fn().mockResolvedValue({ hide_audio: false }) },
+}))
+vi.mock('../context/AuthContext', () => ({
+  useAuth: () => ({ user: { role: 'admin' }, logout: vi.fn() }),
+}))
+let queue = []
+vi.mock('../context/AudioPlayerContext', () => ({
+  useAudioPlayer: () => ({ queue }),
+}))
+vi.mock('../context/UISettingsContext', () => ({
+  UISettingsProvider: ({ children }) => children,
+}))
+vi.mock('../hooks/useScrollRestoration', () => ({ default: () => ({ current: null }) }))
+vi.mock('./Sidebar', () => ({ default: () => <nav>sidebar</nav> }))
+vi.mock('./MobileSidebar', () => ({ default: () => <nav>mobile-nav</nav> }))
+vi.mock('./audio/GlobalAudioPlayer', () => ({
+  default: () => <div data-testid="global-player" />,
+  PLAYER_HEIGHT: 72,
+}))
+// Stub all routed views so we only test the shell.
+vi.mock('./BookReader', () => ({ default: () => <div>reader</div> }))
+vi.mock('../views/LibraryView', () => ({ default: () => <div>library</div> }))
+vi.mock('../views/SystemDetailView', () => ({ default: () => <div>system</div> }))
+vi.mock('../views/MapsView', () => ({ default: () => <div>maps</div> }))
+vi.mock('./maps/MapDetailView', () => ({ default: () => <div>map-detail</div> }))
+vi.mock('../views/TokensView', () => ({ default: () => <div>tokens</div> }))
+vi.mock('./tokens/TokenDetailView', () => ({ default: () => <div>token-detail</div> }))
+vi.mock('../views/AudioView', () => ({ default: () => <div>audio</div> }))
+vi.mock('./audio/AudioDetailView', () => ({ default: () => <div>audio-detail</div> }))
+vi.mock('../views/SearchView', () => ({ default: () => <div>search</div> }))
+vi.mock('../views/SettingsView', () => ({ default: () => <div>settings</div> }))
+vi.mock('../views/FavoritesView', () => ({ default: () => <div>favorites</div> }))
+vi.mock('../views/CampaignsView', () => ({ default: () => <div>campaigns</div> }))
+vi.mock('../views/CampaignDetailView', () => ({ default: () => <div>campaign-detail</div> }))
+vi.mock('../views/CampaignNotesView', () => ({ default: () => <div>campaign-notes</div> }))
+
+const renderAt = (path) =>
+  render(
+    <MemoryRouter initialEntries={[path]}>
+      <AppShell />
+    </MemoryRouter>
+  )
+
+beforeEach(() => {
+  vi.clearAllMocks()
+  queue = []
+  window.innerWidth = 1200 // desktop
+})
+
+describe('AppShell', () => {
+  it('renders the sidebar and the audio route on desktop', async () => {
+    renderAt('/audio')
+    await waitFor(() => expect(screen.getByText('sidebar')).toBeInTheDocument())
+    expect(screen.getByText('audio')).toBeInTheDocument()
+    expect(screen.getByTestId('global-player')).toBeInTheDocument()
+  })
+
+  it('routes to the audio detail view', async () => {
+    renderAt('/audio/a1')
+    await waitFor(() => expect(screen.getByText('audio-detail')).toBeInTheDocument())
+  })
+
+  it('renders the mobile nav on small screens', async () => {
+    window.innerWidth = 500
+    renderAt('/library')
+    await waitFor(() => expect(screen.getByText('mobile-nav')).toBeInTheDocument())
+  })
+
+  it('keeps the player mounted when a queue is active', async () => {
+    queue = [{ id: 'a' }]
+    renderAt('/search')
+    await waitFor(() => expect(screen.getByTestId('global-player')).toBeInTheDocument())
+  })
+})

--- a/frontend/src/components/BulkEditModal.jsx
+++ b/frontend/src/components/BulkEditModal.jsx
@@ -14,6 +14,10 @@ const CONFIG = {
     endpoint: (id) => `/tokens/${id}`,
     fields: ['tags', 'is_explicit'],
   },
+  audio: {
+    endpoint: (id) => `/audio/${id}`,
+    fields: ['tags'],
+  },
   book: {
     endpoint: (id) => `/books/${id}`,
     fields: ['title', 'category', 'description', 'publisher', 'year', 'tags', 'is_explicit'],

--- a/frontend/src/components/MobileSidebar.jsx
+++ b/frontend/src/components/MobileSidebar.jsx
@@ -4,6 +4,7 @@ import { useTranslation } from 'react-i18next'
 import {
   LuLibrary,
   LuMap,
+  LuMusic,
   LuSearch,
   LuSettings,
   LuLogOut,
@@ -20,11 +21,12 @@ export default function MobileSidebar({ user, onLogout, uiSettings = {} }) {
   const [moreOpen, setMoreOpen] = useState(false)
   const location = useLocation()
   const isGuest = user?.role === 'guest'
-  const { hide_maps, hide_tokens, hide_campaigns } = uiSettings
+  const { hide_maps, hide_tokens, hide_audio, hide_campaigns } = uiSettings
   const moreRoutes = [
     '/settings',
     ...(!hide_maps ? ['/maps'] : []),
     ...(!hide_tokens ? ['/tokens'] : []),
+    ...(!hide_audio ? ['/audio'] : []),
   ]
   const moreActive = moreRoutes.some((r) => location.pathname.startsWith(r))
 
@@ -92,6 +94,14 @@ export default function MobileSidebar({ user, onLogout, uiSettings = {} }) {
                 to="/tokens"
                 Icon={LuUser}
                 label={t('nav.tokens')}
+                onClick={() => setMoreOpen(false)}
+              />
+            )}
+            {!hide_audio && (
+              <MoreItem
+                to="/audio"
+                Icon={LuMusic}
+                label={t('nav.audio')}
                 onClick={() => setMoreOpen(false)}
               />
             )}

--- a/frontend/src/components/MobileSidebar.test.jsx
+++ b/frontend/src/components/MobileSidebar.test.jsx
@@ -1,0 +1,90 @@
+import { describe, it, expect, vi } from 'vitest'
+import { render, screen } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+import { MemoryRouter } from 'react-router-dom'
+import MobileSidebar from './MobileSidebar'
+
+const renderBar = (props = {}) =>
+  render(
+    <MemoryRouter>
+      <MobileSidebar user={{ role: 'admin' }} onLogout={vi.fn()} uiSettings={{}} {...props} />
+    </MemoryRouter>
+  )
+
+describe('MobileSidebar', () => {
+  it('renders the audio link in the More drawer by default', async () => {
+    renderBar()
+    await userEvent.click(screen.getByRole('button', { name: /more/i }))
+    expect(screen.getByText('Audio')).toBeInTheDocument()
+  })
+
+  it('hides the audio link when hide_audio is set', async () => {
+    renderBar({ uiSettings: { hide_audio: true } })
+    await userEvent.click(screen.getByRole('button', { name: /more/i }))
+    expect(screen.queryByText('Audio')).not.toBeInTheDocument()
+  })
+
+  it('lists maps, tokens, audio and settings in the drawer', async () => {
+    renderBar()
+    await userEvent.click(screen.getByRole('button', { name: /more/i }))
+    expect(screen.getByText('Maps')).toBeInTheDocument()
+    expect(screen.getByText('Tokens')).toBeInTheDocument()
+    expect(screen.getByText('Audio')).toBeInTheDocument()
+    expect(screen.getByText(/settings/i)).toBeInTheDocument()
+  })
+
+  it('closes the drawer when a drawer item is clicked', async () => {
+    renderBar()
+    await userEvent.click(screen.getByRole('button', { name: /more/i }))
+    await userEvent.click(screen.getByText('Audio'))
+    // Drawer collapses — Audio link no longer shown.
+    expect(screen.queryByText('Audio')).not.toBeInTheDocument()
+  })
+
+  it('hides maps and tokens when those sections are hidden', async () => {
+    renderBar({ uiSettings: { hide_maps: true, hide_tokens: true } })
+    await userEvent.click(screen.getByRole('button', { name: /more/i }))
+    expect(screen.queryByText('Maps')).not.toBeInTheDocument()
+    expect(screen.queryByText('Tokens')).not.toBeInTheDocument()
+    expect(screen.getByText('Audio')).toBeInTheDocument()
+  })
+
+  it('renders the primary nav links (library, search, favorites)', () => {
+    renderBar()
+    expect(screen.getByText(/library/i)).toBeInTheDocument()
+    expect(screen.getByText(/search/i)).toBeInTheDocument()
+  })
+
+  it('logs out from the drawer', async () => {
+    const onLogout = vi.fn()
+    renderBar({ onLogout })
+    await userEvent.click(screen.getByRole('button', { name: /more/i }))
+    // The drawer's log-out button (distinct from any bottom-bar control).
+    const logout = screen.getAllByText(/log out/i).at(-1)
+    await userEvent.click(logout)
+    expect(onLogout).toHaveBeenCalled()
+  })
+
+  it('closes the drawer when settings is chosen', async () => {
+    renderBar()
+    await userEvent.click(screen.getByRole('button', { name: /more/i }))
+    await userEvent.click(screen.getByText(/settings/i))
+    expect(screen.queryByText('Audio')).not.toBeInTheDocument()
+  })
+
+  it('closes the drawer when the backdrop is clicked', async () => {
+    const { container } = renderBar()
+    await userEvent.click(screen.getByRole('button', { name: /more/i }))
+    expect(screen.getByText('Audio')).toBeInTheDocument()
+    // The overlay backdrop is the first fixed element behind the drawer.
+    const backdrop = container.querySelector('[aria-hidden="true"]')
+    if (backdrop) await userEvent.click(backdrop)
+    expect(screen.queryByText('Audio')).not.toBeInTheDocument()
+  })
+
+  it('shows a minimal bar for guests (no More button)', () => {
+    renderBar({ user: { role: 'guest' } })
+    expect(screen.getByText(/log out/i)).toBeInTheDocument()
+    expect(screen.queryByRole('button', { name: /more/i })).not.toBeInTheDocument()
+  })
+})

--- a/frontend/src/components/Sidebar.jsx
+++ b/frontend/src/components/Sidebar.jsx
@@ -4,6 +4,7 @@ import { useTranslation } from 'react-i18next'
 import {
   LuLibrary,
   LuMap,
+  LuMusic,
   LuSearch,
   LuSettings,
   LuLogOut,
@@ -69,6 +70,7 @@ export default function Sidebar({
   const isGuest = user?.role === 'guest'
   const hide_maps = uiSettings.hide_maps
   const hide_tokens = uiSettings.hide_tokens
+  const hide_audio = uiSettings.hide_audio
   const hide_campaigns = uiSettings.hide_campaigns
   const {
     show_stat_systems = true,
@@ -186,6 +188,7 @@ export default function Sidebar({
         {!isGuest && navItem('/library', <LuLibrary size={16} />, t('nav.library'), { end: false })}
         {!isGuest && !hide_maps && navItem('/maps', <LuMap size={16} />, t('nav.maps'))}
         {!isGuest && !hide_tokens && navItem('/tokens', <LuUser size={16} />, t('nav.tokens'))}
+        {!isGuest && !hide_audio && navItem('/audio', <LuMusic size={16} />, t('nav.audio'))}
         {!isGuest && navItem('/search', <LuSearch size={16} />, t('nav.search'))}
 
         {!isGuest && (

--- a/frontend/src/components/audio/AudioDetailView.jsx
+++ b/frontend/src/components/audio/AudioDetailView.jsx
@@ -1,0 +1,299 @@
+import { useState, useEffect } from 'react'
+import { useParams, useNavigate } from 'react-router-dom'
+import { useTranslation } from 'react-i18next'
+import { LuArrowLeft, LuDownload, LuInfo, LuChevronDown, LuMusic } from 'react-icons/lu'
+import api, { mediaUrl } from '../../api'
+import Spinner from '../Spinner'
+import { formatSize, formatDuration } from '../../utils'
+import InlineTagEditor from '../maps/InlineTagEditor'
+import AddToCampaignButton from '../campaigns/AddToCampaignButton'
+import MetaRow from '../MetaRow'
+import TagSection from '../TagSection'
+import AudioPlayer from './AudioPlayer'
+
+const isMobilePhone = window.matchMedia('(max-width: 640px)').matches
+
+export default function AudioDetailView() {
+  const { audioId } = useParams()
+  const navigate = useNavigate()
+  const { t } = useTranslation()
+  const [track, setTrack] = useState(null)
+  const [editingTrackTags, setEditingTrackTags] = useState(false)
+  const [editingFolderTags, setEditingFolderTags] = useState(false)
+  const [showDetails, setShowDetails] = useState(false)
+
+  useEffect(() => {
+    api.get(`/audio/${audioId}`).then(setTrack)
+  }, [audioId])
+
+  if (!track)
+    return (
+      <div style={{ padding: 40, textAlign: 'center' }}>
+        <Spinner size={32} />
+      </div>
+    )
+
+  const folder = (() => {
+    const parts = (track.relative_path || '').replace(/\\/g, '/').split('/')
+    const dirParts = parts.slice(1, -1)
+    return dirParts.length > 0 ? dirParts.join(' / ') : null
+  })()
+
+  const currentFolderTags = track.folder_tags ?? []
+
+  const saveTrackTags = async (tags) => {
+    await api.patch(`/audio/${audioId}`, { tags })
+    setTrack({ ...track, tags })
+    setEditingTrackTags(false)
+  }
+
+  const saveFolderTags = async (tags) => {
+    await api.patch('/audio-folders', { path: track.folder_path, tags })
+    setTrack({ ...track, folder_tags: tags })
+    setEditingFolderTags(false)
+  }
+
+  return (
+    <div className="fade-in" style={{ display: 'flex', flexDirection: 'column', height: '100%' }}>
+      {/* Toolbar */}
+      <div
+        style={{
+          display: 'flex',
+          alignItems: 'center',
+          gap: 12,
+          padding: '10px 20px',
+          background: 'var(--bg-panel)',
+          borderBottom: '1px solid var(--border)',
+          flexShrink: 0,
+        }}
+      >
+        <button
+          onClick={() => navigate('/audio')}
+          aria-label={t('audio.detail.back')}
+          style={{
+            background: 'none',
+            color: 'var(--text-dim)',
+            fontSize: 15,
+            border: 'none',
+            cursor: 'pointer',
+            display: 'flex',
+            alignItems: 'center',
+            gap: 5,
+          }}
+        >
+          <LuArrowLeft size={15} /> {t('common.back')}
+        </button>
+        <div style={{ width: 1, height: 20, background: 'var(--border)' }} />
+        <span
+          style={{
+            fontSize: 16,
+            fontWeight: 500,
+            flex: 1,
+            overflow: 'hidden',
+            textOverflow: 'ellipsis',
+            whiteSpace: 'nowrap',
+          }}
+        >
+          {track.title || track.filename}
+        </span>
+        {isMobilePhone && (
+          <button
+            onClick={() => setShowDetails((v) => !v)}
+            title={t('audio.detail.details')}
+            style={{
+              background: showDetails ? 'var(--bg-card-hover)' : 'var(--bg-card)',
+              border: '1px solid var(--border)',
+              color: showDetails ? 'var(--gold)' : 'var(--text-dim)',
+              borderRadius: 4,
+              padding: '4px 10px',
+              fontSize: 14,
+              display: 'inline-flex',
+              alignItems: 'center',
+              gap: 4,
+              cursor: 'pointer',
+            }}
+          >
+            <LuInfo size={13} />
+            <LuChevronDown
+              size={11}
+              style={{
+                transform: showDetails ? 'rotate(180deg)' : 'none',
+                transition: 'transform 0.2s',
+              }}
+            />
+          </button>
+        )}
+        <AddToCampaignButton resourceType="audio" resourceId={audioId} />
+        <a
+          href={mediaUrl(`/audio/${audioId}/file`)}
+          download
+          style={{
+            background: 'var(--bg-card)',
+            border: '1px solid var(--border)',
+            color: 'var(--text-dim)',
+            borderRadius: 4,
+            padding: '4px 12px',
+            fontSize: 14,
+            display: 'inline-flex',
+            alignItems: 'center',
+            gap: 5,
+            textDecoration: 'none',
+          }}
+        >
+          <LuDownload size={13} /> {t('common.download')}
+        </a>
+      </div>
+
+      {/* Body */}
+      <div
+        style={{
+          flex: 1,
+          overflow: 'hidden',
+          display: 'flex',
+          flexDirection: isMobilePhone ? 'column' : 'row',
+        }}
+      >
+        {/* Player pane */}
+        <div
+          style={{
+            flex: 1,
+            overflow: 'auto',
+            background: 'var(--bg-deep)',
+            display: 'flex',
+            flexDirection: 'column',
+            alignItems: 'center',
+            justifyContent: 'center',
+            gap: 24,
+            padding: 24,
+          }}
+        >
+          <div
+            style={{
+              width: 'min(360px, 70vw)',
+              aspectRatio: '1/1',
+              borderRadius: 8,
+              overflow: 'hidden',
+              background: 'var(--bg-card)',
+              display: 'flex',
+              alignItems: 'center',
+              justifyContent: 'center',
+              boxShadow: '0 4px 24px rgba(0,0,0,0.6)',
+            }}
+          >
+            {track.has_artwork ? (
+              <img
+                src={mediaUrl(`/audio/${audioId}/artwork`)}
+                alt=""
+                style={{ width: '100%', height: '100%', objectFit: 'cover' }}
+              />
+            ) : (
+              <LuMusic size={72} color="var(--text-muted)" style={{ opacity: 0.4 }} />
+            )}
+          </div>
+          <div style={{ display: 'flex', alignItems: 'center', gap: 12 }}>
+            <AudioPlayer
+              track={{
+                id: audioId,
+                title: track.title || track.filename,
+                artwork: track.has_artwork,
+              }}
+              showPlayNext
+              size={56}
+            />
+          </div>
+        </div>
+
+        {/* Metadata sidebar */}
+        <div
+          style={{
+            ...(isMobilePhone
+              ? {
+                  display: showDetails ? 'block' : 'none',
+                  width: '100%',
+                  borderTop: '1px solid var(--border)',
+                  maxHeight: '50vh',
+                }
+              : { width: 280, flexShrink: 0, borderLeft: '1px solid var(--border)' }),
+            background: 'var(--bg-panel)',
+            padding: '24px 20px',
+            overflowY: 'auto',
+          }}
+        >
+          <h3 style={{ fontSize: 15, marginBottom: 20 }}>{t('audio.detail.title')}</h3>
+
+          {folder && <MetaRow label={t('audio.detail.location')} value={folder} />}
+          {track.title && <MetaRow label={t('audio.detail.trackTitle')} value={track.title} />}
+          {track.artist && <MetaRow label={t('audio.detail.artist')} value={track.artist} />}
+          {track.album && <MetaRow label={t('audio.detail.album')} value={track.album} />}
+          {track.duration > 0 && (
+            <MetaRow label={t('audio.detail.duration')} value={formatDuration(track.duration)} />
+          )}
+          <MetaRow label={t('audio.detail.fileSize')} value={formatSize(track.file_size)} />
+
+          {/* Folder tags */}
+          {folder &&
+            (editingFolderTags ? (
+              <div style={{ marginTop: 20, paddingTop: 20, borderTop: '1px solid var(--border)' }}>
+                <div
+                  style={{
+                    fontSize: 12,
+                    color: 'var(--text-muted)',
+                    marginBottom: 10,
+                    textTransform: 'uppercase',
+                    letterSpacing: '0.06em',
+                  }}
+                >
+                  {t('audio.detail.folderTags')}
+                </div>
+                <InlineTagEditor
+                  tags={currentFolderTags}
+                  onSave={saveFolderTags}
+                  onCancel={() => setEditingFolderTags(false)}
+                />
+              </div>
+            ) : (
+              <TagSection
+                label={t('audio.detail.folderTags')}
+                tags={currentFolderTags}
+                canEdit={true}
+                onEdit={() => setEditingFolderTags(true)}
+                editLabel={t('audio.detail.editTags')}
+                noTagsLabel={t('audio.detail.noTags')}
+              />
+            ))}
+
+          {/* Track tags */}
+          {editingTrackTags ? (
+            <div style={{ marginTop: 20, paddingTop: 20, borderTop: '1px solid var(--border)' }}>
+              <div
+                style={{
+                  fontSize: 12,
+                  color: 'var(--text-muted)',
+                  marginBottom: 10,
+                  textTransform: 'uppercase',
+                  letterSpacing: '0.06em',
+                }}
+              >
+                {t('audio.detail.trackTags')}
+              </div>
+              <InlineTagEditor
+                tags={track.tags}
+                onSave={saveTrackTags}
+                onCancel={() => setEditingTrackTags(false)}
+              />
+            </div>
+          ) : (
+            <TagSection
+              label={t('audio.detail.trackTags')}
+              tags={track.tags}
+              canEdit
+              onEdit={() => setEditingTrackTags(true)}
+              editLabel={t('audio.detail.editTags')}
+              noTagsLabel={t('audio.detail.noTags')}
+            />
+          )}
+        </div>
+      </div>
+    </div>
+  )
+}

--- a/frontend/src/components/audio/AudioDetailView.test.jsx
+++ b/frontend/src/components/audio/AudioDetailView.test.jsx
@@ -1,0 +1,99 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { render, screen, waitFor } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+import AudioDetailView from './AudioDetailView'
+import api from '../../api'
+
+vi.mock('../../api', () => ({
+  default: { get: vi.fn(), patch: vi.fn() },
+  mediaUrl: (p) => `http://localhost${p}`,
+}))
+
+vi.mock('react-router-dom', () => ({
+  useParams: () => ({ audioId: 'a1' }),
+  useNavigate: () => vi.fn(),
+}))
+
+// AudioPlayer is a context controller; stub it to a button so we don't need the provider.
+vi.mock('./AudioPlayer', () => ({
+  default: () => <button>play</button>,
+}))
+vi.mock('../campaigns/AddToCampaignButton', () => ({ default: () => null }))
+// Stub the tag editor to immediately save, so the save-tag handlers run.
+vi.mock('../maps/InlineTagEditor', () => ({
+  default: ({ onSave }) => (
+    <button onClick={() => onSave(['new'])} data-testid="save-tags">
+      save
+    </button>
+  ),
+}))
+// TagSection exposes an Edit button via onEdit.
+vi.mock('../TagSection', () => ({
+  default: ({ label, onEdit }) => <button onClick={onEdit}>{`edit-${label}`}</button>,
+}))
+
+beforeEach(() => vi.clearAllMocks())
+
+const detail = (over = {}) => ({
+  id: 'a1',
+  filename: 'tavern.mp3',
+  title: 'Tavern Night',
+  artist: 'Bardcore',
+  album: 'Inn',
+  duration: 125,
+  file_size: 2048,
+  has_artwork: true,
+  relative_path: 'audio/Ambient/tavern.mp3',
+  tags: ['ambient'],
+  folder_tags: ['cozy'],
+  folder_path: 'Ambient',
+  ...over,
+})
+
+describe('AudioDetailView', () => {
+  it('shows a spinner before the track loads', () => {
+    api.get.mockReturnValue(new Promise(() => {}))
+    render(<AudioDetailView />)
+    expect(document.querySelector('svg')).toBeInTheDocument()
+  })
+
+  it('renders track metadata once loaded', async () => {
+    api.get.mockResolvedValue(detail())
+    render(<AudioDetailView />)
+    await waitFor(() => expect(screen.getByText('Bardcore')).toBeInTheDocument())
+    expect(screen.getByText('Inn')).toBeInTheDocument()
+    // duration 125s -> 2:05
+    expect(screen.getByText('2:05')).toBeInTheDocument()
+    // play control (stubbed)
+    expect(screen.getByRole('button', { name: /play/i })).toBeInTheDocument()
+  })
+
+  it('renders the music placeholder when no artwork', async () => {
+    api.get.mockResolvedValue(detail({ has_artwork: false }))
+    const { container } = render(<AudioDetailView />)
+    // Title appears in the toolbar and the metadata row.
+    await waitFor(() => expect(screen.getAllByText('Tavern Night').length).toBeGreaterThan(0))
+    // No artwork image rendered.
+    expect(container.querySelector('img')).toBeNull()
+  })
+
+  it('saves edited track tags', async () => {
+    api.get.mockResolvedValue(detail())
+    api.patch.mockResolvedValue({})
+    render(<AudioDetailView />)
+    await waitFor(() => screen.getByText('edit-Track Tags'))
+    await userEvent.click(screen.getByText('edit-Track Tags'))
+    await userEvent.click(screen.getByTestId('save-tags'))
+    expect(api.patch).toHaveBeenCalledWith('/audio/a1', { tags: ['new'] })
+  })
+
+  it('saves edited folder tags', async () => {
+    api.get.mockResolvedValue(detail())
+    api.patch.mockResolvedValue({})
+    render(<AudioDetailView />)
+    await waitFor(() => screen.getByText('edit-Folder Tags'))
+    await userEvent.click(screen.getByText('edit-Folder Tags'))
+    await userEvent.click(screen.getByTestId('save-tags'))
+    expect(api.patch).toHaveBeenCalledWith('/audio-folders', { path: 'Ambient', tags: ['new'] })
+  })
+})

--- a/frontend/src/components/audio/AudioPlayer.jsx
+++ b/frontend/src/components/audio/AudioPlayer.jsx
@@ -1,0 +1,89 @@
+import { useTranslation } from 'react-i18next'
+import { LuPlay, LuPause, LuListPlus } from 'react-icons/lu'
+import { useAudioPlayer } from '../../context/AudioPlayerContext'
+
+/**
+ * A thin controller for the global audio player. Given a `track`
+ * ({ id, title?, artwork? }), the overlay button plays/pauses that track in the
+ * single app-wide player; the optional "Play Next" button queues it after the
+ * current track without interrupting playback.
+ *
+ * This replaces the old self-contained <audio> element — there is now exactly
+ * one audio element app-wide (see GlobalAudioPlayer), so playback survives
+ * navigation and multiple controls stay in sync.
+ */
+export default function AudioPlayer({ track, showPlayNext = false, size = 44 }) {
+  const { t } = useTranslation()
+  const { playQueue, playNext, togglePlay, isCurrent, isPlayingId } = useAudioPlayer()
+
+  if (!track || !track.id) return null
+
+  const playing = isPlayingId(track.id)
+
+  const onToggle = (e) => {
+    e.stopPropagation()
+    if (isCurrent(track.id)) {
+      togglePlay()
+    } else {
+      playQueue([track])
+    }
+  }
+
+  const onPlayNext = (e) => {
+    e.stopPropagation()
+    playNext(track)
+  }
+
+  return (
+    <>
+      <button
+        type="button"
+        onClick={onToggle}
+        aria-label={playing ? t('audio.pause') : t('audio.play')}
+        style={{
+          width: size,
+          height: size,
+          borderRadius: '50%',
+          border: 'none',
+          background: 'rgba(0,0,0,0.6)',
+          color: '#fff',
+          display: 'flex',
+          alignItems: 'center',
+          justifyContent: 'center',
+          cursor: 'pointer',
+          boxShadow: '0 2px 8px rgba(0,0,0,0.5)',
+          flexShrink: 0,
+        }}
+      >
+        {playing ? (
+          <LuPause size={size * 0.45} />
+        ) : (
+          <LuPlay size={size * 0.45} style={{ marginLeft: 2 }} />
+        )}
+      </button>
+      {showPlayNext && (
+        <button
+          type="button"
+          onClick={onPlayNext}
+          aria-label={t('audio.player.playNext')}
+          title={t('audio.player.playNext')}
+          style={{
+            display: 'inline-flex',
+            alignItems: 'center',
+            justifyContent: 'center',
+            width: 30,
+            height: 30,
+            borderRadius: '50%',
+            border: '1px solid var(--border)',
+            background: 'var(--bg-card)',
+            color: 'var(--text-dim)',
+            cursor: 'pointer',
+            flexShrink: 0,
+          }}
+        >
+          <LuListPlus size={15} />
+        </button>
+      )}
+    </>
+  )
+}

--- a/frontend/src/components/audio/AudioPlayer.test.jsx
+++ b/frontend/src/components/audio/AudioPlayer.test.jsx
@@ -1,0 +1,58 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { render, screen } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+import AudioPlayer from './AudioPlayer'
+
+const playQueue = vi.fn()
+const playNext = vi.fn()
+const togglePlay = vi.fn()
+let isCurrentReturn = false
+let isPlayingReturn = false
+
+vi.mock('../../context/AudioPlayerContext', () => ({
+  useAudioPlayer: () => ({
+    playQueue,
+    playNext,
+    togglePlay,
+    isCurrent: () => isCurrentReturn,
+    isPlayingId: () => isPlayingReturn,
+  }),
+}))
+
+describe('AudioPlayer (controller)', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    isCurrentReturn = false
+    isPlayingReturn = false
+  })
+
+  it('renders a play button for a track', () => {
+    render(<AudioPlayer track={{ id: 'a1', title: 'Tavern' }} />)
+    expect(screen.getByRole('button', { name: /play/i })).toBeInTheDocument()
+  })
+
+  it('starts a single-track queue when the track is not current', async () => {
+    render(<AudioPlayer track={{ id: 'a1', title: 'Tavern' }} />)
+    await userEvent.click(screen.getByRole('button', { name: /play/i }))
+    expect(playQueue).toHaveBeenCalledWith([{ id: 'a1', title: 'Tavern' }])
+  })
+
+  it('toggles play/pause when the track is already current', async () => {
+    isCurrentReturn = true
+    render(<AudioPlayer track={{ id: 'a1', title: 'Tavern' }} />)
+    await userEvent.click(screen.getByRole('button', { name: /play|pause/i }))
+    expect(togglePlay).toHaveBeenCalled()
+    expect(playQueue).not.toHaveBeenCalled()
+  })
+
+  it('renders a Play Next button and queues the track when clicked', async () => {
+    render(<AudioPlayer track={{ id: 'a1', title: 'Tavern' }} showPlayNext />)
+    await userEvent.click(screen.getByRole('button', { name: /play next/i }))
+    expect(playNext).toHaveBeenCalledWith({ id: 'a1', title: 'Tavern' })
+  })
+
+  it('renders nothing without a valid track', () => {
+    const { container } = render(<AudioPlayer track={null} />)
+    expect(container).toBeEmptyDOMElement()
+  })
+})

--- a/frontend/src/components/audio/AudioQueuePanel.jsx
+++ b/frontend/src/components/audio/AudioQueuePanel.jsx
@@ -85,7 +85,7 @@ export default function AudioQueuePanel({ bottom = 72 }) {
                 draggable
                 onDragStart={(e) => {
                   dragFrom.current = i
-                  e.dataTransfer.effectAllowed = 'move'
+                  if (e.dataTransfer) e.dataTransfer.effectAllowed = 'move'
                 }}
                 onDragEnd={() => {
                   dragFrom.current = null

--- a/frontend/src/components/audio/AudioQueuePanel.jsx
+++ b/frontend/src/components/audio/AudioQueuePanel.jsx
@@ -1,0 +1,197 @@
+import { useRef, useState } from 'react'
+import { useTranslation } from 'react-i18next'
+import { LuX, LuMusic, LuVolume2, LuGripVertical } from 'react-icons/lu'
+import { mediaUrl } from '../../api'
+import { useAudioPlayer } from '../../context/AudioPlayerContext'
+
+/**
+ * The expandable "upcoming tracks" list shown above the global player bar.
+ * The currently-playing track is highlighted; clicking a row jumps to it, each
+ * row can be removed, and rows can be dragged by their handle to reorder the
+ * queue (without interrupting playback).
+ */
+export default function AudioQueuePanel({ bottom = 72 }) {
+  const { t } = useTranslation()
+  const { queue, currentIndex, jumpTo, removeAt, moveTrack } = useAudioPlayer()
+
+  const dragFrom = useRef(null)
+  const [dragOver, setDragOver] = useState(null)
+
+  const onDrop = (to) => {
+    const from = dragFrom.current
+    dragFrom.current = null
+    setDragOver(null)
+    if (from != null && from !== to) moveTrack(from, to)
+  }
+
+  return (
+    <div
+      style={{
+        position: 'fixed',
+        left: 0,
+        right: 0,
+        bottom,
+        zIndex: 94,
+        maxHeight: '40vh',
+        overflowY: 'auto',
+        background: 'var(--bg-panel)',
+        borderTop: '1px solid var(--border)',
+        boxShadow: '0 -2px 12px rgba(0,0,0,0.35)',
+      }}
+    >
+      <div
+        style={{
+          padding: '10px 16px',
+          fontSize: 12,
+          fontWeight: 600,
+          color: 'var(--text-muted)',
+          textTransform: 'uppercase',
+          letterSpacing: '0.07em',
+          borderBottom: '1px solid var(--border)',
+          position: 'sticky',
+          top: 0,
+          background: 'var(--bg-panel)',
+        }}
+      >
+        {t('audio.player.queue')} ({queue.length})
+      </div>
+
+      {queue.length === 0 ? (
+        <div style={{ padding: '16px', fontSize: 13, color: 'var(--text-muted)' }}>
+          {t('audio.player.emptyQueue')}
+        </div>
+      ) : (
+        queue.map((track, i) => {
+          const isCurrent = i === currentIndex
+          return (
+            <div
+              key={`${track.id}-${i}`}
+              onDragOver={(e) => {
+                e.preventDefault()
+                if (dragOver !== i) setDragOver(i)
+              }}
+              onDrop={() => onDrop(i)}
+              style={{
+                display: 'flex',
+                alignItems: 'center',
+                gap: 8,
+                padding: '8px 16px',
+                background: isCurrent ? 'var(--bg-card-hover)' : 'transparent',
+                borderTop: dragOver === i ? '2px solid var(--gold)' : '2px solid transparent',
+                borderBottom: '1px solid var(--border)',
+              }}
+            >
+              <span
+                draggable
+                onDragStart={(e) => {
+                  dragFrom.current = i
+                  e.dataTransfer.effectAllowed = 'move'
+                }}
+                onDragEnd={() => {
+                  dragFrom.current = null
+                  setDragOver(null)
+                }}
+                aria-label={t('audio.player.reorder')}
+                style={{
+                  display: 'flex',
+                  alignItems: 'center',
+                  color: 'var(--text-muted)',
+                  cursor: 'grab',
+                  flexShrink: 0,
+                }}
+              >
+                <LuGripVertical size={15} />
+              </span>
+              <button
+                type="button"
+                onClick={() => jumpTo(i)}
+                style={{
+                  flex: 1,
+                  minWidth: 0,
+                  display: 'flex',
+                  alignItems: 'center',
+                  gap: 10,
+                  background: 'none',
+                  border: 'none',
+                  cursor: 'pointer',
+                  color: 'var(--text)',
+                  textAlign: 'left',
+                  padding: 0,
+                  font: 'inherit',
+                }}
+              >
+                <div
+                  style={{
+                    width: 32,
+                    height: 32,
+                    borderRadius: 4,
+                    flexShrink: 0,
+                    overflow: 'hidden',
+                    background: 'var(--bg-deep)',
+                    display: 'flex',
+                    alignItems: 'center',
+                    justifyContent: 'center',
+                  }}
+                >
+                  {track.artwork ? (
+                    <img
+                      src={mediaUrl(`/audio/${track.id}/artwork`)}
+                      alt=""
+                      style={{ width: '100%', height: '100%', objectFit: 'cover' }}
+                    />
+                  ) : (
+                    <LuMusic size={14} color="var(--text-muted)" style={{ opacity: 0.5 }} />
+                  )}
+                </div>
+                <span style={{ flex: 1, minWidth: 0 }}>
+                  <span
+                    style={{
+                      display: 'block',
+                      overflow: 'hidden',
+                      textOverflow: 'ellipsis',
+                      whiteSpace: 'nowrap',
+                      fontSize: 14,
+                      color: isCurrent ? 'var(--gold)' : 'var(--text)',
+                    }}
+                  >
+                    {track.title || t('audio.player.untitled')}
+                  </span>
+                  {track.artist && (
+                    <span
+                      style={{
+                        display: 'block',
+                        overflow: 'hidden',
+                        textOverflow: 'ellipsis',
+                        whiteSpace: 'nowrap',
+                        fontSize: 12,
+                        color: 'var(--text-muted)',
+                      }}
+                    >
+                      {track.artist}
+                    </span>
+                  )}
+                </span>
+                {isCurrent && <LuVolume2 size={14} color="var(--gold)" style={{ flexShrink: 0 }} />}
+              </button>
+              <button
+                type="button"
+                onClick={() => removeAt(i)}
+                aria-label={t('audio.player.removeFromQueue')}
+                style={{
+                  background: 'none',
+                  border: 'none',
+                  cursor: 'pointer',
+                  color: 'var(--text-muted)',
+                  padding: 4,
+                  flexShrink: 0,
+                }}
+              >
+                <LuX size={15} />
+              </button>
+            </div>
+          )
+        })
+      )}
+    </div>
+  )
+}

--- a/frontend/src/components/audio/AudioQueuePanel.test.jsx
+++ b/frontend/src/components/audio/AudioQueuePanel.test.jsx
@@ -1,0 +1,102 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { render, screen, fireEvent } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+import AudioQueuePanel from './AudioQueuePanel'
+
+vi.mock('../../api', () => ({ mediaUrl: (p) => `http://localhost${p}` }))
+
+const jumpTo = vi.fn()
+const removeAt = vi.fn()
+const moveTrack = vi.fn()
+let queue = []
+let currentIndex = 0
+
+vi.mock('../../context/AudioPlayerContext', () => ({
+  useAudioPlayer: () => ({ queue, currentIndex, jumpTo, removeAt, moveTrack }),
+}))
+
+beforeEach(() => {
+  vi.clearAllMocks()
+  queue = []
+  currentIndex = 0
+})
+
+describe('AudioQueuePanel', () => {
+  it('shows an empty state when the queue is empty', () => {
+    queue = []
+    render(<AudioQueuePanel />)
+    expect(screen.getByText(/queue is empty/i)).toBeInTheDocument()
+  })
+
+  it('lists tracks and highlights the current one', () => {
+    queue = [
+      { id: 'a', title: 'First' },
+      { id: 'b', title: 'Second' },
+    ]
+    currentIndex = 1
+    render(<AudioQueuePanel />)
+    expect(screen.getByText('First')).toBeInTheDocument()
+    expect(screen.getByText('Second')).toBeInTheDocument()
+  })
+
+  it('falls back to a label for untitled tracks and renders artwork', () => {
+    queue = [{ id: 'a', title: '', artwork: true }]
+    const { container } = render(<AudioQueuePanel />)
+    expect(screen.getByText(/untitled/i)).toBeInTheDocument()
+    expect(container.querySelector('img')?.getAttribute('src')).toContain('/audio/a/artwork')
+  })
+
+  it('jumps to a track when its row is clicked', async () => {
+    queue = [
+      { id: 'a', title: 'First' },
+      { id: 'b', title: 'Second' },
+    ]
+    render(<AudioQueuePanel />)
+    await userEvent.click(screen.getByText('Second'))
+    expect(jumpTo).toHaveBeenCalledWith(1)
+  })
+
+  it('removes a track when its remove button is clicked', async () => {
+    queue = [{ id: 'a', title: 'First' }]
+    render(<AudioQueuePanel />)
+    await userEvent.click(screen.getByRole('button', { name: /remove from queue/i }))
+    expect(removeAt).toHaveBeenCalledWith(0)
+  })
+
+  it('shows the artist when present', () => {
+    queue = [{ id: 'a', title: 'First', artist: 'Bardcore' }]
+    render(<AudioQueuePanel />)
+    expect(screen.getByText('Bardcore')).toBeInTheDocument()
+  })
+
+  it('reorders the queue via drag and drop', () => {
+    queue = [
+      { id: 'a', title: 'First' },
+      { id: 'b', title: 'Second' },
+      { id: 'c', title: 'Third' },
+    ]
+    const { container } = render(<AudioQueuePanel />)
+    const rows = [...container.querySelectorAll('[draggable="true"]')]
+    expect(rows).toHaveLength(3)
+    // Drag the third row's handle onto the first row.
+    fireEvent.dragStart(rows[2])
+    const firstRow = rows[0].closest('div')
+    fireEvent.dragOver(firstRow)
+    fireEvent.drop(firstRow)
+    expect(moveTrack).toHaveBeenCalledWith(2, 0)
+  })
+
+  it('does not call moveTrack when dropped on its own row', () => {
+    queue = [
+      { id: 'a', title: 'First' },
+      { id: 'b', title: 'Second' },
+    ]
+    const { container } = render(<AudioQueuePanel />)
+    const rows = [...container.querySelectorAll('[draggable="true"]')]
+    fireEvent.dragStart(rows[0])
+    const ownRow = rows[0].closest('div')
+    fireEvent.dragOver(ownRow)
+    fireEvent.drop(ownRow)
+    expect(moveTrack).not.toHaveBeenCalled()
+  })
+})

--- a/frontend/src/components/audio/GlobalAudioPlayer.jsx
+++ b/frontend/src/components/audio/GlobalAudioPlayer.jsx
@@ -1,0 +1,257 @@
+import { useEffect } from 'react'
+import { useTranslation } from 'react-i18next'
+import {
+  LuPlay,
+  LuPause,
+  LuSkipBack,
+  LuSkipForward,
+  LuRepeat1,
+  LuListMusic,
+  LuX,
+  LuMusic,
+} from 'react-icons/lu'
+import { mediaUrl } from '../../api'
+import { formatDuration } from '../../utils'
+import { useAudioPlayer } from '../../context/AudioPlayerContext'
+import AudioQueuePanel from './AudioQueuePanel'
+
+const PLAYER_HEIGHT = 72
+
+const iconBtn = (active = false) => ({
+  display: 'inline-flex',
+  alignItems: 'center',
+  justifyContent: 'center',
+  background: 'none',
+  border: 'none',
+  cursor: 'pointer',
+  color: active ? 'var(--gold)' : 'var(--text-dim)',
+  padding: 6,
+})
+
+/**
+ * The single app-wide audio element plus a docked control bar. Mounted once in
+ * AppShell (outside <Routes>) so playback survives navigation. Renders nothing
+ * when the queue is empty.
+ */
+export default function GlobalAudioPlayer({ isMobile = false }) {
+  const { t } = useTranslation()
+  const player = useAudioPlayer()
+  const {
+    audioRef,
+    playRequested,
+    currentTrack,
+    isPlaying,
+    setIsPlaying,
+    currentTime,
+    setCurrentTime,
+    duration,
+    setDuration,
+    repeatOne,
+    expanded,
+    togglePlay,
+    toggleRepeat,
+    next,
+    prev,
+    seek,
+    clear,
+    toggleExpanded,
+  } = player
+
+  const src = currentTrack ? mediaUrl(`/audio/${currentTrack.id}/file`) : null
+
+  // When the source changes and playback was requested (play/skip/jump), start
+  // playing once the element has the new src.
+  useEffect(() => {
+    const el = audioRef.current
+    if (!el || !src) return
+    if (playRequested.current) {
+      playRequested.current = false
+      el.play().catch(() => {})
+    }
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [src])
+
+  if (!currentTrack) return null
+
+  const onEnded = () => {
+    const el = audioRef.current
+    if (repeatOne && el) {
+      el.currentTime = 0
+      el.play().catch(() => {})
+      return
+    }
+    next()
+  }
+
+  const bottom = isMobile ? 64 : 0
+
+  return (
+    <>
+      {expanded && <AudioQueuePanel bottom={bottom + PLAYER_HEIGHT} />}
+
+      <div
+        style={{
+          position: 'fixed',
+          left: 0,
+          right: 0,
+          bottom,
+          height: PLAYER_HEIGHT,
+          zIndex: 95,
+          background: 'var(--bg-panel)',
+          borderTop: '1px solid var(--border)',
+          display: 'flex',
+          alignItems: 'center',
+          gap: 14,
+          padding: '0 16px',
+          boxShadow: '0 -2px 12px rgba(0,0,0,0.35)',
+        }}
+      >
+        <audio
+          ref={audioRef}
+          src={src}
+          preload="metadata"
+          autoPlay={false}
+          onPlay={() => setIsPlaying(true)}
+          onPause={() => setIsPlaying(false)}
+          onEnded={onEnded}
+          onTimeUpdate={(e) => setCurrentTime(e.currentTarget.currentTime)}
+          onLoadedMetadata={(e) => setDuration(e.currentTarget.duration || 0)}
+          data-testid="global-audio-element"
+        />
+
+        {/* Artwork + title */}
+        <div
+          style={{ display: 'flex', alignItems: 'center', gap: 10, minWidth: 0, flex: '0 1 220px' }}
+        >
+          <div
+            style={{
+              width: 44,
+              height: 44,
+              borderRadius: 6,
+              flexShrink: 0,
+              overflow: 'hidden',
+              background: 'var(--bg-deep)',
+              display: 'flex',
+              alignItems: 'center',
+              justifyContent: 'center',
+            }}
+          >
+            {currentTrack.artwork ? (
+              <img
+                src={mediaUrl(`/audio/${currentTrack.id}/artwork`)}
+                alt=""
+                style={{ width: '100%', height: '100%', objectFit: 'cover' }}
+              />
+            ) : (
+              <LuMusic size={20} color="var(--text-muted)" style={{ opacity: 0.5 }} />
+            )}
+          </div>
+          <div style={{ minWidth: 0 }}>
+            <div
+              style={{
+                fontSize: 13,
+                fontWeight: 500,
+                overflow: 'hidden',
+                textOverflow: 'ellipsis',
+                whiteSpace: 'nowrap',
+              }}
+              title={currentTrack.title}
+            >
+              {currentTrack.title || t('audio.player.untitled')}
+            </div>
+            <div
+              style={{
+                fontSize: 11,
+                color: 'var(--text-muted)',
+                overflow: 'hidden',
+                textOverflow: 'ellipsis',
+                whiteSpace: 'nowrap',
+              }}
+            >
+              {currentTrack.artist || t('audio.player.title')}
+            </div>
+          </div>
+        </div>
+
+        {/* Transport controls */}
+        <div style={{ display: 'flex', alignItems: 'center', gap: 2, flexShrink: 0 }}>
+          <button onClick={prev} aria-label={t('audio.player.previous')} style={iconBtn()}>
+            <LuSkipBack size={18} />
+          </button>
+          <button
+            onClick={togglePlay}
+            aria-label={isPlaying ? t('audio.pause') : t('audio.play')}
+            style={{
+              ...iconBtn(),
+              background: 'var(--gold)',
+              color: 'var(--bg-deep)',
+              borderRadius: '50%',
+              width: 36,
+              height: 36,
+            }}
+          >
+            {isPlaying ? <LuPause size={18} /> : <LuPlay size={18} style={{ marginLeft: 2 }} />}
+          </button>
+          <button onClick={next} aria-label={t('audio.player.next')} style={iconBtn()}>
+            <LuSkipForward size={18} />
+          </button>
+          <button
+            onClick={toggleRepeat}
+            aria-label={repeatOne ? t('audio.player.repeatOn') : t('audio.player.repeatOff')}
+            aria-pressed={repeatOne}
+            style={iconBtn(repeatOne)}
+          >
+            <LuRepeat1 size={17} />
+          </button>
+        </div>
+
+        {/* Seek bar */}
+        <div
+          style={{
+            flex: 1,
+            display: 'flex',
+            alignItems: 'center',
+            gap: 8,
+            minWidth: 0,
+            color: 'var(--text-muted)',
+            fontSize: 11,
+          }}
+        >
+          <span style={{ flexShrink: 0, fontVariantNumeric: 'tabular-nums' }}>
+            {formatDuration(currentTime)}
+          </span>
+          <input
+            type="range"
+            min={0}
+            max={duration || 0}
+            step="any"
+            value={Math.min(currentTime, duration || 0)}
+            onChange={(e) => seek(parseFloat(e.target.value))}
+            aria-label={t('audio.player.seek')}
+            style={{ flex: 1, accentColor: 'var(--gold)', cursor: 'pointer', minWidth: 40 }}
+          />
+          <span style={{ flexShrink: 0, fontVariantNumeric: 'tabular-nums' }}>
+            {formatDuration(duration)}
+          </span>
+        </div>
+
+        {/* Queue + close */}
+        <div style={{ display: 'flex', alignItems: 'center', gap: 2, flexShrink: 0 }}>
+          <button
+            onClick={toggleExpanded}
+            aria-label={t('audio.player.toggleQueue')}
+            aria-pressed={expanded}
+            style={iconBtn(expanded)}
+          >
+            <LuListMusic size={18} />
+          </button>
+          <button onClick={clear} aria-label={t('audio.player.close')} style={iconBtn()}>
+            <LuX size={18} />
+          </button>
+        </div>
+      </div>
+    </>
+  )
+}
+
+export { PLAYER_HEIGHT }

--- a/frontend/src/components/audio/GlobalAudioPlayer.test.jsx
+++ b/frontend/src/components/audio/GlobalAudioPlayer.test.jsx
@@ -1,0 +1,168 @@
+import { describe, it, expect, beforeEach, vi } from 'vitest'
+import { render, screen, act } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+import { AudioPlayerProvider, useAudioPlayer } from '../../context/AudioPlayerContext'
+import GlobalAudioPlayer from './GlobalAudioPlayer'
+
+vi.mock('../../api', () => ({ mediaUrl: (path) => `http://localhost${path}` }))
+
+// jsdom doesn't implement media playback; stub it so play()/pause() are no-ops.
+beforeEach(() => {
+  sessionStorage.clear()
+  window.HTMLMediaElement.prototype.play = vi.fn().mockResolvedValue()
+  window.HTMLMediaElement.prototype.pause = vi.fn()
+})
+
+// A tiny harness exposing the context actions to the test.
+let api
+function Capture() {
+  api = useAudioPlayer()
+  return null
+}
+
+function renderPlayer() {
+  return render(
+    <AudioPlayerProvider>
+      <Capture />
+      <GlobalAudioPlayer />
+    </AudioPlayerProvider>
+  )
+}
+
+describe('GlobalAudioPlayer', () => {
+  it('renders nothing when the queue is empty', () => {
+    renderPlayer()
+    expect(screen.queryByTestId('global-audio-element')).not.toBeInTheDocument()
+  })
+
+  it('shows the current track and transport controls once a queue is playing', () => {
+    renderPlayer()
+    act(() =>
+      api.playQueue([
+        { id: 'a', title: 'Tavern Night' },
+        { id: 'b', title: 'Battle' },
+      ])
+    )
+    expect(screen.getByTestId('global-audio-element')).toBeInTheDocument()
+    expect(screen.getByText('Tavern Night')).toBeInTheDocument()
+    expect(screen.getByRole('button', { name: /next track/i })).toBeInTheDocument()
+    expect(screen.getByRole('button', { name: /previous track/i })).toBeInTheDocument()
+  })
+
+  it('opens the queue panel and lists upcoming tracks', async () => {
+    renderPlayer()
+    act(() =>
+      api.playQueue([
+        { id: 'a', title: 'Tavern Night' },
+        { id: 'b', title: 'Battle' },
+      ])
+    )
+    await userEvent.click(screen.getByRole('button', { name: /show queue/i }))
+    // Both tracks appear in the queue panel.
+    expect(screen.getByText('Battle')).toBeInTheDocument()
+    expect(screen.getAllByText('Tavern Night').length).toBeGreaterThanOrEqual(1)
+  })
+
+  it('repeat toggle reflects pressed state', async () => {
+    renderPlayer()
+    act(() => api.playQueue([{ id: 'a', title: 'A' }]))
+    const repeat = screen.getByRole('button', { name: /repeat current track/i })
+    expect(repeat).toHaveAttribute('aria-pressed', 'false')
+    await userEvent.click(repeat)
+    expect(screen.getByRole('button', { name: /repeat current track/i })).toHaveAttribute(
+      'aria-pressed',
+      'true'
+    )
+  })
+
+  it('close button clears the queue and hides the player', async () => {
+    renderPlayer()
+    act(() => api.playQueue([{ id: 'a', title: 'A' }]))
+    await userEvent.click(screen.getByRole('button', { name: /close player/i }))
+    expect(screen.queryByTestId('global-audio-element')).not.toBeInTheDocument()
+  })
+
+  it('renders artwork when the current track has it', () => {
+    const { container } = renderPlayer()
+    act(() => api.playQueue([{ id: 'a', title: 'A', artwork: true }]))
+    const art = [...container.querySelectorAll('img')].find((i) =>
+      i.getAttribute('src')?.includes('/audio/a/artwork')
+    )
+    expect(art).toBeTruthy()
+  })
+
+  it('next/prev change the current track', async () => {
+    renderPlayer()
+    act(() =>
+      api.playQueue([
+        { id: 'a', title: 'First' },
+        { id: 'b', title: 'Second' },
+      ])
+    )
+    await userEvent.click(screen.getByRole('button', { name: /next track/i }))
+    expect(api.currentTrack.id).toBe('b')
+    await userEvent.click(screen.getByRole('button', { name: /previous track/i }))
+    expect(api.currentTrack.id).toBe('a')
+  })
+
+  it('play/pause button calls the media element', async () => {
+    renderPlayer()
+    act(() => api.playQueue([{ id: 'a', title: 'A' }]))
+    const btn = screen.getByRole('button', { name: /^play$|^pause$/i })
+    await userEvent.click(btn)
+    expect(
+      window.HTMLMediaElement.prototype.play.mock.calls.length +
+        window.HTMLMediaElement.prototype.pause.mock.calls.length
+    ).toBeGreaterThan(0)
+  })
+
+  it('seeking updates the audio element currentTime', () => {
+    renderPlayer()
+    act(() => api.playQueue([{ id: 'a', title: 'A' }]))
+    const el = screen.getByTestId('global-audio-element')
+    // Provide a duration so the range has a max.
+    act(() => el.dispatchEvent(new Event('loadedmetadata')))
+    const range = screen.getByRole('slider')
+    act(() => api.seek(5))
+    expect(typeof range).toBe('object')
+  })
+
+  it('onEnded advances to the next track when repeat is off', () => {
+    renderPlayer()
+    act(() =>
+      api.playQueue([
+        { id: 'a', title: 'A' },
+        { id: 'b', title: 'B' },
+      ])
+    )
+    const el = screen.getByTestId('global-audio-element')
+    act(() => el.dispatchEvent(new Event('ended')))
+    expect(api.currentTrack.id).toBe('b')
+  })
+
+  it('onEnded replays the same track when repeat-one is on', () => {
+    renderPlayer()
+    act(() =>
+      api.playQueue([
+        { id: 'a', title: 'A' },
+        { id: 'b', title: 'B' },
+      ])
+    )
+    act(() => api.toggleRepeat())
+    const el = screen.getByTestId('global-audio-element')
+    act(() => el.dispatchEvent(new Event('ended')))
+    // Stays on the same track.
+    expect(api.currentTrack.id).toBe('a')
+  })
+
+  it('renders above the mobile nav when isMobile', () => {
+    render(
+      <AudioPlayerProvider>
+        <Capture />
+        <GlobalAudioPlayer isMobile />
+      </AudioPlayerProvider>
+    )
+    act(() => api.playQueue([{ id: 'a', title: 'A' }]))
+    expect(screen.getByTestId('global-audio-element')).toBeInTheDocument()
+  })
+})

--- a/frontend/src/components/campaigns/EmbedCard.jsx
+++ b/frontend/src/components/campaigns/EmbedCard.jsx
@@ -1,6 +1,7 @@
 import { useTranslation } from 'react-i18next'
-import { LuBookOpen, LuMap, LuUser, LuFile } from 'react-icons/lu'
+import { LuBookOpen, LuMap, LuUser, LuMusic, LuFile } from 'react-icons/lu'
 import { campaigns } from '../../api'
+import AudioPlayer from '../audio/AudioPlayer'
 
 const embedCardStyle = {
   display: 'inline-flex',
@@ -17,12 +18,46 @@ const embedCardStyle = {
 }
 
 /**
- * Renders a [[book:ID]] / [[map:ID]] / [[token:ID]] / [[file:ID]] / [[image:ID]]
- * wiki embed as an inline image or a link/download card.
+ * Renders a [[book:ID]] / [[map:ID]] / [[token:ID]] / [[audio:ID]] / [[file:ID]] / [[image:ID]]
+ * wiki embed as an inline image, an inline audio player, or a link/download card.
  */
 export default function EmbedCard({ spec, campaignId, onNavigate }) {
   const { t } = useTranslation()
   const [type, id, page] = spec.split(':')
+
+  // An embedded audio track plays in the global player (play / play next), with a
+  // click-through to its detail page.
+  if (type === 'audio') {
+    return (
+      <span
+        style={{
+          ...embedCardStyle,
+          cursor: 'default',
+          gap: 10,
+        }}
+      >
+        <AudioPlayer track={{ id }} showPlayNext size={34} />
+        <button
+          type="button"
+          onClick={() => onNavigate(`/audio/${id}`)}
+          style={{
+            background: 'none',
+            border: 'none',
+            padding: 0,
+            font: 'inherit',
+            color: 'var(--text)',
+            cursor: 'pointer',
+            display: 'inline-flex',
+            alignItems: 'center',
+            gap: 6,
+          }}
+        >
+          <LuMusic size={15} color="#f0a868" />
+          {t('wiki.embed_audio')}
+        </button>
+      </span>
+    )
+  }
 
   // An embedded image renders inline. It's served from the campaign file endpoint
   // (token-authenticated), so we need the campaign id to build the URL.

--- a/frontend/src/components/campaigns/EmbedCard.test.jsx
+++ b/frontend/src/components/campaigns/EmbedCard.test.jsx
@@ -1,0 +1,48 @@
+import { describe, it, expect, vi } from 'vitest'
+import { render, screen } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+import EmbedCard from './EmbedCard'
+
+vi.mock('../../api', () => ({
+  campaigns: { fileUrl: (cid, id) => `http://localhost/campaigns/${cid}/files/${id}` },
+  mediaUrl: (path) => `http://localhost${path}`,
+}))
+
+const playQueue = vi.fn()
+vi.mock('../../context/AudioPlayerContext', () => ({
+  useAudioPlayer: () => ({
+    playQueue,
+    playNext: vi.fn(),
+    togglePlay: vi.fn(),
+    isCurrent: () => false,
+    isPlayingId: () => false,
+  }),
+}))
+
+describe('EmbedCard', () => {
+  it('renders a play control for audio embeds', () => {
+    render(<EmbedCard spec="audio:track123" campaignId="c1" onNavigate={vi.fn()} />)
+    expect(screen.getByRole('button', { name: 'Play' })).toBeInTheDocument()
+    expect(screen.getByText('Audio')).toBeInTheDocument()
+  })
+
+  it('plays the embedded track in the global player', async () => {
+    render(<EmbedCard spec="audio:track123" campaignId="c1" onNavigate={vi.fn()} />)
+    await userEvent.click(screen.getByRole('button', { name: 'Play' }))
+    expect(playQueue).toHaveBeenCalledWith([{ id: 'track123' }])
+  })
+
+  it('navigates to the audio detail page when the label is clicked', async () => {
+    const onNavigate = vi.fn()
+    render(<EmbedCard spec="audio:track123" campaignId="c1" onNavigate={onNavigate} />)
+    await userEvent.click(screen.getByText('Audio'))
+    expect(onNavigate).toHaveBeenCalledWith('/audio/track123')
+  })
+
+  it('renders a navigate card for a map embed', async () => {
+    const onNavigate = vi.fn()
+    render(<EmbedCard spec="map:m1" campaignId="c1" onNavigate={onNavigate} />)
+    await userEvent.click(screen.getByText('Map'))
+    expect(onNavigate).toHaveBeenCalledWith('/maps/m1')
+  })
+})

--- a/frontend/src/components/campaigns/GrimoireEmbedPicker.jsx
+++ b/frontend/src/components/campaigns/GrimoireEmbedPicker.jsx
@@ -6,6 +6,7 @@ import {
   LuBookOpen,
   LuMap,
   LuUser,
+  LuMusic,
   LuFile,
   LuImage,
   LuPlus,
@@ -16,7 +17,7 @@ import Spinner from '../Spinner'
 import ImageUploadPanel from './ImageUploadPanel'
 import { miniBtn, miniBtnGhost } from './embedPickerStyles'
 
-const TYPE_ICON = { book: LuBookOpen, map: LuMap, token: LuUser, file: LuFile }
+const TYPE_ICON = { book: LuBookOpen, map: LuMap, token: LuUser, audio: LuMusic, file: LuFile }
 
 // Picks a linked campaign resource (or uploads a new image) and returns the
 // [[...]] embed token to insert into a wiki note. Only resources already linked
@@ -281,6 +282,10 @@ function thumbnailUrl(campaignId, item) {
     return item.is_image ? campaigns.fileUrl(campaignId, item.resource_id) : null
   }
   if (!item.has_thumbnail) return null
+  // Audio has no thumbnail endpoint — it serves folder/embedded artwork instead.
+  if (item.resource_type === 'audio') {
+    return mediaUrl(`/audio/${item.resource_id}/artwork`)
+  }
   const seg = item.resource_type === 'book' ? 'books' : `${item.resource_type}s`
   return mediaUrl(`/${seg}/${item.resource_id}/thumbnail`)
 }

--- a/frontend/src/components/campaigns/GrimoireEmbedPicker.test.jsx
+++ b/frontend/src/components/campaigns/GrimoireEmbedPicker.test.jsx
@@ -1,0 +1,88 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { render, screen, waitFor } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+import GrimoireEmbedPicker from './GrimoireEmbedPicker'
+import { campaigns } from '../../api'
+
+vi.mock('../../api', () => ({
+  campaigns: { listResources: vi.fn(), fileUrl: (cid, id) => `http://localhost/c/${cid}/f/${id}` },
+  mediaUrl: (p) => `http://localhost${p}`,
+}))
+vi.mock('./ImageUploadPanel', () => ({ default: () => <div>upload-panel</div> }))
+
+beforeEach(() => vi.clearAllMocks())
+
+const resources = [
+  { id: 'r1', resource_type: 'audio', resource_id: 'a1', name: 'Tavern', has_thumbnail: true },
+  { id: 'r2', resource_type: 'map', resource_id: 'm1', name: 'Cave', has_thumbnail: false },
+  { id: 'r3', resource_type: 'book', resource_id: 'b1', name: 'PHB', has_thumbnail: false },
+]
+
+describe('GrimoireEmbedPicker', () => {
+  it('lists linked resources', async () => {
+    campaigns.listResources.mockResolvedValue(resources)
+    render(<GrimoireEmbedPicker campaignId="c1" onInsert={vi.fn()} onClose={vi.fn()} />)
+    await waitFor(() => expect(screen.getByText('Tavern')).toBeInTheDocument())
+    expect(screen.getByText('Cave')).toBeInTheDocument()
+    expect(screen.getByText('PHB')).toBeInTheDocument()
+  })
+
+  it('inserts an [[audio:ID]] token when an audio resource is picked', async () => {
+    campaigns.listResources.mockResolvedValue(resources)
+    const onInsert = vi.fn()
+    render(<GrimoireEmbedPicker campaignId="c1" onInsert={onInsert} onClose={vi.fn()} />)
+    await waitFor(() => screen.getByText('Tavern'))
+    // Resources render in order, so the first Insert button is the audio row's.
+    const insertButtons = screen.getAllByRole('button', { name: /insert/i })
+    await userEvent.click(insertButtons[0])
+    expect(onInsert).toHaveBeenCalledWith('[[audio:a1]]')
+  })
+
+  it('filters resources by the search query', async () => {
+    campaigns.listResources.mockResolvedValue(resources)
+    render(<GrimoireEmbedPicker campaignId="c1" onInsert={vi.fn()} onClose={vi.fn()} />)
+    await waitFor(() => screen.getByText('Tavern'))
+    await userEvent.type(screen.getByPlaceholderText(/search/i), 'cave')
+    expect(screen.queryByText('Tavern')).not.toBeInTheDocument()
+    expect(screen.getByText('Cave')).toBeInTheDocument()
+  })
+
+  it('shows an empty state when no resources are linked', async () => {
+    campaigns.listResources.mockResolvedValue([])
+    render(<GrimoireEmbedPicker campaignId="c1" onInsert={vi.fn()} onClose={vi.fn()} />)
+    await waitFor(() => expect(screen.getByText(/no.*resources|link/i)).toBeInTheDocument())
+  })
+
+  it('inserts a book embed with a page number', async () => {
+    campaigns.listResources.mockResolvedValue([
+      { id: 'r3', resource_type: 'book', resource_id: 'b1', name: 'PHB', has_thumbnail: false },
+    ])
+    const onInsert = vi.fn()
+    render(<GrimoireEmbedPicker campaignId="c1" onInsert={onInsert} onClose={vi.fn()} />)
+    await waitFor(() => screen.getByText('PHB'))
+    // Book rows offer an "At page…" affordance.
+    await userEvent.click(screen.getByRole('button', { name: /at page/i }))
+    await userEvent.type(screen.getByPlaceholderText(/page/i), '42')
+    await userEvent.click(screen.getByRole('button', { name: /^insert$/i }))
+    expect(onInsert).toHaveBeenCalledWith('[[book:b1:42]]')
+  })
+
+  it('opens the image upload panel', async () => {
+    campaigns.listResources.mockResolvedValue([])
+    render(<GrimoireEmbedPicker campaignId="c1" onInsert={vi.fn()} onClose={vi.fn()} />)
+    await waitFor(() => screen.getByPlaceholderText(/search/i))
+    await userEvent.click(screen.getByTitle(/upload image/i))
+    expect(screen.getByText('upload-panel')).toBeInTheDocument()
+  })
+
+  it('closes when the backdrop is clicked', async () => {
+    campaigns.listResources.mockResolvedValue([])
+    const onClose = vi.fn()
+    const { container } = render(
+      <GrimoireEmbedPicker campaignId="c1" onInsert={vi.fn()} onClose={onClose} />
+    )
+    await waitFor(() => screen.getByPlaceholderText(/search/i))
+    await userEvent.click(container.firstChild)
+    expect(onClose).toHaveBeenCalled()
+  })
+})

--- a/frontend/src/components/campaigns/ResourceRow.jsx
+++ b/frontend/src/components/campaigns/ResourceRow.jsx
@@ -4,6 +4,7 @@ import { useNavigate } from 'react-router-dom'
 import { LuBookOpen, LuTrash2, LuChevronRight } from 'react-icons/lu'
 import { campaigns, mediaUrl } from '../../api'
 import { TYPE_ICONS, RESOURCE_NAV, VISIBILITY_OPTIONS, selectStyle } from './resourcesShared'
+import AudioPlayer from '../audio/AudioPlayer'
 
 /** A single linked campaign resource with owner controls (visibility, category, share). */
 export default function ResourceRow({
@@ -25,15 +26,20 @@ export default function ResourceRow({
   const { Icon } = TYPE_ICONS[resource.resource_type] || { Icon: LuBookOpen }
   const isBook = resource.resource_type === 'book'
   const isFile = resource.resource_type === 'file'
+  const isAudio = resource.resource_type === 'audio'
   const isImage = isFile && resource.is_image
 
+  // Audio serves folder/embedded artwork from its own endpoint; other media use
+  // the standard /<collection>/:id/thumbnail route.
   const thumbUrl = isImage
     ? campaigns.fileUrl(campaignId, resource.resource_id)
-    : resource.has_thumbnail && !isFile
-      ? mediaUrl(
-          `/${isBook ? 'books' : resource.resource_type + 's'}/${resource.resource_id}/thumbnail`
-        )
-      : null
+    : resource.has_thumbnail && isAudio
+      ? mediaUrl(`/audio/${resource.resource_id}/artwork`)
+      : resource.has_thumbnail && !isFile
+        ? mediaUrl(
+            `/${isBook ? 'books' : resource.resource_type + 's'}/${resource.resource_id}/thumbnail`
+          )
+        : null
 
   const handleNav = () => {
     if (isFile) {
@@ -225,6 +231,24 @@ export default function ResourceRow({
           </div>
         )}
       </div>
+
+      {isAudio && (
+        <div
+          onClick={stop}
+          role="presentation"
+          style={{ display: 'flex', alignItems: 'center', gap: 6, flexShrink: 0 }}
+        >
+          <AudioPlayer
+            track={{
+              id: resource.resource_id,
+              title: resource.name,
+              artwork: resource.has_thumbnail,
+            }}
+            showPlayNext
+            size={34}
+          />
+        </div>
+      )}
     </div>
   )
 }

--- a/frontend/src/components/campaigns/ResourceRow.test.jsx
+++ b/frontend/src/components/campaigns/ResourceRow.test.jsx
@@ -1,0 +1,141 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { render, screen } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+import ResourceRow from './ResourceRow'
+
+const navigate = vi.fn()
+vi.mock('react-router-dom', () => ({ useNavigate: () => navigate }))
+vi.mock('../../api', () => ({
+  campaigns: { fileUrl: (cid, id) => `http://localhost/campaigns/${cid}/files/${id}` },
+  mediaUrl: (p) => `http://localhost${p}`,
+}))
+vi.mock('../audio/AudioPlayer', () => ({
+  default: ({ track }) => <span data-testid="audio-player">{track?.id}</span>,
+}))
+
+beforeEach(() => vi.clearAllMocks())
+
+const resource = (over = {}) => ({
+  id: 'r1',
+  resource_type: 'audio',
+  resource_id: 'a1',
+  name: 'Tavern Night',
+  has_thumbnail: true,
+  is_image: false,
+  visibility: 'public',
+  category_id: null,
+  ...over,
+})
+
+const baseProps = (over = {}) => ({
+  campaignId: 'c1',
+  isOwner: false,
+  isGmCampaign: false,
+  members: [],
+  categories: [],
+  onRemove: vi.fn(),
+  onSetVisibility: vi.fn(),
+  onSetShares: vi.fn(),
+  onSetCategory: vi.fn(),
+  onDragStart: vi.fn(),
+  ...over,
+})
+
+describe('ResourceRow — audio', () => {
+  it('renders an audio player and uses the artwork endpoint for the thumbnail', () => {
+    const { container } = render(<ResourceRow resource={resource()} {...baseProps()} />)
+    expect(screen.getByTestId('audio-player')).toHaveTextContent('a1')
+    const img = container.querySelector('img')
+    expect(img?.getAttribute('src')).toContain('/audio/a1/artwork')
+  })
+
+  it('navigates to the audio detail page on title click', async () => {
+    render(<ResourceRow resource={resource()} {...baseProps()} />)
+    await userEvent.click(screen.getByText('Tavern Night'))
+    expect(navigate).toHaveBeenCalledWith('/audio/a1', expect.anything())
+  })
+})
+
+describe('ResourceRow — other types', () => {
+  it('opens a file resource in a new tab instead of navigating', async () => {
+    const openSpy = vi.spyOn(window, 'open').mockImplementation(() => null)
+    render(
+      <ResourceRow
+        resource={resource({ resource_type: 'file', resource_id: 'f1', name: 'handout.pdf' })}
+        {...baseProps()}
+      />
+    )
+    await userEvent.click(screen.getByText('handout.pdf'))
+    expect(openSpy).toHaveBeenCalled()
+    openSpy.mockRestore()
+  })
+
+  it('owner sees a remove control', async () => {
+    const onRemove = vi.fn()
+    render(
+      <ResourceRow
+        resource={resource({ resource_type: 'map', resource_id: 'm1', name: 'Cave' })}
+        {...baseProps({ isOwner: true, onRemove })}
+      />
+    )
+    await userEvent.click(screen.getByRole('button', { name: /remove cave/i }))
+    expect(onRemove).toHaveBeenCalled()
+  })
+
+  it('owner in a GM campaign can change visibility and category', async () => {
+    const onSetVisibility = vi.fn()
+    const onSetCategory = vi.fn()
+    render(
+      <ResourceRow
+        resource={resource({ resource_type: 'map', resource_id: 'm1', name: 'Cave' })}
+        {...baseProps({
+          isOwner: true,
+          isGmCampaign: true,
+          categories: [{ id: 'c1', name: 'Handouts' }],
+          onSetVisibility,
+          onSetCategory,
+        })}
+      />
+    )
+    const selects = screen.getAllByRole('combobox')
+    await userEvent.selectOptions(selects[0], 'private')
+    expect(onSetVisibility).toHaveBeenCalledWith('r1', 'private')
+    await userEvent.selectOptions(selects[1], 'c1')
+    expect(onSetCategory).toHaveBeenCalledWith('r1', 'c1')
+  })
+
+  it('renders private-share checkboxes for a private resource in a GM campaign', async () => {
+    const onSetShares = vi.fn()
+    render(
+      <ResourceRow
+        resource={resource({
+          resource_type: 'map',
+          resource_id: 'm1',
+          name: 'Cave',
+          visibility: 'private',
+          shared_user_ids: [],
+        })}
+        {...baseProps({
+          isOwner: true,
+          isGmCampaign: true,
+          members: [{ user_id: 'u2', username: 'bob' }],
+          onSetShares,
+        })}
+      />
+    )
+    const checkbox = screen.getByRole('checkbox')
+    await userEvent.click(checkbox)
+    expect(onSetShares).toHaveBeenCalledWith('r1', ['u2'])
+  })
+
+  it('non-owner in a GM campaign sees the visibility label', () => {
+    render(
+      <ResourceRow
+        resource={resource({ resource_type: 'map', resource_id: 'm1', name: 'Cave' })}
+        {...baseProps({ isOwner: false, isGmCampaign: true })}
+      />
+    )
+    // The visibility text label is shown instead of editor controls.
+    expect(screen.getByText(/public/i)).toBeInTheDocument()
+  })
+})

--- a/frontend/src/components/campaigns/ResourcesPanel.jsx
+++ b/frontend/src/components/campaigns/ResourcesPanel.jsx
@@ -5,12 +5,15 @@ import {
   LuPlus,
   LuChevronRight,
   LuChevronDown,
+  LuFolder,
   LuFolderCog,
   LuUpload,
+  LuPlay,
 } from 'react-icons/lu'
 import { campaigns } from '../../api'
 import { useAuth } from '../../context/AuthContext'
 import { useUISettings } from '../../context/UISettingsContext'
+import { useAudioPlayer } from '../../context/AudioPlayerContext'
 import Spinner from '../Spinner'
 import CategoryManager from './CategoryManager'
 import { CampaignIcon } from './campaignIcons'
@@ -22,12 +25,14 @@ export default function ResourcesPanel({ campaign, isOwner, onRefresh }) {
   const { t } = useTranslation()
   const { user } = useAuth()
   const ui = useUISettings()
+  const { playQueue } = useAudioPlayer()
   const isGmCampaign = campaign.is_gm_campaign
 
   const TYPE_LABELS = {
     book: t('resources.books'),
     map: t('resources.maps'),
     token: t('resources.tokens'),
+    audio: t('resources.audio'),
     file: t('resources.files'),
   }
 
@@ -279,6 +284,8 @@ export default function ResourcesPanel({ campaign, isOwner, onRefresh }) {
           {visibleGroups.map((g) => {
             const TypeIcon = g.type ? TYPE_ICONS[g.type].Icon : LuFolder
             const isCollapsed = collapsed.has(g.key)
+            // Audio resources in this group, for the GM-only group play button.
+            const audioItems = g.items.filter((r) => r.resource_type === 'audio')
             return (
               <section
                 key={g.key}
@@ -286,37 +293,70 @@ export default function ResourcesPanel({ campaign, isOwner, onRefresh }) {
                 onDrop={isOwner ? () => onDropToGroup(g) : undefined}
                 style={{ marginBottom: 4 }}
               >
-                <button
-                  type="button"
-                  onClick={() => toggleCollapse(g.key)}
-                  aria-expanded={!isCollapsed}
-                  style={{
-                    width: '100%',
-                    fontSize: 12,
-                    fontWeight: 600,
-                    color: 'var(--text-muted)',
-                    textTransform: 'uppercase',
-                    letterSpacing: '0.07em',
-                    marginBottom: 8,
-                    display: 'flex',
-                    alignItems: 'center',
-                    gap: 6,
-                    background: 'none',
-                    border: 'none',
-                    padding: 0,
-                    cursor: 'pointer',
-                    textAlign: 'left',
-                    font: 'inherit',
-                  }}
-                >
-                  {isCollapsed ? (
-                    <LuChevronRight size={13} aria-hidden="true" style={{ flexShrink: 0 }} />
-                  ) : (
-                    <LuChevronDown size={13} aria-hidden="true" style={{ flexShrink: 0 }} />
+                <div style={{ display: 'flex', alignItems: 'center', gap: 6, marginBottom: 8 }}>
+                  <button
+                    type="button"
+                    onClick={() => toggleCollapse(g.key)}
+                    aria-expanded={!isCollapsed}
+                    style={{
+                      flex: 1,
+                      minWidth: 0,
+                      fontSize: 12,
+                      fontWeight: 600,
+                      color: 'var(--text-muted)',
+                      textTransform: 'uppercase',
+                      letterSpacing: '0.07em',
+                      display: 'flex',
+                      alignItems: 'center',
+                      gap: 6,
+                      background: 'none',
+                      border: 'none',
+                      padding: 0,
+                      cursor: 'pointer',
+                      textAlign: 'left',
+                      font: 'inherit',
+                    }}
+                  >
+                    {isCollapsed ? (
+                      <LuChevronRight size={13} aria-hidden="true" style={{ flexShrink: 0 }} />
+                    ) : (
+                      <LuChevronDown size={13} aria-hidden="true" style={{ flexShrink: 0 }} />
+                    )}
+                    <CampaignIcon name={g.icon} fallback={TypeIcon} size={12} /> {g.label} (
+                    {g.items.length})
+                  </button>
+                  {isOwner && audioItems.length > 0 && (
+                    <button
+                      type="button"
+                      onClick={() =>
+                        playQueue(
+                          audioItems.map((r) => ({
+                            id: r.resource_id,
+                            title: r.name,
+                            artwork: r.has_thumbnail,
+                          }))
+                        )
+                      }
+                      title={t('audio.playGroup')}
+                      aria-label={t('audio.playGroup')}
+                      style={{
+                        display: 'inline-flex',
+                        alignItems: 'center',
+                        gap: 3,
+                        flexShrink: 0,
+                        padding: '2px 8px',
+                        borderRadius: 5,
+                        fontSize: 11,
+                        color: 'var(--text-dim)',
+                        border: '1px solid var(--border)',
+                        background: 'var(--bg-deep)',
+                        cursor: 'pointer',
+                      }}
+                    >
+                      <LuPlay size={11} /> {t('audio.player.play')}
+                    </button>
                   )}
-                  <CampaignIcon name={g.icon} fallback={TypeIcon} size={12} /> {g.label} (
-                  {g.items.length})
-                </button>
+                </div>
                 {isCollapsed ? null : g.items.length === 0 ? (
                   <div
                     style={{

--- a/frontend/src/components/campaigns/ResourcesPanel.test.jsx
+++ b/frontend/src/components/campaigns/ResourcesPanel.test.jsx
@@ -1,0 +1,206 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { render, screen, waitFor, fireEvent } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+import ResourcesPanel from './ResourcesPanel'
+import { campaigns } from '../../api'
+
+vi.mock('../../api', () => ({
+  campaigns: {
+    listResources: vi.fn(),
+    listCategories: vi.fn(),
+    removeResource: vi.fn(),
+    updateResource: vi.fn(),
+    uploadFile: vi.fn(),
+    reorderResources: vi.fn(),
+  },
+}))
+
+const playQueue = vi.fn()
+vi.mock('../../context/AudioPlayerContext', () => ({ useAudioPlayer: () => ({ playQueue }) }))
+vi.mock('../../context/AuthContext', () => ({ useAuth: () => ({ user: { id: 'u1' } }) }))
+vi.mock('../../context/UISettingsContext', () => ({
+  useUISettings: () => ({ campaign_uploads_disabled: false }),
+}))
+// Render each resource row with buttons that fire the owner-action callbacks,
+// so the panel's remove/visibility/category handlers are exercised.
+vi.mock('./ResourceRow', () => ({
+  default: ({ resource, onRemove, onSetVisibility, onSetCategory, onSetShares, onDragStart }) => (
+    <div>
+      <span>{resource.name}</span>
+      <button onClick={() => onRemove(resource)}>{`remove-${resource.id}`}</button>
+      <button
+        onClick={() => onSetVisibility(resource.id, 'private')}
+      >{`vis-${resource.id}`}</button>
+      <button onClick={() => onSetCategory(resource.id, 'cat1')}>{`cat-${resource.id}`}</button>
+      <button onClick={() => onSetShares(resource.id, ['u2'])}>{`share-${resource.id}`}</button>
+      <button onClick={() => onDragStart({ dataTransfer: { effectAllowed: '' } }, resource)}>
+        {`drag-${resource.id}`}
+      </button>
+    </div>
+  ),
+}))
+vi.mock('./CategoryManager', () => ({
+  default: ({ onClose, onChanged, onGroupOrderChange }) => (
+    <div data-testid="category-manager">
+      <button onClick={() => onGroupOrderChange(['type:audio', 'type:map'])}>reorder-groups</button>
+      <button onClick={onChanged}>cats-changed</button>
+      <button onClick={onClose}>close-cats</button>
+    </div>
+  ),
+}))
+vi.mock('./ResourcePicker', () => ({
+  default: ({ onAdd, onClose }) => (
+    <div data-testid="resource-picker">
+      <button onClick={onAdd}>picker-added</button>
+      <button onClick={onClose}>close-picker</button>
+    </div>
+  ),
+}))
+
+beforeEach(() => {
+  vi.clearAllMocks()
+  campaigns.listCategories.mockResolvedValue([])
+})
+
+const campaign = { id: 'c1', is_gm_campaign: true, resource_group_order: [] }
+
+const resources = [
+  { id: 'r1', resource_type: 'audio', resource_id: 'a1', name: 'Tavern', has_thumbnail: true },
+  { id: 'r2', resource_type: 'audio', resource_id: 'a2', name: 'Battle', has_thumbnail: false },
+  { id: 'r3', resource_type: 'map', resource_id: 'm1', name: 'Cave', has_thumbnail: false },
+]
+
+describe('ResourcesPanel', () => {
+  it('renders resources grouped by type', async () => {
+    campaigns.listResources.mockResolvedValue(resources)
+    render(<ResourcesPanel campaign={campaign} isOwner onRefresh={vi.fn()} />)
+    await waitFor(() => expect(screen.getByText('Tavern')).toBeInTheDocument())
+    expect(screen.getByText('Battle')).toBeInTheDocument()
+    expect(screen.getByText('Cave')).toBeInTheDocument()
+  })
+
+  it('shows a GM-only Play button on an audio group that queues its tracks', async () => {
+    campaigns.listResources.mockResolvedValue(resources)
+    render(<ResourcesPanel campaign={campaign} isOwner onRefresh={vi.fn()} />)
+    await waitFor(() => screen.getByText('Tavern'))
+    await userEvent.click(screen.getByTitle(/play audio/i))
+    expect(playQueue).toHaveBeenCalledTimes(1)
+    expect(playQueue.mock.calls[0][0].map((t) => t.id)).toEqual(['a1', 'a2'])
+  })
+
+  it('hides the group Play button for non-owners', async () => {
+    campaigns.listResources.mockResolvedValue(resources)
+    render(<ResourcesPanel campaign={campaign} isOwner={false} onRefresh={vi.fn()} />)
+    await waitFor(() => screen.getByText('Tavern'))
+    expect(screen.queryByTitle(/play audio/i)).not.toBeInTheDocument()
+  })
+
+  it('shows an empty state when there are no resources', async () => {
+    campaigns.listResources.mockResolvedValue([])
+    render(<ResourcesPanel campaign={campaign} isOwner onRefresh={vi.fn()} />)
+    await waitFor(() => expect(campaigns.listResources).toHaveBeenCalled())
+    // Audio group has no items → no play button.
+    expect(screen.queryByTitle(/play audio/i)).not.toBeInTheDocument()
+  })
+
+  it('removes a resource and reloads', async () => {
+    campaigns.listResources.mockResolvedValue(resources)
+    campaigns.removeResource.mockResolvedValue({})
+    render(<ResourcesPanel campaign={campaign} isOwner onRefresh={vi.fn()} />)
+    await waitFor(() => screen.getByText('Cave'))
+    await userEvent.click(screen.getByText('remove-r3'))
+    expect(campaigns.removeResource).toHaveBeenCalledWith('c1', 'r3')
+  })
+
+  it('updates visibility, category, and shares via row controls', async () => {
+    campaigns.listResources.mockResolvedValue(resources)
+    campaigns.updateResource.mockResolvedValue({})
+    render(<ResourcesPanel campaign={campaign} isOwner onRefresh={vi.fn()} />)
+    await waitFor(() => screen.getByText('Cave'))
+    await userEvent.click(screen.getByText('vis-r1'))
+    expect(campaigns.updateResource).toHaveBeenCalledWith('c1', 'r1', { visibility: 'private' })
+    await userEvent.click(screen.getByText('cat-r1'))
+    expect(campaigns.updateResource).toHaveBeenCalledWith('c1', 'r1', { category_id: 'cat1' })
+    await userEvent.click(screen.getByText('share-r1'))
+    expect(campaigns.updateResource).toHaveBeenCalledWith('c1', 'r1', { shared_user_ids: ['u2'] })
+  })
+
+  it('opens the category manager and the resource picker', async () => {
+    campaigns.listResources.mockResolvedValue([])
+    render(<ResourcesPanel campaign={campaign} isOwner onRefresh={vi.fn()} />)
+    await waitFor(() => expect(campaigns.listResources).toHaveBeenCalled())
+    await userEvent.click(screen.getByRole('button', { name: /categories/i }))
+    expect(screen.getByTestId('category-manager')).toBeInTheDocument()
+    await userEvent.click(screen.getByText('close-cats'))
+
+    await userEvent.click(screen.getByRole('button', { name: /link|add/i }))
+    expect(screen.getByTestId('resource-picker')).toBeInTheDocument()
+  })
+
+  it('uploads a file', async () => {
+    campaigns.listResources.mockResolvedValue([])
+    campaigns.uploadFile.mockResolvedValue({})
+    const { container } = render(<ResourcesPanel campaign={campaign} isOwner onRefresh={vi.fn()} />)
+    await waitFor(() => expect(campaigns.listResources).toHaveBeenCalled())
+    const input = container.querySelector('input[type="file"]')
+    const file = new File(['x'], 'handout.pdf', { type: 'application/pdf' })
+    await userEvent.upload(input, file)
+    expect(campaigns.uploadFile).toHaveBeenCalledWith('c1', file)
+  })
+
+  it('renders custom category groups', async () => {
+    campaigns.listResources.mockResolvedValue([
+      { id: 'r1', resource_type: 'map', resource_id: 'm1', name: 'Cave', category_id: 'cat1' },
+    ])
+    campaigns.listCategories.mockResolvedValue([
+      { id: 'cat1', name: 'Handouts', sort_order: 0, kind: 'resource' },
+    ])
+    render(<ResourcesPanel campaign={campaign} isOwner onRefresh={vi.fn()} />)
+    await waitFor(() => expect(screen.getByText(/Handouts/)).toBeInTheDocument())
+    expect(screen.getByText('Cave')).toBeInTheDocument()
+  })
+
+  it('starts a drag without throwing (drag handlers wired for owners)', async () => {
+    campaigns.listResources.mockResolvedValue(resources)
+    render(<ResourcesPanel campaign={campaign} isOwner onRefresh={vi.fn()} />)
+    await waitFor(() => screen.getByText('Cave'))
+    // The drag-start handler records the dragged id (no throw).
+    await userEvent.click(screen.getByText('drag-r1'))
+    expect(screen.getByText('Cave')).toBeInTheDocument()
+  })
+
+  it('reloads when the resource picker reports an addition', async () => {
+    campaigns.listResources.mockResolvedValue([])
+    render(<ResourcesPanel campaign={campaign} isOwner onRefresh={vi.fn()} />)
+    await waitFor(() => expect(campaigns.listResources).toHaveBeenCalled())
+    await userEvent.click(screen.getByRole('button', { name: /link|add/i }))
+    campaigns.listResources.mockClear()
+    await userEvent.click(screen.getByText('picker-added'))
+    expect(campaigns.listResources).toHaveBeenCalled()
+  })
+
+  it('reorders groups and reloads from the category manager', async () => {
+    campaigns.listResources.mockResolvedValue([])
+    const onRefresh = vi.fn()
+    render(<ResourcesPanel campaign={campaign} isOwner onRefresh={onRefresh} />)
+    await waitFor(() => expect(campaigns.listResources).toHaveBeenCalled())
+    await userEvent.click(screen.getByRole('button', { name: /categories/i }))
+    await userEvent.click(screen.getByText('reorder-groups'))
+    await userEvent.click(screen.getByText('cats-changed'))
+    expect(onRefresh).toHaveBeenCalled()
+  })
+
+  it('reorders a resource when dropped onto another resource', async () => {
+    campaigns.listResources.mockResolvedValue(resources)
+    campaigns.reorderResources.mockResolvedValue({})
+    const { container } = render(<ResourcesPanel campaign={campaign} isOwner onRefresh={vi.fn()} />)
+    await waitFor(() => screen.getByText('Cave'))
+    // Begin a drag, then drop the dragged item onto another resource's wrapper.
+    fireEvent.click(screen.getByText('drag-r1'))
+    // Each ResourceRow is wrapped in a div with onDrop; drop onto the Battle row.
+    const battleWrapper = screen.getByText('Battle').closest('div').parentElement
+    fireEvent.dragOver(battleWrapper)
+    fireEvent.drop(battleWrapper)
+    await waitFor(() => expect(campaigns.reorderResources).toHaveBeenCalled())
+  })
+})

--- a/frontend/src/components/campaigns/WikiMarkdown.jsx
+++ b/frontend/src/components/campaigns/WikiMarkdown.jsx
@@ -11,10 +11,10 @@ import EmbedCard from './EmbedCard'
 // custom `a` renderer below.
 //   [[Page Title]]            -> [Page Title](grimoire-wiki:slug-of-title)
 //   [[Page Title|label]]      -> [label](grimoire-wiki:slug-of-title)
-//   [[book:ID]] / [[book:ID:PAGE]] / [[map:ID]] / [[token:ID]] / [[file:ID]] / [[image:ID]]
+//   [[book:ID]] / [[book:ID:PAGE]] / [[map:ID]] / [[token:ID]] / [[audio:ID]] / [[file:ID]] / [[image:ID]]
 //                             -> [embed](grimoire-embed:book:ID:PAGE)
 const LINK_RE = /\[\[([^\]|]+?)(?:\|([^\]]+))?\]\]/g
-const EMBED_PREFIXES = ['book:', 'map:', 'token:', 'file:', 'image:']
+const EMBED_PREFIXES = ['book:', 'map:', 'token:', 'audio:', 'file:', 'image:']
 
 // ||GM-only text||. Only the owner ever receives a body still containing these
 // (the backend strips them for everyone else), so rendering them as a tinted

--- a/frontend/src/components/campaigns/WikiView.jsx
+++ b/frontend/src/components/campaigns/WikiView.jsx
@@ -12,8 +12,10 @@ import {
   LuUpload,
   LuChevronRight,
   LuChevronDown,
+  LuListMusic,
 } from 'react-icons/lu'
 import { campaigns } from '../../api'
+import { useAudioPlayer } from '../../context/AudioPlayerContext'
 import Spinner from '../Spinner'
 import WikiMarkdown from './WikiMarkdown'
 import WikiImportModal from './WikiImportModal'
@@ -24,8 +26,16 @@ import VisibilityEditor from './VisibilityEditor'
 import PageEditor from './PageEditor'
 import { descendantIds, VIS_META, ghostBtn, goldBtn } from './wikiShared'
 
+// Ordered list of [[audio:ID]] embed ids in a note body, used for "play all".
+const AUDIO_EMBED_RE = /\[\[audio:([^\]|]+?)(?:\|[^\]]+)?\]\]/g
+function extractAudioEmbedIds(body) {
+  if (!body) return []
+  return Array.from(body.matchAll(AUDIO_EMBED_RE), (m) => m[1].trim()).filter(Boolean)
+}
+
 export default function WikiView({ campaign, isOwner }) {
   const { t } = useTranslation()
+  const { playQueue } = useAudioPlayer()
   const [pages, setPages] = useState(null)
   const [selectedId, setSelectedId] = useState(null)
   const [page, setPage] = useState(null)
@@ -607,16 +617,36 @@ export default function WikiView({ campaign, isOwner }) {
                   )}
                 </div>
               </div>
-              {page.can_edit && (
-                <div style={{ display: 'flex', gap: 8, flexShrink: 0 }}>
-                  <button onClick={() => setEditing(true)} style={ghostBtn}>
-                    <LuPencil size={13} /> {t('common.edit')}
-                  </button>
-                  <button onClick={handleDelete} style={{ ...ghostBtn, color: 'var(--danger)' }}>
-                    <LuTrash2 size={13} />
-                  </button>
-                </div>
-              )}
+              {(() => {
+                const audioIds = extractAudioEmbedIds(page.body)
+                if (!page.can_edit && audioIds.length === 0) return null
+                return (
+                  <div style={{ display: 'flex', gap: 8, flexShrink: 0 }}>
+                    {audioIds.length > 0 && (
+                      <button
+                        onClick={() => playQueue(audioIds.map((id) => ({ id })))}
+                        style={ghostBtn}
+                        title={t('audio.playAll')}
+                      >
+                        <LuListMusic size={13} /> {t('audio.playAll')}
+                      </button>
+                    )}
+                    {page.can_edit && (
+                      <>
+                        <button onClick={() => setEditing(true)} style={ghostBtn}>
+                          <LuPencil size={13} /> {t('common.edit')}
+                        </button>
+                        <button
+                          onClick={handleDelete}
+                          style={{ ...ghostBtn, color: 'var(--danger)' }}
+                        >
+                          <LuTrash2 size={13} />
+                        </button>
+                      </>
+                    )}
+                  </div>
+                )
+              })()}
             </div>
 
             <div

--- a/frontend/src/components/campaigns/WikiView.test.jsx
+++ b/frontend/src/components/campaigns/WikiView.test.jsx
@@ -17,7 +17,20 @@ vi.mock('../../api', () => ({
     getWikiPage: vi.fn(),
     updateWikiPage: vi.fn(),
     reorderWikiPages: vi.fn(),
+    createWikiPage: vi.fn(),
+    deleteWikiPage: vi.fn(),
   },
+}))
+
+const playQueue = vi.fn()
+vi.mock('../../context/AudioPlayerContext', () => ({
+  useAudioPlayer: () => ({
+    playQueue,
+    playNext: vi.fn(),
+    togglePlay: vi.fn(),
+    isCurrent: () => false,
+    isPlayingId: () => false,
+  }),
 }))
 
 import { campaigns } from '../../api'
@@ -319,5 +332,108 @@ describe('WikiView markdown formatting toolbar', () => {
     textarea.setSelectionRange(0, 0)
     fireEvent.click(screen.getByRole('button', { name: 'Bullet list' }))
     expect(textarea.value).toBe('- Here be dragons')
+  })
+})
+
+describe('WikiView audio "play all"', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    playQueue.mockClear()
+  })
+
+  const pageWithAudio = {
+    ...page,
+    body: 'Intro [[audio:a1]] middle [[audio:a2|Custom]] end',
+  }
+
+  it('shows a Play all button when the note embeds audio and queues them in order', async () => {
+    campaigns.listWikiPages.mockResolvedValue([pageWithAudio])
+    campaigns.getWikiPage.mockResolvedValue(pageWithAudio)
+    renderView()
+    const playAll = await screen.findByRole('button', { name: /play all/i })
+    fireEvent.click(playAll)
+    expect(playQueue).toHaveBeenCalledTimes(1)
+    expect(playQueue.mock.calls[0][0].map((t) => t.id)).toEqual(['a1', 'a2'])
+  })
+
+  it('does not show a Play all button when the note has no audio embeds', async () => {
+    campaigns.listWikiPages.mockResolvedValue([page])
+    campaigns.getWikiPage.mockResolvedValue(page)
+    renderView()
+    await waitFor(() => screen.getByText('Dragons'))
+    expect(screen.queryByTitle(/play all/i)).not.toBeInTheDocument()
+  })
+
+  it('shows Play all to a non-editor viewer when the note has audio', async () => {
+    campaigns.listWikiPages.mockResolvedValue([pageWithAudio])
+    campaigns.getWikiPage.mockResolvedValue({ ...pageWithAudio, can_edit: false })
+    renderView({ isOwner: false })
+    expect(await screen.findByRole('button', { name: /play all/i })).toBeInTheDocument()
+  })
+})
+
+describe('WikiView create / delete / search', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    campaigns.listWikiPages.mockResolvedValue([page])
+    campaigns.getWikiPage.mockResolvedValue(page)
+    campaigns.updateWikiPage.mockResolvedValue(page)
+    campaigns.deleteWikiPage.mockResolvedValue({})
+  })
+
+  it('opens the page editor when New Page is clicked', async () => {
+    renderView()
+    await screen.findByText('Here be dragons')
+    fireEvent.click(screen.getByRole('button', { name: /new page/i }))
+    // The editor exposes a Markdown textarea.
+    expect(await screen.findByLabelText('Markdown')).toBeInTheDocument()
+  })
+
+  it('deletes the open page after confirmation', async () => {
+    vi.spyOn(window, 'confirm').mockReturnValue(true)
+    renderView()
+    await screen.findByText('Here be dragons')
+    // The page header has a delete (trash) button.
+    const buttons = screen.getAllByRole('button')
+    const del = buttons.find((b) => b.querySelector('svg') && b.textContent === '')
+    // Fall back: click the trash button near the Edit button.
+    fireEvent.click(screen.getByRole('button', { name: 'Edit' }))
+    fireEvent.click(screen.getByRole('button', { name: /cancel/i }))
+    // Re-open view, then delete.
+    await screen.findByText('Here be dragons')
+    const trash = screen.getAllByRole('button').find((b) => b.style.color === 'var(--danger)')
+    fireEvent.click(trash)
+    await waitFor(() => expect(campaigns.deleteWikiPage).toHaveBeenCalledWith('c1', 'p1'))
+    window.confirm.mockRestore()
+  })
+
+  it('filters the page list by the search query', async () => {
+    campaigns.listWikiPages.mockResolvedValue([
+      { ...page, id: 'p1', title: 'Dragons', slug: 'dragons' },
+      { ...page, id: 'p2', title: 'Kobolds', slug: 'kobolds' },
+    ])
+    renderView()
+    await screen.findByText('Kobolds')
+    fireEvent.change(screen.getByPlaceholderText(/search/i), { target: { value: 'kobold' } })
+    // The non-matching sidebar entry is filtered out; Kobolds remains.
+    expect(screen.getByText('Kobolds')).toBeInTheDocument()
+    // "Dragons" remains only as the open page's title heading, not a list row.
+    const dragonNodes = screen.getAllByText('Dragons')
+    expect(dragonNodes.every((n) => n.tagName === 'H2')).toBe(true)
+  })
+
+  it('navigates to a page by clicking its sidebar entry', async () => {
+    campaigns.listWikiPages.mockResolvedValue([
+      { ...page, id: 'p1', title: 'Dragons', slug: 'dragons' },
+      { ...page, id: 'p2', title: 'Kobolds', slug: 'kobolds' },
+    ])
+    campaigns.getWikiPage.mockImplementation((_c, id) =>
+      Promise.resolve({ ...page, id, title: id === 'p2' ? 'Kobolds' : 'Dragons' })
+    )
+    renderView()
+    await screen.findByText('Kobolds')
+    campaigns.getWikiPage.mockClear()
+    fireEvent.click(screen.getByText('Kobolds'))
+    await waitFor(() => expect(campaigns.getWikiPage).toHaveBeenCalledWith('c1', 'p2'))
   })
 })

--- a/frontend/src/components/campaigns/resourcesShared.js
+++ b/frontend/src/components/campaigns/resourcesShared.js
@@ -1,9 +1,10 @@
-import { LuBookOpen, LuMap, LuUser, LuFile } from 'react-icons/lu'
+import { LuBookOpen, LuMap, LuUser, LuMusic, LuFile } from 'react-icons/lu'
 
 export const TYPE_ICONS = {
   book: { Icon: LuBookOpen, color: '#a78bfa' },
   map: { Icon: LuMap, color: '#60a5fa' },
   token: { Icon: LuUser, color: '#34d399' },
+  audio: { Icon: LuMusic, color: '#f0a868' },
   file: { Icon: LuFile, color: '#e0b341' },
 }
 
@@ -11,6 +12,7 @@ export const RESOURCE_NAV = {
   book: (id) => `/library/book/${id}`,
   map: (id) => `/maps/${id}`,
   token: (id) => `/tokens/${id}`,
+  audio: (id) => `/audio/${id}`,
 }
 
 // Visibility selector order: public, then private, then GM-only.

--- a/frontend/src/components/campaigns/resourcesShared.test.js
+++ b/frontend/src/components/campaigns/resourcesShared.test.js
@@ -1,0 +1,26 @@
+import { describe, it, expect } from 'vitest'
+import { TYPE_ICONS, RESOURCE_NAV, VISIBILITY_OPTIONS, selectStyle } from './resourcesShared'
+
+describe('resourcesShared', () => {
+  it('has icons for every resource type including audio', () => {
+    for (const type of ['book', 'map', 'token', 'audio', 'file']) {
+      expect(TYPE_ICONS[type]).toBeTruthy()
+      expect(TYPE_ICONS[type].Icon).toBeTruthy()
+    }
+  })
+
+  it('builds navigation paths for library resource types', () => {
+    expect(RESOURCE_NAV.book('b1')).toBe('/library/book/b1')
+    expect(RESOURCE_NAV.map('m1')).toBe('/maps/m1')
+    expect(RESOURCE_NAV.token('t1')).toBe('/tokens/t1')
+    expect(RESOURCE_NAV.audio('a1')).toBe('/audio/a1')
+  })
+
+  it('exposes visibility options in priority order', () => {
+    expect(VISIBILITY_OPTIONS).toEqual(['public', 'private', 'gm'])
+  })
+
+  it('exposes a select style object', () => {
+    expect(selectStyle).toHaveProperty('cursor', 'pointer')
+  })
+})

--- a/frontend/src/components/favorites/AudioFavorite.jsx
+++ b/frontend/src/components/favorites/AudioFavorite.jsx
@@ -1,0 +1,99 @@
+import { useNavigate } from 'react-router-dom'
+import { LuMusic } from 'react-icons/lu'
+import { mediaUrl } from '../../api'
+import FavoriteButton from '../FavoriteButton'
+import {
+  cardWrapperStyle,
+  rowWrapperStyle,
+  hoverIn,
+  hoverOut,
+  rowFavoriteButtonStyle,
+} from './favoriteStyles'
+
+export default function AudioFavorite({ item, grid }) {
+  const navigate = useNavigate()
+  const open = () => navigate(`/audio/${item.item_id}`)
+  const label = item.title || item.filename
+
+  if (!grid) {
+    return (
+      <div onClick={open} style={rowWrapperStyle} onMouseEnter={hoverIn} onMouseLeave={hoverOut}>
+        <div
+          style={{
+            width: 40,
+            height: 40,
+            borderRadius: 4,
+            overflow: 'hidden',
+            flexShrink: 0,
+            background: 'var(--bg-deep)',
+            display: 'flex',
+            alignItems: 'center',
+            justifyContent: 'center',
+          }}
+        >
+          {item.has_artwork ? (
+            <img
+              src={mediaUrl(`/audio/${item.item_id}/artwork`)}
+              alt=""
+              style={{ width: '100%', height: '100%', objectFit: 'cover' }}
+            />
+          ) : (
+            <LuMusic size={16} color="var(--text-muted)" style={{ opacity: 0.4 }} />
+          )}
+        </div>
+        <div
+          style={{
+            flex: 1,
+            minWidth: 0,
+            fontSize: 15,
+            overflow: 'hidden',
+            textOverflow: 'ellipsis',
+            whiteSpace: 'nowrap',
+          }}
+        >
+          {label}
+        </div>
+        <FavoriteButton type="audio" id={item.item_id} style={rowFavoriteButtonStyle} />
+      </div>
+    )
+  }
+
+  return (
+    <div onClick={open} style={cardWrapperStyle} onMouseEnter={hoverIn} onMouseLeave={hoverOut}>
+      <div
+        style={{
+          width: '100%',
+          height: 110,
+          background: 'var(--bg-deep)',
+          display: 'flex',
+          alignItems: 'center',
+          justifyContent: 'center',
+        }}
+      >
+        {item.has_artwork ? (
+          <img
+            src={mediaUrl(`/audio/${item.item_id}/artwork`)}
+            alt=""
+            loading="lazy"
+            style={{ width: '100%', height: '100%', objectFit: 'cover' }}
+          />
+        ) : (
+          <LuMusic size={28} color="var(--text-muted)" style={{ opacity: 0.4 }} />
+        )}
+      </div>
+      <div style={{ padding: '8px 10px' }}>
+        <div
+          style={{
+            fontSize: 13,
+            overflow: 'hidden',
+            textOverflow: 'ellipsis',
+            whiteSpace: 'nowrap',
+          }}
+        >
+          {label}
+        </div>
+      </div>
+      <FavoriteButton type="audio" id={item.item_id} />
+    </div>
+  )
+}

--- a/frontend/src/components/favorites/AudioFavorite.test.jsx
+++ b/frontend/src/components/favorites/AudioFavorite.test.jsx
@@ -1,0 +1,47 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { render, screen } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+import AudioFavorite from './AudioFavorite'
+
+const navigate = vi.fn()
+vi.mock('react-router-dom', () => ({ useNavigate: () => navigate }))
+vi.mock('../../api', () => ({ mediaUrl: (p) => `http://localhost${p}` }))
+vi.mock('../FavoriteButton', () => ({ default: () => <button>fav</button> }))
+
+beforeEach(() => vi.clearAllMocks())
+
+const track = (over = {}) => ({
+  item_id: 'a1',
+  title: 'Tavern Night',
+  filename: 'tavern.mp3',
+  has_artwork: false,
+  ...over,
+})
+
+describe('AudioFavorite', () => {
+  it('renders the title in grid mode and navigates on click', async () => {
+    render(<AudioFavorite item={track()} grid />)
+    expect(screen.getByText('Tavern Night')).toBeInTheDocument()
+    await userEvent.click(screen.getByText('Tavern Night'))
+    expect(navigate).toHaveBeenCalledWith('/audio/a1')
+  })
+
+  it('falls back to filename when title is empty', () => {
+    render(<AudioFavorite item={track({ title: '' })} grid />)
+    expect(screen.getByText('tavern.mp3')).toBeInTheDocument()
+  })
+
+  it('renders artwork image when has_artwork', () => {
+    const { container } = render(<AudioFavorite item={track({ has_artwork: true })} grid />)
+    const img = container.querySelector('img')
+    expect(img).toBeTruthy()
+    expect(img.getAttribute('src')).toContain('/audio/a1/artwork')
+  })
+
+  it('renders in row mode (no grid)', async () => {
+    render(<AudioFavorite item={track()} grid={false} />)
+    expect(screen.getByText('Tavern Night')).toBeInTheDocument()
+    await userEvent.click(screen.getByText('Tavern Night'))
+    expect(navigate).toHaveBeenCalledWith('/audio/a1')
+  })
+})

--- a/frontend/src/components/media/MediaCard.jsx
+++ b/frontend/src/components/media/MediaCard.jsx
@@ -5,6 +5,7 @@ import { mediaUrl } from '../../api'
 import { formatSize } from '../../utils'
 import FavoriteButton from '../FavoriteButton'
 import DownloadButton from '../DownloadButton'
+import AudioPlayer from '../audio/AudioPlayer'
 
 const CORNER_POS = {
   'bottom-left': { bottom: 6, left: 6 },
@@ -39,6 +40,15 @@ export default function MediaCard({ config, item, onClick, bulkMode, selected, o
 
   // Badges that apply to this item, in config order.
   const activeBadges = config.badges.filter((b) => item[b.flag])
+
+  // Which item field signals an available thumbnail/artwork (audio uses artwork).
+  const hasThumbnail = item[config.thumbnailFlag || 'has_thumbnail']
+
+  // Track ref for the global audio player (audio gallery only).
+  const isAudio = !!config.audioFileUrl
+  const track = isAudio
+    ? { id: item.id, title: item.title || item.filename, artwork: item.has_artwork }
+    : null
 
   if (list) {
     return (
@@ -92,7 +102,7 @@ export default function MediaCard({ config, item, onClick, bulkMode, selected, o
             justifyContent: 'center',
           }}
         >
-          {item.has_thumbnail ? (
+          {hasThumbnail ? (
             <img
               src={mediaUrl(config.thumbnailUrl(item.id))}
               alt=""
@@ -133,7 +143,8 @@ export default function MediaCard({ config, item, onClick, bulkMode, selected, o
           </div>
         </div>
         {!bulkMode && (
-          <div style={{ display: 'flex', alignItems: 'center', flexShrink: 0 }}>
+          <div style={{ display: 'flex', alignItems: 'center', gap: 4, flexShrink: 0 }}>
+            {isAudio && !item.is_missing && <AudioPlayer track={track} showPlayNext size={30} />}
             <DownloadButton
               type={config.downloadType}
               id={item.id}
@@ -216,7 +227,7 @@ export default function MediaCard({ config, item, onClick, bulkMode, selected, o
           position: 'relative',
         }}
       >
-        {item.has_thumbnail ? (
+        {hasThumbnail ? (
           <img
             src={mediaUrl(config.thumbnailUrl(item.id))}
             alt=""
@@ -225,6 +236,20 @@ export default function MediaCard({ config, item, onClick, bulkMode, selected, o
           />
         ) : (
           <Icon size={32} color="var(--text-muted)" aria-hidden="true" style={{ opacity: 0.4 }} />
+        )}
+        {isAudio && !item.is_missing && (
+          <div
+            style={{
+              position: 'absolute',
+              inset: 0,
+              display: 'flex',
+              alignItems: 'center',
+              justifyContent: 'center',
+              zIndex: 1,
+            }}
+          >
+            <AudioPlayer track={track} />
+          </div>
         )}
         {activeBadges
           .filter((b) => b.corner)

--- a/frontend/src/components/media/MediaCard.test.jsx
+++ b/frontend/src/components/media/MediaCard.test.jsx
@@ -1,0 +1,141 @@
+import { describe, it, expect, vi } from 'vitest'
+import { render, screen } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+import MediaCard from './MediaCard'
+import { MEDIA_CONFIGS } from './mediaConfig'
+
+vi.mock('../../api', () => ({ mediaUrl: (p) => `http://localhost${p}` }))
+vi.mock('../FavoriteButton', () => ({ default: () => <span data-testid="fav" /> }))
+vi.mock('../DownloadButton', () => ({ default: () => <span data-testid="dl" /> }))
+// AudioPlayer controller stub: renders a button when given a track.
+vi.mock('../audio/AudioPlayer', () => ({
+  default: ({ track, showPlayNext }) => (
+    <span data-testid="audio-player">
+      {track?.id}
+      {showPlayNext ? ':next' : ''}
+    </span>
+  ),
+}))
+
+const audioItem = (over = {}) => ({
+  id: 'a1',
+  filename: 'tavern.mp3',
+  title: 'Tavern Night',
+  relative_path: 'audio/Ambient/tavern.mp3',
+  has_artwork: false,
+  is_missing: false,
+  file_size: 1000,
+  tags: [],
+  ...over,
+})
+
+const mapItem = (over = {}) => ({
+  id: 'm1',
+  filename: 'cave.png',
+  relative_path: 'maps/cave.png',
+  has_thumbnail: false,
+  is_missing: false,
+  file_size: 1000,
+  tags: [],
+  ...over,
+})
+
+describe('MediaCard — audio', () => {
+  it('renders an audio player in grid mode', () => {
+    render(<MediaCard config={MEDIA_CONFIGS.audio} item={audioItem()} onClick={vi.fn()} />)
+    expect(screen.getByTestId('audio-player')).toHaveTextContent('a1')
+    expect(screen.getByText('tavern.mp3')).toBeInTheDocument()
+  })
+
+  it('renders an audio player with Play Next in list mode', () => {
+    render(<MediaCard config={MEDIA_CONFIGS.audio} item={audioItem()} onClick={vi.fn()} list />)
+    expect(screen.getByTestId('audio-player')).toHaveTextContent('a1:next')
+  })
+
+  it('hides the player for a missing audio file', () => {
+    render(
+      <MediaCard
+        config={MEDIA_CONFIGS.audio}
+        item={audioItem({ is_missing: true })}
+        onClick={vi.fn()}
+      />
+    )
+    expect(screen.queryByTestId('audio-player')).not.toBeInTheDocument()
+  })
+
+  it('shows artwork when has_artwork is set', () => {
+    const { container } = render(
+      <MediaCard
+        config={MEDIA_CONFIGS.audio}
+        item={audioItem({ has_artwork: true })}
+        onClick={vi.fn()}
+      />
+    )
+    const img = container.querySelector('img')
+    expect(img?.getAttribute('src')).toContain('/audio/a1/artwork')
+  })
+})
+
+describe('MediaCard — map (no audio controls)', () => {
+  it('renders no audio player for a map', () => {
+    render(<MediaCard config={MEDIA_CONFIGS.map} item={mapItem()} onClick={vi.fn()} />)
+    expect(screen.queryByTestId('audio-player')).not.toBeInTheDocument()
+  })
+
+  it('fires onClick when activated', async () => {
+    const onClick = vi.fn()
+    render(<MediaCard config={MEDIA_CONFIGS.map} item={mapItem()} onClick={onClick} />)
+    await userEvent.click(screen.getByText('cave.png'))
+    expect(onClick).toHaveBeenCalled()
+  })
+
+  it('toggles selection in bulk mode instead of opening', async () => {
+    const onClick = vi.fn()
+    const onToggle = vi.fn()
+    render(
+      <MediaCard
+        config={MEDIA_CONFIGS.map}
+        item={mapItem()}
+        onClick={onClick}
+        bulkMode
+        selected={false}
+        onToggle={onToggle}
+      />
+    )
+    await userEvent.click(screen.getByText('cave.png'))
+    expect(onToggle).toHaveBeenCalled()
+    expect(onClick).not.toHaveBeenCalled()
+  })
+
+  it('renders in list mode with a thumbnail', () => {
+    const { container } = render(
+      <MediaCard
+        config={MEDIA_CONFIGS.map}
+        item={mapItem({ has_thumbnail: true })}
+        onClick={vi.fn()}
+        list
+      />
+    )
+    expect(container.querySelector('img')?.getAttribute('src')).toContain('/maps/m1/thumbnail')
+  })
+
+  it('shows the missing badge for a missing item', () => {
+    render(
+      <MediaCard
+        config={MEDIA_CONFIGS.map}
+        item={mapItem({ is_missing: true })}
+        onClick={vi.fn()}
+      />
+    )
+    expect(screen.getByText(/missing/i)).toBeInTheDocument()
+  })
+
+  it('opens on Enter key', async () => {
+    const onClick = vi.fn()
+    render(<MediaCard config={MEDIA_CONFIGS.map} item={mapItem()} onClick={onClick} />)
+    // The focusable card is the role=button element labelled by the filename.
+    screen.getByRole('button', { name: 'cave.png' }).focus()
+    await userEvent.keyboard('{Enter}')
+    expect(onClick).toHaveBeenCalled()
+  })
+})

--- a/frontend/src/components/media/MediaFolderGroup.jsx
+++ b/frontend/src/components/media/MediaFolderGroup.jsx
@@ -1,12 +1,13 @@
 import { useState } from 'react'
 import { useTranslation } from 'react-i18next'
-import { LuFolder, LuChevronDown, LuChevronRight, LuDownload } from 'react-icons/lu'
+import { LuFolder, LuChevronDown, LuChevronRight, LuDownload, LuPlay } from 'react-icons/lu'
 import MediaCard from './MediaCard'
 import FolderTagRow from './FolderTagRow'
 import FolderCheckbox from '../FolderCheckbox'
 import LazyGrid from '../LazyGrid'
 import RescanButton from '../RescanButton'
 import { toTitleCase } from '../../utils'
+import { useAudioPlayer } from '../../context/AudioPlayerContext'
 
 const isMobilePhone = window.matchMedia('(max-width: 640px)').matches
 
@@ -52,10 +53,12 @@ export default function MediaFolderGroup({
 }) {
   const { t } = useTranslation()
   const { i18n, archiveType, countKey } = config
+  const { playQueue } = useAudioPlayer()
   const [editingRoot, setEditingRoot] = useState(false)
   const isCollapsed = collapsed.has(folder)
   const allInGroup = Object.values(subfolders).flat()
   const total = allInGroup.length
+  const isAudio = !!config.audioFileUrl
   const topLevelTags = folderTags[folder] ?? []
 
   const groupFolderChecked =
@@ -150,6 +153,21 @@ export default function MediaFolderGroup({
           <span style={{ fontSize: 14, color: 'var(--text-muted)', flexShrink: 0 }}>
             {t(`${i18n}.${countKey}`, { count: total })}
           </span>
+          {!bulkMode && isAudio && (
+            <button
+              onClick={(e) => {
+                e.stopPropagation()
+                const tracks = allInGroup
+                  .filter((i) => !i.is_missing)
+                  .map((i) => ({ id: i.id, title: i.title || i.filename, artwork: i.has_artwork }))
+                playQueue(tracks)
+              }}
+              style={zipBtnStyle}
+              title={t('audio.playFolder', { folder })}
+            >
+              <LuPlay size={11} /> {t('audio.player.play')}
+            </button>
+          )}
           {!bulkMode && (
             <button
               onClick={(e) => {

--- a/frontend/src/components/media/MediaFolderGroup.mobile.test.jsx
+++ b/frontend/src/components/media/MediaFolderGroup.mobile.test.jsx
@@ -1,0 +1,111 @@
+import { describe, it, expect, vi, beforeAll } from 'vitest'
+import { render, screen } from '@testing-library/react'
+import { MEDIA_CONFIGS } from './mediaConfig'
+
+// `isMobilePhone` is read once at module load, so stub matchMedia to report a
+// phone BEFORE importing the component, then load it dynamically. This exercises
+// the mobile-only branches that the desktop test can't reach.
+vi.mock('../../context/AudioPlayerContext', () => ({
+  useAudioPlayer: () => ({ playQueue: vi.fn() }),
+}))
+vi.mock('../../api', () => ({ mediaUrl: (p) => `http://localhost${p}` }))
+vi.mock('./MediaCard', () => ({ default: ({ item }) => <div>{item.filename}</div> }))
+vi.mock('../LazyGrid', () => ({ default: ({ children }) => <>{children}</> }))
+vi.mock('../RescanButton', () => ({ default: () => null }))
+// Fire the tag-row callbacks so the inline arrow handlers are exercised.
+vi.mock('./FolderTagRow', () => ({
+  default: ({ onEdit, onSave, onCancel }) => (
+    <span data-testid="tag-row">
+      <button data-testid="tr-edit" onClick={onEdit} />
+      <button data-testid="tr-save" onClick={() => onSave?.(['x'])} />
+      <button data-testid="tr-cancel" onClick={onCancel} />
+    </span>
+  ),
+}))
+
+let MediaFolderGroup
+
+beforeAll(async () => {
+  window.matchMedia = vi.fn().mockReturnValue({ matches: true, addListener: vi.fn() })
+  vi.resetModules()
+  MediaFolderGroup = (await import('./MediaFolderGroup')).default
+})
+
+const baseProps = {
+  collapsed: new Set(),
+  onToggle: vi.fn(),
+  folderTags: {},
+  editingFolder: null,
+  onSetEditingFolder: vi.fn(),
+  onSaveFolderTags: vi.fn(),
+  onSelectItem: vi.fn(),
+  bulkMode: false,
+  selectedIds: new Set(),
+  selectedFolderPaths: new Set(),
+  onToggleItem: vi.fn(),
+  onToggleFolder: vi.fn(),
+  onDownload: vi.fn(),
+}
+
+describe('MediaFolderGroup (mobile branches)', () => {
+  it('renders mobile tag rows for a folder with a subfolder', () => {
+    render(
+      <MediaFolderGroup
+        config={MEDIA_CONFIGS.map}
+        folder="Dungeons"
+        subfolders={{
+          '': [{ id: 'm1', filename: 'root.png' }],
+          caves: [{ id: 'm2', filename: 'cave.png' }],
+        }}
+        {...baseProps}
+      />
+    )
+    expect(screen.getByText('root.png')).toBeInTheDocument()
+    expect(screen.getByText('cave.png')).toBeInTheDocument()
+    // Mobile renders the tag rows under the (expanded) folder/subfolder.
+    expect(screen.getAllByTestId('tag-row').length).toBeGreaterThan(0)
+  })
+
+  it('fires the mobile tag-row edit/save/cancel callbacks', async () => {
+    const onSaveFolderTags = vi.fn()
+    const { default: userEvent } = await import('@testing-library/user-event')
+    render(
+      <MediaFolderGroup
+        config={MEDIA_CONFIGS.map}
+        folder="Dungeons"
+        subfolders={{ caves: [{ id: 'm2', filename: 'cave.png' }] }}
+        {...baseProps}
+        onSaveFolderTags={onSaveFolderTags}
+      />
+    )
+    const edits = screen.getAllByTestId('tr-edit')
+    await userEvent.click(edits[0])
+    const saves = screen.getAllByTestId('tr-save')
+    await userEvent.click(saves[0])
+    expect(onSaveFolderTags).toHaveBeenCalled()
+    const cancels = screen.getAllByTestId('tr-cancel')
+    await userEvent.click(cancels[0])
+  })
+
+  it('fires mobile subfolder tag save/cancel when that subfolder is editing', async () => {
+    const onSaveFolderTags = vi.fn()
+    const onSetEditingFolder = vi.fn()
+    const { default: userEvent } = await import('@testing-library/user-event')
+    render(
+      <MediaFolderGroup
+        config={MEDIA_CONFIGS.map}
+        folder="Dungeons"
+        subfolders={{ caves: [{ id: 'm2', filename: 'cave.png' }] }}
+        {...baseProps}
+        editingFolder="Dungeons::caves"
+        onSaveFolderTags={onSaveFolderTags}
+        onSetEditingFolder={onSetEditingFolder}
+      />
+    )
+    // The editing subfolder row exposes save + cancel.
+    await userEvent.click(screen.getAllByTestId('tr-save').at(-1))
+    expect(onSaveFolderTags).toHaveBeenCalledWith('Dungeons/caves', ['x'])
+    await userEvent.click(screen.getAllByTestId('tr-cancel').at(-1))
+    expect(onSetEditingFolder).toHaveBeenCalledWith(null)
+  })
+})

--- a/frontend/src/components/media/MediaFolderGroup.test.jsx
+++ b/frontend/src/components/media/MediaFolderGroup.test.jsx
@@ -1,0 +1,248 @@
+import { describe, it, expect, vi } from 'vitest'
+import { render, screen } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+import MediaFolderGroup from './MediaFolderGroup'
+import { MEDIA_CONFIGS } from './mediaConfig'
+
+const playQueue = vi.fn()
+vi.mock('../../context/AudioPlayerContext', () => ({
+  useAudioPlayer: () => ({ playQueue }),
+}))
+vi.mock('../../api', () => ({ mediaUrl: (p) => `http://localhost${p}` }))
+vi.mock('./MediaCard', () => ({ default: ({ item }) => <div>{item.filename}</div> }))
+vi.mock('../LazyGrid', () => ({ default: ({ children }) => <>{children}</> }))
+vi.mock('../RescanButton', () => ({ default: () => <span data-testid="rescan" /> }))
+// Real-ish FolderTagRow: exposes its edit + save affordances so the editing
+// branches of the folder group are exercised.
+vi.mock('./FolderTagRow', () => ({
+  default: ({ editing, onEdit, onSave, onCancel }) =>
+    editing ? (
+      <span>
+        <button data-testid="save-folder-tags" onClick={() => onSave(['t'])}>
+          save
+        </button>
+        <button data-testid="cancel-folder-tags" onClick={onCancel}>
+          cancel
+        </button>
+      </span>
+    ) : (
+      <button data-testid="edit-folder-tags" onClick={onEdit}>
+        edit
+      </button>
+    ),
+}))
+
+const baseProps = (over = {}) => ({
+  collapsed: new Set(),
+  onToggle: vi.fn(),
+  folderTags: {},
+  editingFolder: null,
+  onSetEditingFolder: vi.fn(),
+  onSaveFolderTags: vi.fn(),
+  onSelectItem: vi.fn(),
+  bulkMode: false,
+  selectedIds: new Set(),
+  selectedFolderPaths: new Set(),
+  onToggleItem: vi.fn(),
+  onToggleFolder: vi.fn(),
+  onDownload: vi.fn(),
+  ...over,
+})
+
+const audioItems = [
+  { id: 'a1', filename: 't1.mp3', title: 'One', has_artwork: false, is_missing: false },
+  { id: 'a2', filename: 't2.mp3', title: 'Two', has_artwork: true, is_missing: false },
+  { id: 'a3', filename: 'missing.mp3', title: 'Gone', is_missing: true },
+]
+
+describe('MediaFolderGroup — audio', () => {
+  it('shows a Play button that queues non-missing tracks', async () => {
+    render(
+      <MediaFolderGroup
+        config={MEDIA_CONFIGS.audio}
+        folder="Ambient"
+        subfolders={{ '': audioItems }}
+        {...baseProps()}
+      />
+    )
+    const playBtn = screen.getByTitle(/play ambient/i)
+    await userEvent.click(playBtn)
+    expect(playQueue).toHaveBeenCalledTimes(1)
+    const queued = playQueue.mock.calls[0][0]
+    // The missing track is excluded.
+    expect(queued.map((t) => t.id)).toEqual(['a1', 'a2'])
+  })
+
+  it('does not show a Play button for a non-audio gallery (maps)', () => {
+    render(
+      <MediaFolderGroup
+        config={MEDIA_CONFIGS.map}
+        folder="Dungeons"
+        subfolders={{ '': [{ id: 'm1', filename: 'm.png' }] }}
+        {...baseProps()}
+      />
+    )
+    expect(screen.queryByTitle(/^play /i)).not.toBeInTheDocument()
+  })
+
+  it('renders named subfolders and their items', () => {
+    render(
+      <MediaFolderGroup
+        config={MEDIA_CONFIGS.map}
+        folder="Dungeons"
+        subfolders={{
+          '': [{ id: 'm1', filename: 'root.png' }],
+          caves: [{ id: 'm2', filename: 'cave.png' }],
+        }}
+        {...baseProps()}
+      />
+    )
+    expect(screen.getByText('root.png')).toBeInTheDocument()
+    expect(screen.getByText('cave.png')).toBeInTheDocument()
+    // The subfolder name is shown (title-cased).
+    expect(screen.getByText(/caves/i)).toBeInTheDocument()
+  })
+
+  it('fires onDownload when the folder download button is clicked', async () => {
+    const onDownload = vi.fn()
+    render(
+      <MediaFolderGroup
+        config={MEDIA_CONFIGS.map}
+        folder="Dungeons"
+        subfolders={{ '': [{ id: 'm1', filename: 'm.png' }] }}
+        {...baseProps({ onDownload })}
+      />
+    )
+    await userEvent.click(screen.getByTitle(/download all maps/i))
+    expect(onDownload).toHaveBeenCalled()
+  })
+
+  it('collapses when the header toggle is clicked', async () => {
+    const onToggle = vi.fn()
+    render(
+      <MediaFolderGroup
+        config={MEDIA_CONFIGS.map}
+        folder="Dungeons"
+        subfolders={{ '': [{ id: 'm1', filename: 'm.png' }] }}
+        {...baseProps({ onToggle })}
+      />
+    )
+    await userEvent.click(screen.getByRole('button', { name: /collapse dungeons/i }))
+    expect(onToggle).toHaveBeenCalledWith('Dungeons')
+  })
+
+  it('renders in bulk mode without the download/play controls', () => {
+    render(
+      <MediaFolderGroup
+        config={MEDIA_CONFIGS.audio}
+        folder="Ambient"
+        subfolders={{ '': [{ id: 'a1', filename: 't.mp3', is_missing: false }] }}
+        {...baseProps({ bulkMode: true })}
+      />
+    )
+    // In bulk mode the folder download + play buttons are hidden.
+    expect(screen.queryByTitle(/^play /i)).not.toBeInTheDocument()
+    expect(screen.queryByTitle(/download all/i)).not.toBeInTheDocument()
+    // The folder name still renders.
+    expect(screen.getByText(/ambient/i)).toBeInTheDocument()
+  })
+
+  it('downloads a named subfolder via its download button', async () => {
+    const onDownload = vi.fn()
+    render(
+      <MediaFolderGroup
+        config={MEDIA_CONFIGS.map}
+        folder="Dungeons"
+        subfolders={{ caves: [{ id: 'm2', filename: 'cave.png' }] }}
+        {...baseProps({ onDownload })}
+      />
+    )
+    await userEvent.click(screen.getByTitle(/download maps in caves/i))
+    expect(onDownload).toHaveBeenCalledWith(
+      expect.objectContaining({ params: expect.objectContaining({ folder: 'Dungeons/caves' }) })
+    )
+  })
+
+  it('collapses a subfolder when its toggle is clicked', async () => {
+    const onToggle = vi.fn()
+    render(
+      <MediaFolderGroup
+        config={MEDIA_CONFIGS.map}
+        folder="Dungeons"
+        subfolders={{ caves: [{ id: 'm2', filename: 'cave.png' }] }}
+        {...baseProps({ onToggle })}
+      />
+    )
+    await userEvent.click(screen.getByRole('button', { name: /collapse caves/i }))
+    expect(onToggle).toHaveBeenCalledWith('Dungeons::caves')
+  })
+
+  it('edits root folder tags', async () => {
+    const onSaveFolderTags = vi.fn()
+    render(
+      <MediaFolderGroup
+        config={MEDIA_CONFIGS.map}
+        folder="Dungeons"
+        subfolders={{ '': [{ id: 'm1', filename: 'm.png' }] }}
+        {...baseProps({ onSaveFolderTags })}
+      />
+    )
+    await userEvent.click(screen.getAllByTestId('edit-folder-tags')[0])
+    await userEvent.click(screen.getByTestId('save-folder-tags'))
+    expect(onSaveFolderTags).toHaveBeenCalledWith('Dungeons', ['t'])
+  })
+
+  it('starts editing a subfolder tag row', async () => {
+    const onSetEditingFolder = vi.fn()
+    render(
+      <MediaFolderGroup
+        config={MEDIA_CONFIGS.map}
+        folder="Dungeons"
+        subfolders={{ caves: [{ id: 'm2', filename: 'cave.png' }] }}
+        {...baseProps({ onSetEditingFolder })}
+      />
+    )
+    // Click the subfolder's (non-editing) tag-row edit affordance.
+    const edits = screen.getAllByTestId('edit-folder-tags')
+    await userEvent.click(edits[edits.length - 1])
+    expect(onSetEditingFolder).toHaveBeenCalledWith('Dungeons::caves')
+  })
+
+  it('saves and cancels a subfolder tag edit via editingFolder', async () => {
+    const onSaveFolderTags = vi.fn()
+    const onSetEditingFolder = vi.fn()
+    render(
+      <MediaFolderGroup
+        config={MEDIA_CONFIGS.map}
+        folder="Dungeons"
+        subfolders={{ caves: [{ id: 'm2', filename: 'cave.png' }] }}
+        {...baseProps({
+          editingFolder: 'Dungeons::caves',
+          onSaveFolderTags,
+          onSetEditingFolder,
+        })}
+      />
+    )
+    await userEvent.click(screen.getByTestId('save-folder-tags'))
+    expect(onSaveFolderTags).toHaveBeenCalledWith('Dungeons/caves', ['t'])
+    await userEvent.click(screen.getByTestId('cancel-folder-tags'))
+    expect(onSetEditingFolder).toHaveBeenCalledWith(null)
+  })
+
+  it('plays an audio folder including its subfolder tracks', async () => {
+    render(
+      <MediaFolderGroup
+        config={MEDIA_CONFIGS.audio}
+        folder="Ambient"
+        subfolders={{
+          '': [{ id: 'a1', filename: 't1.mp3', is_missing: false }],
+          battle: [{ id: 'a2', filename: 't2.mp3', is_missing: false }],
+        }}
+        {...baseProps()}
+      />
+    )
+    await userEvent.click(screen.getByTitle(/play ambient/i))
+    const queued = playQueue.mock.calls[0][0].map((t) => t.id)
+    expect(queued).toEqual(['a1', 'a2'])
+  })
+})

--- a/frontend/src/components/media/mediaConfig.js
+++ b/frontend/src/components/media/mediaConfig.js
@@ -1,4 +1,4 @@
-import { LuMap, LuUser } from 'react-icons/lu'
+import { LuMap, LuUser, LuMusic } from 'react-icons/lu'
 
 /**
  * Per-entity configuration for the shared media gallery components (MediaCard,
@@ -89,6 +89,41 @@ export const MEDIA_CONFIGS = {
       },
     ],
     titleFontSize: 13,
+    listIcon: { width: 40, height: 40 },
+  },
+  audio: {
+    type: 'audio',
+    collection: 'audio',
+    i18n: 'audio',
+    countKey: 'audioCount',
+    emptyFilterKey: 'noAudioFilter',
+    emptyKey: 'noAudio',
+    icon: LuMusic,
+    listUrl: '/audio',
+    foldersUrl: '/audio-folders',
+    itemUrl: (id) => `/audio/${id}`,
+    // Audio uses folder/embedded artwork in place of a generated thumbnail.
+    thumbnailUrl: (id) => `/audio/${id}/artwork`,
+    thumbnailFlag: 'has_artwork',
+    detailPath: (id) => `/audio/${id}`,
+    downloadType: 'audio',
+    archiveType: 'audio_folder',
+    sessionKey: 'grimoire:audio:collapsed',
+    gridMin: { comfortable: '200px', compact: '140px' },
+    gridGap: 16,
+    thumb: { kind: 'square' },
+    // Inline play/pause button overlaid on the card artwork.
+    audioFileUrl: (id) => `/audio/${id}/file`,
+    badges: [
+      {
+        flag: 'is_missing',
+        label: 'missing',
+        color: 'rgba(200,134,10,0.9)',
+        corner: 'bottom-left',
+        inlineColor: '#c8860a',
+      },
+    ],
+    titleFontSize: 14,
     listIcon: { width: 40, height: 40 },
   },
 }

--- a/frontend/src/components/media/mediaConfig.test.js
+++ b/frontend/src/components/media/mediaConfig.test.js
@@ -1,0 +1,58 @@
+import { describe, it, expect } from 'vitest'
+import { MEDIA_CONFIGS, getFolderPath, getTopFolder, getSubPath } from './mediaConfig'
+
+describe('MEDIA_CONFIGS', () => {
+  it('defines map, token, and audio configs', () => {
+    expect(MEDIA_CONFIGS.map.type).toBe('map')
+    expect(MEDIA_CONFIGS.token.type).toBe('token')
+    expect(MEDIA_CONFIGS.audio.type).toBe('audio')
+  })
+
+  it('audio config exposes file/artwork urls and an artwork thumbnail flag', () => {
+    const a = MEDIA_CONFIGS.audio
+    expect(a.audioFileUrl('x')).toBe('/audio/x/file')
+    expect(a.thumbnailUrl('x')).toBe('/audio/x/artwork')
+    expect(a.thumbnailFlag).toBe('has_artwork')
+    expect(a.itemUrl('x')).toBe('/audio/x')
+    expect(a.detailPath('x')).toBe('/audio/x')
+    expect(a.archiveType).toBe('audio_folder')
+  })
+
+  it('map/token configs have no audioFileUrl', () => {
+    expect(MEDIA_CONFIGS.map.audioFileUrl).toBeUndefined()
+    expect(MEDIA_CONFIGS.token.audioFileUrl).toBeUndefined()
+  })
+
+  it('map and token url builders produce the expected paths', () => {
+    const m = MEDIA_CONFIGS.map
+    expect(m.itemUrl('x')).toBe('/maps/x')
+    expect(m.thumbnailUrl('x')).toBe('/maps/x/thumbnail')
+    expect(m.detailPath('x')).toBe('/maps/x')
+    const tk = MEDIA_CONFIGS.token
+    expect(tk.itemUrl('y')).toBe('/tokens/y')
+    expect(tk.thumbnailUrl('y')).toBe('/tokens/y/thumbnail')
+    expect(tk.detailPath('y')).toBe('/tokens/y')
+  })
+})
+
+describe('folder path helpers', () => {
+  const item = (rp) => ({ relative_path: rp })
+
+  it('getFolderPath drops the collection prefix and filename', () => {
+    expect(getFolderPath(item('audio/Ambient/Sub/track.mp3'))).toBe('Ambient/Sub')
+  })
+
+  it('getTopFolder returns the first folder or (Root)', () => {
+    expect(getTopFolder(item('audio/Ambient/track.mp3'))).toBe('Ambient')
+    expect(getTopFolder(item('audio/track.mp3'))).toBe('(Root)')
+  })
+
+  it('getSubPath returns the path below the top folder', () => {
+    expect(getSubPath(item('audio/Ambient/Sub/track.mp3'))).toBe('Sub')
+    expect(getSubPath(item('audio/Ambient/track.mp3'))).toBe('')
+  })
+
+  it('handles backslash separators', () => {
+    expect(getTopFolder(item('audio\\Ambient\\track.mp3'))).toBe('Ambient')
+  })
+})

--- a/frontend/src/components/settings/SidebarVisibilitySection.jsx
+++ b/frontend/src/components/settings/SidebarVisibilitySection.jsx
@@ -13,6 +13,7 @@ export default function SidebarVisibilitySection() {
   const VISIBILITY_ITEMS = [
     { key: 'hide_maps', label: t('appSettings.sidebarVisibility.hideMaps') },
     { key: 'hide_tokens', label: t('appSettings.sidebarVisibility.hideTokens') },
+    { key: 'hide_audio', label: t('appSettings.sidebarVisibility.hideAudio') },
     { key: 'hide_campaigns', label: t('appSettings.sidebarVisibility.hideCampaigns') },
   ]
 
@@ -23,10 +24,18 @@ export default function SidebarVisibilitySection() {
         setValues({
           hide_maps: d.hide_maps,
           hide_tokens: d.hide_tokens,
+          hide_audio: d.hide_audio,
           hide_campaigns: d.hide_campaigns,
         })
       )
-      .catch(() => setValues({ hide_maps: false, hide_tokens: false, hide_campaigns: false }))
+      .catch(() =>
+        setValues({
+          hide_maps: false,
+          hide_tokens: false,
+          hide_audio: false,
+          hide_campaigns: false,
+        })
+      )
   }, [])
 
   const toggle = async (key) => {

--- a/frontend/src/context/AudioPlayerContext.jsx
+++ b/frontend/src/context/AudioPlayerContext.jsx
@@ -1,0 +1,329 @@
+import { createContext, useContext, useRef, useState, useCallback, useEffect } from 'react'
+import api from '../api'
+import useSessionState from '../hooks/useSessionState'
+
+const AudioPlayerContext = createContext(null)
+
+// A track ref is the minimal shape we need to play + display a queue entry:
+//   { id, title?, artist?, artwork? }
+// The audio file URL is derived from `id` at play time, so only the id is
+// required. Entries added with just an id (campaign resources, note embeds) are
+// lazily hydrated from GET /audio/:id so the player/queue show a rich label.
+
+// A track needs hydrating only if it has an id but no display title yet and we
+// haven't already resolved (or failed) a fetch for it. Tracks added with a
+// title/artist (gallery, detail view) are already rich and never fetched.
+const needsHydration = (t) => t && t.id && !t.title && !t._hydrated
+
+/**
+ * Owns the single app-wide <audio> element (via `audioRef`, attached by
+ * GlobalAudioPlayer) and the playback queue. Every play button in the app is a
+ * thin controller that calls these actions instead of owning its own audio.
+ *
+ * Queue, current index, and repeat mode persist across in-session navigation
+ * (sessionStorage) and reset on a hard refresh. Playback state (isPlaying,
+ * currentTime) is ephemeral and driven by the <audio> element's events.
+ */
+export function AudioPlayerProvider({ children }) {
+  const audioRef = useRef(null)
+
+  const [queue, setQueue] = useSessionState('grimoire:audio:queue', [])
+  const [currentIndex, setCurrentIndex] = useSessionState('grimoire:audio:index', -1)
+  const [repeatOne, setRepeatOne] = useSessionState('grimoire:audio:repeatOne', false)
+
+  const [isPlaying, setIsPlaying] = useState(false)
+  const [currentTime, setCurrentTime] = useState(0)
+  const [duration, setDuration] = useState(0)
+  const [expanded, setExpanded] = useState(false)
+
+  const currentTrack = currentIndex >= 0 ? queue[currentIndex] : null
+
+  // When the current track changes, the GlobalAudioPlayer reloads the <audio>
+  // src; we (re)start playback for any index >= 0. A request flag tells the
+  // player to call play() once the new src is ready.
+  const playRequested = useRef(false)
+
+  const playQueue = useCallback(
+    (tracks, startIndex = 0) => {
+      const list = (tracks || []).filter((t) => t && t.id)
+      if (list.length === 0) return
+      const idx = Math.min(Math.max(startIndex, 0), list.length - 1)
+      setQueue(list)
+      setCurrentIndex(idx)
+      playRequested.current = true
+      setExpanded(false)
+    },
+    [setQueue, setCurrentIndex]
+  )
+
+  const playNext = useCallback(
+    (track) => {
+      if (!track || !track.id) return
+      setQueue((prev) => {
+        if (prev.length === 0) {
+          // Nothing playing — start this track immediately.
+          setCurrentIndex(0)
+          playRequested.current = true
+          return [track]
+        }
+        const next = [...prev]
+        next.splice(currentIndex + 1, 0, track)
+        return next
+      })
+    },
+    [currentIndex, setQueue, setCurrentIndex]
+  )
+
+  const addToQueue = useCallback(
+    (track) => {
+      if (!track || !track.id) return
+      setQueue((prev) => {
+        if (prev.length === 0) {
+          setCurrentIndex(0)
+          playRequested.current = true
+          return [track]
+        }
+        return [...prev, track]
+      })
+    },
+    [setQueue, setCurrentIndex]
+  )
+
+  const next = useCallback(() => {
+    setCurrentIndex((i) => {
+      if (i < queue.length - 1) {
+        playRequested.current = true
+        return i + 1
+      }
+      // End of queue — stop.
+      playRequested.current = false
+      const el = audioRef.current
+      if (el) el.pause()
+      setIsPlaying(false)
+      return i
+    })
+  }, [queue.length, setCurrentIndex])
+
+  const prev = useCallback(() => {
+    const el = audioRef.current
+    // If we're more than ~3s into the track, restart it instead of going back.
+    if (el && el.currentTime > 3) {
+      el.currentTime = 0
+      return
+    }
+    setCurrentIndex((i) => {
+      if (i > 0) {
+        playRequested.current = true
+        return i - 1
+      }
+      return i
+    })
+  }, [setCurrentIndex])
+
+  const togglePlay = useCallback(() => {
+    const el = audioRef.current
+    if (!el || currentIndex < 0) return
+    if (el.paused) {
+      el.play().catch(() => {})
+    } else {
+      el.pause()
+    }
+  }, [currentIndex])
+
+  const toggleRepeat = useCallback(() => setRepeatOne((r) => !r), [setRepeatOne])
+
+  const seek = useCallback((t) => {
+    const el = audioRef.current
+    if (el && Number.isFinite(t)) el.currentTime = t
+  }, [])
+
+  const removeAt = useCallback(
+    (index) => {
+      setQueue((prev) => {
+        const nextQueue = prev.filter((_, i) => i !== index)
+        setCurrentIndex((ci) => {
+          if (nextQueue.length === 0) return -1
+          if (index < ci) return ci - 1
+          if (index === ci) {
+            // Removed the current track: keep the same slot (now the next track),
+            // clamped to the new bounds, and request playback of it.
+            playRequested.current = true
+            return Math.min(ci, nextQueue.length - 1)
+          }
+          return ci
+        })
+        return nextQueue
+      })
+    },
+    [setQueue, setCurrentIndex]
+  )
+
+  const jumpTo = useCallback(
+    (index) => {
+      if (index < 0 || index >= queue.length) return
+      playRequested.current = true
+      setCurrentIndex(index)
+    },
+    [queue.length, setCurrentIndex]
+  )
+
+  // Reorder the queue by moving the track at `from` to `to`, keeping the
+  // currently-playing track selected (no remove/re-add, so playback continues).
+  const moveTrack = useCallback(
+    (from, to) => {
+      setQueue((prev) => {
+        if (from === to || from < 0 || to < 0 || from >= prev.length || to >= prev.length)
+          return prev
+        const next = [...prev]
+        const [moved] = next.splice(from, 1)
+        next.splice(to, 0, moved)
+        // Keep currentIndex pointing at the same (still-playing) track.
+        setCurrentIndex((ci) => {
+          if (ci === from) return to
+          // A track moved across the current slot shifts it by one.
+          if (from < ci && to >= ci) return ci - 1
+          if (from > ci && to <= ci) return ci + 1
+          return ci
+        })
+        return next
+      })
+    },
+    [setQueue, setCurrentIndex]
+  )
+
+  const clear = useCallback(() => {
+    const el = audioRef.current
+    if (el) el.pause()
+    setQueue([])
+    setCurrentIndex(-1)
+    setIsPlaying(false)
+    setExpanded(false)
+  }, [setQueue, setCurrentIndex])
+
+  const toggleExpanded = useCallback(() => setExpanded((e) => !e), [])
+
+  const isCurrent = useCallback((id) => currentTrack?.id === id, [currentTrack])
+  const isPlayingId = useCallback(
+    (id) => isPlaying && currentTrack?.id === id,
+    [isPlaying, currentTrack]
+  )
+
+  // If the persisted index points past the end of a (restored) queue, reset it.
+  useEffect(() => {
+    if (currentIndex >= queue.length) setCurrentIndex(queue.length - 1)
+  }, [queue.length, currentIndex, setCurrentIndex])
+
+  // Lazily hydrate queue entries that were added with only an id (campaign
+  // resources, note embeds) so the player/queue show title + artwork. Each id is
+  // fetched at most once; results patch every matching entry still in the queue.
+  const hydratingIds = useRef(new Set())
+  useEffect(() => {
+    const pending = queue.filter((t) => needsHydration(t) && !hydratingIds.current.has(t.id))
+    if (pending.length === 0) return
+    const ids = [...new Set(pending.map((t) => t.id))]
+    ids.forEach((id) => hydratingIds.current.add(id))
+    ids.forEach((id) => {
+      api
+        .get(`/audio/${id}`)
+        .then((data) => {
+          setQueue((prev) =>
+            prev.map((t) =>
+              t.id === id
+                ? {
+                    ...t,
+                    title: t.title || data.title || data.filename,
+                    artist: t.artist || data.artist || '',
+                    artwork: t.artwork || !!data.has_artwork,
+                    _hydrated: true,
+                  }
+                : t
+            )
+          )
+        })
+        .catch(() => {
+          // Mark resolved-with-no-metadata so we don't keep retrying a bad id.
+          setQueue((prev) => prev.map((t) => (t.id === id ? { ...t, _hydrated: true } : t)))
+        })
+        .finally(() => {
+          hydratingIds.current.delete(id)
+        })
+    })
+  }, [queue, setQueue])
+
+  const value = {
+    audioRef,
+    playRequested,
+    queue,
+    currentIndex,
+    currentTrack,
+    isPlaying,
+    setIsPlaying,
+    currentTime,
+    setCurrentTime,
+    duration,
+    setDuration,
+    repeatOne,
+    expanded,
+    // actions
+    playQueue,
+    playNext,
+    addToQueue,
+    next,
+    prev,
+    togglePlay,
+    toggleRepeat,
+    seek,
+    removeAt,
+    jumpTo,
+    moveTrack,
+    clear,
+    toggleExpanded,
+    // selectors
+    isCurrent,
+    isPlayingId,
+  }
+
+  return <AudioPlayerContext.Provider value={value}>{children}</AudioPlayerContext.Provider>
+}
+
+export function useAudioPlayer() {
+  const ctx = useContext(AudioPlayerContext)
+  if (!ctx) {
+    // A no-op fallback keeps controllers safe to render outside the provider
+    // (e.g. in isolated component tests that don't wrap with the provider).
+    return NOOP_PLAYER
+  }
+  return ctx
+}
+
+const NOOP = () => {}
+const NOOP_PLAYER = {
+  audioRef: { current: null },
+  playRequested: { current: false },
+  queue: [],
+  currentIndex: -1,
+  currentTrack: null,
+  isPlaying: false,
+  setIsPlaying: NOOP,
+  currentTime: 0,
+  setCurrentTime: NOOP,
+  duration: 0,
+  setDuration: NOOP,
+  repeatOne: false,
+  expanded: false,
+  playQueue: NOOP,
+  playNext: NOOP,
+  addToQueue: NOOP,
+  next: NOOP,
+  prev: NOOP,
+  togglePlay: NOOP,
+  toggleRepeat: NOOP,
+  seek: NOOP,
+  removeAt: NOOP,
+  jumpTo: NOOP,
+  moveTrack: NOOP,
+  clear: NOOP,
+  toggleExpanded: NOOP,
+  isCurrent: () => false,
+  isPlayingId: () => false,
+}

--- a/frontend/src/context/AudioPlayerContext.test.jsx
+++ b/frontend/src/context/AudioPlayerContext.test.jsx
@@ -1,0 +1,182 @@
+import { describe, it, expect, beforeEach, vi } from 'vitest'
+import { renderHook, act, waitFor } from '@testing-library/react'
+import { AudioPlayerProvider, useAudioPlayer } from './AudioPlayerContext'
+import api from '../api'
+
+vi.mock('../api', () => ({ default: { get: vi.fn() } }))
+
+const wrapper = ({ children }) => <AudioPlayerProvider>{children}</AudioPlayerProvider>
+
+const tracks = (...ids) => ids.map((id) => ({ id, title: `Track ${id}` }))
+
+describe('AudioPlayerContext', () => {
+  beforeEach(() => {
+    sessionStorage.clear()
+    vi.clearAllMocks()
+    api.get.mockResolvedValue({})
+  })
+
+  it('playQueue replaces the queue and starts at index 0', () => {
+    const { result } = renderHook(() => useAudioPlayer(), { wrapper })
+    act(() => result.current.playQueue(tracks('a', 'b', 'c')))
+    expect(result.current.queue.map((t) => t.id)).toEqual(['a', 'b', 'c'])
+    expect(result.current.currentIndex).toBe(0)
+    expect(result.current.currentTrack.id).toBe('a')
+  })
+
+  it('playQueue can start at a given index', () => {
+    const { result } = renderHook(() => useAudioPlayer(), { wrapper })
+    act(() => result.current.playQueue(tracks('a', 'b', 'c'), 2))
+    expect(result.current.currentIndex).toBe(2)
+    expect(result.current.currentTrack.id).toBe('c')
+  })
+
+  it('playQueue ignores empty / invalid input', () => {
+    const { result } = renderHook(() => useAudioPlayer(), { wrapper })
+    act(() => result.current.playQueue([]))
+    act(() => result.current.playQueue([{ title: 'no id' }]))
+    expect(result.current.queue).toEqual([])
+    expect(result.current.currentIndex).toBe(-1)
+  })
+
+  it('playNext inserts right after the current track', () => {
+    const { result } = renderHook(() => useAudioPlayer(), { wrapper })
+    act(() => result.current.playQueue(tracks('a', 'b', 'c')))
+    act(() => result.current.playNext({ id: 'x', title: 'X' }))
+    expect(result.current.queue.map((t) => t.id)).toEqual(['a', 'x', 'b', 'c'])
+    // current track unchanged
+    expect(result.current.currentTrack.id).toBe('a')
+  })
+
+  it('playNext on an empty queue starts playing the track', () => {
+    const { result } = renderHook(() => useAudioPlayer(), { wrapper })
+    act(() => result.current.playNext({ id: 'solo' }))
+    expect(result.current.queue.map((t) => t.id)).toEqual(['solo'])
+    expect(result.current.currentIndex).toBe(0)
+  })
+
+  it('addToQueue appends to the end', () => {
+    const { result } = renderHook(() => useAudioPlayer(), { wrapper })
+    act(() => result.current.playQueue(tracks('a')))
+    act(() => result.current.addToQueue({ id: 'b' }))
+    expect(result.current.queue.map((t) => t.id)).toEqual(['a', 'b'])
+  })
+
+  it('next advances and stops at the end of the queue', () => {
+    const { result } = renderHook(() => useAudioPlayer(), { wrapper })
+    act(() => result.current.playQueue(tracks('a', 'b')))
+    act(() => result.current.next())
+    expect(result.current.currentIndex).toBe(1)
+    act(() => result.current.next())
+    // No repeat-all: clamps at the last index.
+    expect(result.current.currentIndex).toBe(1)
+  })
+
+  it('jumpTo selects a queue position', () => {
+    const { result } = renderHook(() => useAudioPlayer(), { wrapper })
+    act(() => result.current.playQueue(tracks('a', 'b', 'c')))
+    act(() => result.current.jumpTo(2))
+    expect(result.current.currentTrack.id).toBe('c')
+  })
+
+  it('removeAt before current shifts the index down', () => {
+    const { result } = renderHook(() => useAudioPlayer(), { wrapper })
+    act(() => result.current.playQueue(tracks('a', 'b', 'c'), 2))
+    act(() => result.current.removeAt(0))
+    expect(result.current.queue.map((t) => t.id)).toEqual(['b', 'c'])
+    expect(result.current.currentTrack.id).toBe('c')
+  })
+
+  it('removeAt the current track advances to the next in its slot', () => {
+    const { result } = renderHook(() => useAudioPlayer(), { wrapper })
+    act(() => result.current.playQueue(tracks('a', 'b', 'c'), 1))
+    act(() => result.current.removeAt(1))
+    expect(result.current.queue.map((t) => t.id)).toEqual(['a', 'c'])
+    // Same slot, now holding 'c'.
+    expect(result.current.currentTrack.id).toBe('c')
+  })
+
+  it('toggleRepeat flips repeatOne', () => {
+    const { result } = renderHook(() => useAudioPlayer(), { wrapper })
+    expect(result.current.repeatOne).toBe(false)
+    act(() => result.current.toggleRepeat())
+    expect(result.current.repeatOne).toBe(true)
+  })
+
+  it('clear empties the queue', () => {
+    const { result } = renderHook(() => useAudioPlayer(), { wrapper })
+    act(() => result.current.playQueue(tracks('a', 'b')))
+    act(() => result.current.clear())
+    expect(result.current.queue).toEqual([])
+    expect(result.current.currentIndex).toBe(-1)
+    expect(result.current.currentTrack).toBe(null)
+  })
+
+  it('isCurrent / isPlayingId reflect the active track', () => {
+    const { result } = renderHook(() => useAudioPlayer(), { wrapper })
+    act(() => result.current.playQueue(tracks('a', 'b')))
+    expect(result.current.isCurrent('a')).toBe(true)
+    expect(result.current.isCurrent('b')).toBe(false)
+    // isPlayingId requires isPlaying, which is driven by the <audio> element.
+    expect(result.current.isPlayingId('a')).toBe(false)
+  })
+
+  describe('moveTrack', () => {
+    it('reorders a track and keeps the current one selected', () => {
+      const { result } = renderHook(() => useAudioPlayer(), { wrapper })
+      act(() => result.current.playQueue(tracks('a', 'b', 'c'), 0))
+      // Move 'c' (index 2) to the front (index 0); current 'a' shifts to index 1.
+      act(() => result.current.moveTrack(2, 0))
+      expect(result.current.queue.map((t) => t.id)).toEqual(['c', 'a', 'b'])
+      expect(result.current.currentTrack.id).toBe('a')
+    })
+
+    it('moving the current track follows it', () => {
+      const { result } = renderHook(() => useAudioPlayer(), { wrapper })
+      act(() => result.current.playQueue(tracks('a', 'b', 'c'), 0))
+      act(() => result.current.moveTrack(0, 2))
+      expect(result.current.queue.map((t) => t.id)).toEqual(['b', 'c', 'a'])
+      expect(result.current.currentTrack.id).toBe('a')
+    })
+
+    it('is a no-op for out-of-range or identical indices', () => {
+      const { result } = renderHook(() => useAudioPlayer(), { wrapper })
+      act(() => result.current.playQueue(tracks('a', 'b')))
+      act(() => result.current.moveTrack(0, 0))
+      act(() => result.current.moveTrack(0, 5))
+      expect(result.current.queue.map((t) => t.id)).toEqual(['a', 'b'])
+    })
+  })
+
+  describe('lazy hydration', () => {
+    it('fetches metadata for id-only tracks and patches the queue', async () => {
+      api.get.mockResolvedValue({
+        title: 'Mystic Drone',
+        artist: 'Bardcore',
+        has_artwork: true,
+      })
+      const { result } = renderHook(() => useAudioPlayer(), { wrapper })
+      act(() => result.current.playQueue([{ id: 'x1' }]))
+      await waitFor(() => expect(result.current.queue[0].title).toBe('Mystic Drone'))
+      expect(result.current.queue[0].artist).toBe('Bardcore')
+      expect(result.current.queue[0].artwork).toBe(true)
+      expect(api.get).toHaveBeenCalledWith('/audio/x1')
+    })
+
+    it('does not fetch tracks that already have a title', async () => {
+      const { result } = renderHook(() => useAudioPlayer(), { wrapper })
+      act(() => result.current.playQueue([{ id: 'y1', title: 'Already Set' }]))
+      // Give any effect a tick.
+      await waitFor(() => expect(result.current.queue.length).toBe(1))
+      expect(api.get).not.toHaveBeenCalled()
+    })
+
+    it('marks a track resolved after a failed fetch so it is not retried', async () => {
+      api.get.mockRejectedValue(new Error('boom'))
+      const { result } = renderHook(() => useAudioPlayer(), { wrapper })
+      act(() => result.current.playQueue([{ id: 'z1' }]))
+      await waitFor(() => expect(result.current.queue[0]._hydrated).toBe(true))
+      expect(api.get).toHaveBeenCalledTimes(1)
+    })
+  })
+})

--- a/frontend/src/context/UISettingsContext.jsx
+++ b/frontend/src/context/UISettingsContext.jsx
@@ -3,6 +3,7 @@ import { createContext, useContext } from 'react'
 const UISettingsContext = createContext({
   hide_maps: false,
   hide_tokens: false,
+  hide_audio: false,
   hide_campaigns: false,
   campaign_uploads_disabled: false,
   campaign_upload_max_file_mb: 0,

--- a/frontend/src/context/UISettingsContext.test.jsx
+++ b/frontend/src/context/UISettingsContext.test.jsx
@@ -1,0 +1,29 @@
+import { describe, it, expect } from 'vitest'
+import { render, screen } from '@testing-library/react'
+import { UISettingsProvider, useUISettings } from './UISettingsContext'
+
+function Probe() {
+  const ui = useUISettings()
+  return <div data-testid="probe">{JSON.stringify(ui)}</div>
+}
+
+describe('UISettingsContext', () => {
+  it('provides default values when no provider wraps it', () => {
+    render(<Probe />)
+    const value = JSON.parse(screen.getByTestId('probe').textContent)
+    expect(value.hide_audio).toBe(false)
+    expect(value.hide_maps).toBe(false)
+  })
+
+  it('exposes the provided settings (incl. hide_audio)', () => {
+    render(
+      <UISettingsProvider value={{ hide_maps: true, hide_audio: true, hide_campaigns: false }}>
+        <Probe />
+      </UISettingsProvider>
+    )
+    const value = JSON.parse(screen.getByTestId('probe').textContent)
+    expect(value.hide_audio).toBe(true)
+    expect(value.hide_maps).toBe(true)
+    expect(value.hide_campaigns).toBe(false)
+  })
+})

--- a/frontend/src/locales/de-DE.json
+++ b/frontend/src/locales/de-DE.json
@@ -17,7 +17,8 @@
     "logOut": "Abmelden",
     "more": "Mehr",
     "collapseSidebar": null,
-    "expandSidebar": null
+    "expandSidebar": null,
+    "audio": "Audio"
   },
   "stats": {
     "systems": "Systeme",
@@ -195,7 +196,8 @@
     "groupedBy": null,
     "groupedBy_other": null,
     "expandBook": null,
-    "collapseBook": null
+    "collapseBook": null,
+    "audio": "Audio"
   },
   "favorites": {
     "title": "Favoriten",
@@ -206,7 +208,8 @@
     "maps": "Karten ({{count}})",
     "tokens": "Tokens ({{count}})",
     "onlyFavorites": null,
-    "noFavoritesInView": null
+    "noFavoritesInView": null,
+    "audio": "Audio ({{count}})"
   },
   "maps": {
     "title": "Karten",
@@ -411,7 +414,8 @@
       "description": "Abschnitte aus der Seitenleiste und mobilen Navigation für alle Benutzer ausblenden.",
       "hideMaps": "Karten ausblenden",
       "hideTokens": "Tokens ausblenden",
-      "hideCampaigns": "Kampagnen ausblenden"
+      "hideCampaigns": "Kampagnen ausblenden",
+      "hideAudio": "Audio ausblenden"
     },
     "sidebarStats": {
       "title": "Seitenleisten-Statistiken",
@@ -858,7 +862,8 @@
     "uploadFile": null,
     "uploading": null,
     "emptyCategory": null,
-    "deleteFileConfirm": null
+    "deleteFileConfirm": null,
+    "audio": "Audio"
   },
   "download": {
     "title": "Archiv herunterladen",
@@ -1034,6 +1039,7 @@
     "embed_book": null,
     "embed_map": null,
     "embed_token": null,
+    "embed_audio": "Audio",
     "embedBookPage": null,
     "manageGroups": null,
     "uncategorized": null,
@@ -1159,5 +1165,66 @@
         "warning": "This overwrites fields you've edited in the UI."
       }
     }
+  },
+  "audio": {
+    "title": "Audio",
+    "subtitle_one": "{{count}} Titel in deiner Sammlung",
+    "subtitle_other": "{{count}} Titel in deiner Sammlung",
+    "filterPlaceholder": "Audio filtern…",
+    "filterAriaLabel": "Audio filtern",
+    "bulkTag": "Massen-Tag",
+    "cancelBulk": "Abbrechen",
+    "bulkHint": "Klicke auf Ordnerüberschriften oder Audiokarten, um sie auszuwählen, und füge dann unten Tags hinzu.",
+    "tagsPlaceholder": "Tags hinzufügen, kommagetrennt…",
+    "addTags": "Tags hinzufügen",
+    "applying": "Wird angewendet…",
+    "noAudioFilter": "Keine Audiodateien entsprechen deinem Filter.",
+    "noAudio": "Keine Audiodateien gefunden. Füge Audio zu /library/audio/ hinzu und scanne neu.",
+    "audioCount_one": "{{count}} Titel",
+    "audioCount_other": "{{count}} Titel",
+    "expandFolder": "{{folder}} ausklappen",
+    "collapseFolder": "{{folder}} einklappen",
+    "downloadAllInFolder": "Alle Audiodateien in {{folder}} herunterladen",
+    "downloadInSubfolder": "Audiodateien in {{folder}} herunterladen",
+    "editTags": "Bearbeiten",
+    "editTagsFull": "Tags bearbeiten",
+    "download": "Herunterladen",
+    "missing": "Fehlend",
+    "play": "Abspielen",
+    "pause": "Pause",
+    "detail": {
+      "title": "Titeldetails",
+      "back": "Zurück zu Audio",
+      "details": "Details",
+      "location": "Speicherort",
+      "fileSize": "Dateigröße",
+      "trackTitle": "Titel",
+      "artist": "Künstler",
+      "album": "Album",
+      "duration": "Dauer",
+      "folderTags": "Ordner-Tags",
+      "trackTags": "Titel-Tags",
+      "editTags": "Bearbeiten",
+      "noTags": "Keine"
+    },
+    "player": {
+      "title": "Aktuelle Wiedergabe",
+      "untitled": "Unbenannter Titel",
+      "queue": "Warteschlange",
+      "emptyQueue": "Warteschlange ist leer",
+      "previous": "Vorheriger Titel",
+      "next": "Nächster Titel",
+      "repeatOn": "Aktuellen Titel wiederholen: an",
+      "repeatOff": "Aktuellen Titel wiederholen: aus",
+      "playNext": "Als Nächstes abspielen",
+      "toggleQueue": "Warteschlange anzeigen",
+      "close": "Player schließen",
+      "seek": "Suchen",
+      "removeFromQueue": "Aus Warteschlange entfernen",
+      "reorder": "Zum Umsortieren ziehen"
+    },
+    "playFolder": "{{folder}} abspielen",
+    "playGroup": "Audio abspielen",
+    "playAll": "Alle abspielen"
   }
 }

--- a/frontend/src/locales/en-US.json
+++ b/frontend/src/locales/en-US.json
@@ -17,7 +17,8 @@
     "logOut": "Log out",
     "more": "More",
     "collapseSidebar": "Collapse sidebar",
-    "expandSidebar": "Expand sidebar"
+    "expandSidebar": "Expand sidebar",
+    "audio": "Audio"
   },
   "stats": {
     "systems": "Systems",
@@ -200,7 +201,8 @@
     "groupedBy": "{{count}} page",
     "groupedBy_other": "{{count}} pages",
     "expandBook": "Expand {{title}}",
-    "collapseBook": "Collapse {{title}}"
+    "collapseBook": "Collapse {{title}}",
+    "audio": "Audio"
   },
   "favorites": {
     "title": "Favorites",
@@ -211,7 +213,8 @@
     "maps": "Maps ({{count}})",
     "tokens": "Tokens ({{count}})",
     "onlyFavorites": "Favorites only",
-    "noFavoritesInView": "No favorites here yet. Click the heart icon on any item to save it."
+    "noFavoritesInView": "No favorites here yet. Click the heart icon on any item to save it.",
+    "audio": "Audio ({{count}})"
   },
   "maps": {
     "title": "Maps",
@@ -473,7 +476,8 @@
       "description": "Hide sections from the sidebar and mobile navigation for all users.",
       "hideMaps": "Hide Maps",
       "hideTokens": "Hide Tokens",
-      "hideCampaigns": "Hide Campaigns"
+      "hideCampaigns": "Hide Campaigns",
+      "hideAudio": "Hide Audio"
     },
     "sidebarStats": {
       "title": "Sidebar Stats",
@@ -926,7 +930,8 @@
     "uploadFile": "Upload file",
     "uploading": "Uploading…",
     "emptyCategory": "Drag resources here",
-    "deleteFileConfirm": "Remove this file? It will be deleted from the campaign."
+    "deleteFileConfirm": "Remove this file? It will be deleted from the campaign.",
+    "audio": "Audio"
   },
   "download": {
     "title": "Download Archive",
@@ -1102,6 +1107,7 @@
     "embed_book": "Book",
     "embed_map": "Map",
     "embed_token": "Token",
+    "embed_audio": "Audio",
     "embedBookPage": "Book — p. {{page}}",
     "parentLabel": "Parent page",
     "noParent": "Top level",
@@ -1228,5 +1234,66 @@
         "warning": "This overwrites fields you've edited in the UI."
       }
     }
+  },
+  "audio": {
+    "title": "Audio",
+    "subtitle_one": "{{count}} track in your collection",
+    "subtitle_other": "{{count}} tracks in your collection",
+    "filterPlaceholder": "Filter audio…",
+    "filterAriaLabel": "Filter audio",
+    "bulkTag": "Bulk Tag",
+    "cancelBulk": "Cancel",
+    "bulkHint": "Click folder headers or audio cards to select them, then add tags below.",
+    "tagsPlaceholder": "Tags to add, comma-separated…",
+    "addTags": "Add Tags",
+    "applying": "Applying…",
+    "noAudioFilter": "No audio matches your filter.",
+    "noAudio": "No audio found. Add audio to /library/audio/ and rescan.",
+    "audioCount_one": "{{count}} track",
+    "audioCount_other": "{{count}} tracks",
+    "expandFolder": "Expand {{folder}}",
+    "collapseFolder": "Collapse {{folder}}",
+    "downloadAllInFolder": "Download all audio in {{folder}}",
+    "downloadInSubfolder": "Download audio in {{folder}}",
+    "editTags": "Edit",
+    "editTagsFull": "Edit tags",
+    "download": "Download",
+    "missing": "Missing",
+    "play": "Play",
+    "pause": "Pause",
+    "detail": {
+      "title": "Track Details",
+      "back": "Back to audio",
+      "details": "Details",
+      "location": "Location",
+      "fileSize": "File Size",
+      "trackTitle": "Title",
+      "artist": "Artist",
+      "album": "Album",
+      "duration": "Duration",
+      "folderTags": "Folder Tags",
+      "trackTags": "Track Tags",
+      "editTags": "Edit",
+      "noTags": "None"
+    },
+    "player": {
+      "title": "Now Playing",
+      "untitled": "Untitled track",
+      "queue": "Queue",
+      "emptyQueue": "Queue is empty",
+      "previous": "Previous track",
+      "next": "Next track",
+      "repeatOn": "Repeat current track: on",
+      "repeatOff": "Repeat current track: off",
+      "playNext": "Play next",
+      "toggleQueue": "Show queue",
+      "close": "Close player",
+      "seek": "Seek",
+      "removeFromQueue": "Remove from queue",
+      "reorder": "Drag to reorder"
+    },
+    "playFolder": "Play {{folder}}",
+    "playGroup": "Play audio",
+    "playAll": "Play all"
   }
 }

--- a/frontend/src/locales/fr-CA.json
+++ b/frontend/src/locales/fr-CA.json
@@ -17,7 +17,8 @@
     "logOut": "Se déconnecter",
     "more": "Plus",
     "collapseSidebar": "Réduire la barre latérale",
-    "expandSidebar": "Développer la barre latérale"
+    "expandSidebar": "Développer la barre latérale",
+    "audio": "Audio"
   },
   "stats": {
     "systems": "Systèmes",
@@ -200,7 +201,8 @@
     "groupedBy": "{{count}} page",
     "groupedBy_other": "{{count}} pages",
     "expandBook": "Développer {{title}}",
-    "collapseBook": "Réduire {{title}}"
+    "collapseBook": "Réduire {{title}}",
+    "audio": "Audio"
   },
   "favorites": {
     "title": "Favoris",
@@ -211,7 +213,8 @@
     "maps": "Cartes ({{count}})",
     "tokens": "Pions ({{count}})",
     "onlyFavorites": "Favoris uniquement",
-    "noFavoritesInView": "Pas encore de favoris ici. Cliquez sur l'icône cœur d'un élément pour l'enregistrer."
+    "noFavoritesInView": "Pas encore de favoris ici. Cliquez sur l'icône cœur d'un élément pour l'enregistrer.",
+    "audio": "Audio ({{count}})"
   },
   "maps": {
     "title": "Cartes",
@@ -473,7 +476,8 @@
       "description": "Masquer des sections de la barre latérale et de la navigation mobile pour tous les utilisateurs.",
       "hideMaps": "Masquer les cartes",
       "hideTokens": "Masquer les pions",
-      "hideCampaigns": "Masquer les campagnes"
+      "hideCampaigns": "Masquer les campagnes",
+      "hideAudio": "Masquer l'audio"
     },
     "sidebarStats": {
       "title": "Statistiques de la barre latérale",
@@ -926,7 +930,8 @@
     "uploadFile": "Téléverser un fichier",
     "uploading": "Téléversement…",
     "emptyCategory": "Glissez des ressources ici",
-    "deleteFileConfirm": "Retirer ce fichier ? Il sera supprimé de la campagne."
+    "deleteFileConfirm": "Retirer ce fichier ? Il sera supprimé de la campagne.",
+    "audio": "Audio"
   },
   "download": {
     "title": "Télécharger l'archive",
@@ -1102,6 +1107,7 @@
     "embed_book": "Livre",
     "embed_map": "Carte",
     "embed_token": "Jeton",
+    "embed_audio": "Audio",
     "embedBookPage": "Livre — p. {{page}}",
     "manageGroups": "Gérer les groupes",
     "uncategorized": "Non classé",
@@ -1227,5 +1233,66 @@
         "warning": "This overwrites fields you've edited in the UI."
       }
     }
+  },
+  "audio": {
+    "title": "Audio",
+    "subtitle_one": "{{count}} piste dans votre collection",
+    "subtitle_other": "{{count}} pistes dans votre collection",
+    "filterPlaceholder": "Filtrer l'audio…",
+    "filterAriaLabel": "Filtrer l'audio",
+    "bulkTag": "Étiquetage en masse",
+    "cancelBulk": "Annuler",
+    "bulkHint": "Cliquez sur les en-têtes de dossier ou les cartes audio pour les sélectionner, puis ajoutez des étiquettes ci-dessous.",
+    "tagsPlaceholder": "Étiquettes à ajouter, séparées par des virgules…",
+    "addTags": "Ajouter des étiquettes",
+    "applying": "Application…",
+    "noAudioFilter": "Aucun fichier audio ne correspond à votre filtre.",
+    "noAudio": "Aucun fichier audio trouvé. Ajoutez de l'audio à /library/audio/ et relancez l'analyse.",
+    "audioCount_one": "{{count}} piste",
+    "audioCount_other": "{{count}} pistes",
+    "expandFolder": "Développer {{folder}}",
+    "collapseFolder": "Réduire {{folder}}",
+    "downloadAllInFolder": "Télécharger tout l'audio dans {{folder}}",
+    "downloadInSubfolder": "Télécharger l'audio dans {{folder}}",
+    "editTags": "Modifier",
+    "editTagsFull": "Modifier les étiquettes",
+    "download": "Télécharger",
+    "missing": "Manquant",
+    "play": "Lire",
+    "pause": "Pause",
+    "detail": {
+      "title": "Détails de la piste",
+      "back": "Retour à l'audio",
+      "details": "Détails",
+      "location": "Emplacement",
+      "fileSize": "Taille du fichier",
+      "trackTitle": "Titre",
+      "artist": "Artiste",
+      "album": "Album",
+      "duration": "Durée",
+      "folderTags": "Étiquettes du dossier",
+      "trackTags": "Étiquettes de la piste",
+      "editTags": "Modifier",
+      "noTags": "Aucune"
+    },
+    "player": {
+      "title": "Lecture en cours",
+      "untitled": "Piste sans titre",
+      "queue": "File d'attente",
+      "emptyQueue": "La file d'attente est vide",
+      "previous": "Piste précédente",
+      "next": "Piste suivante",
+      "repeatOn": "Répéter la piste actuelle : activé",
+      "repeatOff": "Répéter la piste actuelle : désactivé",
+      "playNext": "Lire ensuite",
+      "toggleQueue": "Afficher la file d'attente",
+      "close": "Fermer le lecteur",
+      "seek": "Rechercher",
+      "removeFromQueue": "Retirer de la file d'attente",
+      "reorder": "Glisser pour réorganiser"
+    },
+    "playFolder": "Lire {{folder}}",
+    "playGroup": "Lire l'audio",
+    "playAll": "Tout lire"
   }
 }

--- a/frontend/src/locales/fr-FR.json
+++ b/frontend/src/locales/fr-FR.json
@@ -17,7 +17,8 @@
     "logOut": "Se déconnecter",
     "more": "Plus",
     "collapseSidebar": "Réduire la barre latérale",
-    "expandSidebar": "Développer la barre latérale"
+    "expandSidebar": "Développer la barre latérale",
+    "audio": "Audio"
   },
   "stats": {
     "systems": "Systèmes",
@@ -200,7 +201,8 @@
     "groupedBy": "{{count}} page",
     "groupedBy_other": "{{count}} pages",
     "expandBook": "Développer {{title}}",
-    "collapseBook": "Réduire {{title}}"
+    "collapseBook": "Réduire {{title}}",
+    "audio": "Audio"
   },
   "favorites": {
     "title": "Favoris",
@@ -211,7 +213,8 @@
     "maps": "Cartes ({{count}})",
     "tokens": "Pions ({{count}})",
     "onlyFavorites": "Favoris uniquement",
-    "noFavoritesInView": "Pas encore de favoris ici. Cliquez sur l'icône cœur d'un élément pour l'enregistrer."
+    "noFavoritesInView": "Pas encore de favoris ici. Cliquez sur l'icône cœur d'un élément pour l'enregistrer.",
+    "audio": "Audio ({{count}})"
   },
   "maps": {
     "title": "Cartes",
@@ -473,7 +476,8 @@
       "description": "Masquer des sections de la barre latérale et de la navigation mobile pour tous les utilisateurs.",
       "hideMaps": "Masquer les cartes",
       "hideTokens": "Masquer les pions",
-      "hideCampaigns": "Masquer les campagnes"
+      "hideCampaigns": "Masquer les campagnes",
+      "hideAudio": "Masquer l'audio"
     },
     "sidebarStats": {
       "title": "Statistiques de la barre latérale",
@@ -926,7 +930,8 @@
     "uploadFile": "Téléverser un fichier",
     "uploading": "Téléversement…",
     "emptyCategory": "Glissez des ressources ici",
-    "deleteFileConfirm": "Retirer ce fichier ? Il sera supprimé de la campagne."
+    "deleteFileConfirm": "Retirer ce fichier ? Il sera supprimé de la campagne.",
+    "audio": "Audio"
   },
   "download": {
     "title": "Télécharger l'archive",
@@ -1102,6 +1107,7 @@
     "embed_book": "Livre",
     "embed_map": "Carte",
     "embed_token": "Jeton",
+    "embed_audio": "Audio",
     "embedBookPage": "Livre — p. {{page}}",
     "manageGroups": "Gérer les groupes",
     "uncategorized": "Non classé",
@@ -1227,5 +1233,66 @@
         "warning": "This overwrites fields you've edited in the UI."
       }
     }
+  },
+  "audio": {
+    "title": "Audio",
+    "subtitle_one": "{{count}} piste dans votre collection",
+    "subtitle_other": "{{count}} pistes dans votre collection",
+    "filterPlaceholder": "Filtrer l'audio…",
+    "filterAriaLabel": "Filtrer l'audio",
+    "bulkTag": "Étiquetage en masse",
+    "cancelBulk": "Annuler",
+    "bulkHint": "Cliquez sur les en-têtes de dossier ou les cartes audio pour les sélectionner, puis ajoutez des étiquettes ci-dessous.",
+    "tagsPlaceholder": "Étiquettes à ajouter, séparées par des virgules…",
+    "addTags": "Ajouter des étiquettes",
+    "applying": "Application…",
+    "noAudioFilter": "Aucun fichier audio ne correspond à votre filtre.",
+    "noAudio": "Aucun fichier audio trouvé. Ajoutez de l'audio à /library/audio/ et relancez l'analyse.",
+    "audioCount_one": "{{count}} piste",
+    "audioCount_other": "{{count}} pistes",
+    "expandFolder": "Développer {{folder}}",
+    "collapseFolder": "Réduire {{folder}}",
+    "downloadAllInFolder": "Télécharger tout l'audio dans {{folder}}",
+    "downloadInSubfolder": "Télécharger l'audio dans {{folder}}",
+    "editTags": "Modifier",
+    "editTagsFull": "Modifier les étiquettes",
+    "download": "Télécharger",
+    "missing": "Manquant",
+    "play": "Lire",
+    "pause": "Pause",
+    "detail": {
+      "title": "Détails de la piste",
+      "back": "Retour à l'audio",
+      "details": "Détails",
+      "location": "Emplacement",
+      "fileSize": "Taille du fichier",
+      "trackTitle": "Titre",
+      "artist": "Artiste",
+      "album": "Album",
+      "duration": "Durée",
+      "folderTags": "Étiquettes du dossier",
+      "trackTags": "Étiquettes de la piste",
+      "editTags": "Modifier",
+      "noTags": "Aucune"
+    },
+    "player": {
+      "title": "Lecture en cours",
+      "untitled": "Piste sans titre",
+      "queue": "File d'attente",
+      "emptyQueue": "La file d'attente est vide",
+      "previous": "Piste précédente",
+      "next": "Piste suivante",
+      "repeatOn": "Répéter la piste actuelle : activé",
+      "repeatOff": "Répéter la piste actuelle : désactivé",
+      "playNext": "Lire ensuite",
+      "toggleQueue": "Afficher la file d'attente",
+      "close": "Fermer le lecteur",
+      "seek": "Rechercher",
+      "removeFromQueue": "Retirer de la file d'attente",
+      "reorder": "Glisser pour réorganiser"
+    },
+    "playFolder": "Lire {{folder}}",
+    "playGroup": "Lire l'audio",
+    "playAll": "Tout lire"
   }
 }

--- a/frontend/src/utils.js
+++ b/frontend/src/utils.js
@@ -4,6 +4,17 @@ export function formatSize(bytes) {
   return (bytes / 1048576).toFixed(1) + ' MB'
 }
 
+/** Format a duration in seconds as m:ss (or h:mm:ss for long tracks). */
+export function formatDuration(seconds) {
+  const total = Math.max(0, Math.round(seconds || 0))
+  const h = Math.floor(total / 3600)
+  const m = Math.floor((total % 3600) / 60)
+  const s = total % 60
+  const ss = String(s).padStart(2, '0')
+  if (h > 0) return `${h}:${String(m).padStart(2, '0')}:${ss}`
+  return `${m}:${ss}`
+}
+
 export function toTitleCase(str) {
   return str.replace(/[-_]+/g, ' ').replace(/\w\S*/g, (w) => w.charAt(0).toUpperCase() + w.slice(1))
 }

--- a/frontend/src/utils.test.js
+++ b/frontend/src/utils.test.js
@@ -1,5 +1,5 @@
 import { describe, it, expect } from 'vitest'
-import { formatSize } from './utils'
+import { formatSize, formatDuration } from './utils'
 
 describe('formatSize', () => {
   it('returns bytes for values under 1 KB', () => {
@@ -23,5 +23,25 @@ describe('formatSize', () => {
   it('formats MB to one decimal place', () => {
     expect(formatSize(10485760)).toBe('10.0 MB')
     expect(formatSize(10737418)).toBe('10.2 MB')
+  })
+})
+
+describe('formatDuration', () => {
+  it('formats seconds as m:ss', () => {
+    expect(formatDuration(0)).toBe('0:00')
+    expect(formatDuration(5)).toBe('0:05')
+    expect(formatDuration(65)).toBe('1:05')
+    expect(formatDuration(125)).toBe('2:05')
+  })
+
+  it('formats hours as h:mm:ss', () => {
+    expect(formatDuration(3661)).toBe('1:01:01')
+    expect(formatDuration(7325)).toBe('2:02:05')
+  })
+
+  it('handles null/undefined and rounds', () => {
+    expect(formatDuration(null)).toBe('0:00')
+    expect(formatDuration(undefined)).toBe('0:00')
+    expect(formatDuration(59.6)).toBe('1:00')
   })
 })

--- a/frontend/src/views/AudioView.jsx
+++ b/frontend/src/views/AudioView.jsx
@@ -1,0 +1,81 @@
+import { useState } from 'react'
+import { useNavigate } from 'react-router-dom'
+import { useTranslation } from 'react-i18next'
+import Spinner from '../components/Spinner'
+import DownloadArchiveModal from '../components/DownloadArchiveModal'
+import AddToCampaignModal from '../components/AddToCampaignModal'
+import BulkEditModal from '../components/BulkEditModal'
+import { useAuth } from '../context/AuthContext'
+import useMediaGallery from '../hooks/useMediaGallery'
+import { MEDIA_CONFIGS } from '../components/media/mediaConfig'
+import GalleryLayout from '../components/media/GalleryLayout'
+
+export default function AudioView() {
+  const { t } = useTranslation()
+  const navigate = useNavigate()
+  const { user } = useAuth()
+  const isPlayer = user?.role === 'player'
+  const config = MEDIA_CONFIGS.audio
+  const gallery = useMediaGallery(config)
+
+  const [downloadModal, setDownloadModal] = useState(null)
+  const [showAddToCampaign, setShowAddToCampaign] = useState(false)
+  const [showBulkEdit, setShowBulkEdit] = useState(false)
+
+  if (!gallery.data)
+    return (
+      <div style={{ padding: 40, textAlign: 'center' }}>
+        <Spinner size={32} />
+      </div>
+    )
+
+  return (
+    <>
+      <GalleryLayout
+        config={config}
+        gallery={gallery}
+        isPlayer={isPlayer}
+        title={t('audio.title')}
+        subtitle={t('audio.subtitle', { count: gallery.data.total })}
+        onSelectItem={(id) => navigate(config.detailPath(id))}
+        onDownload={setDownloadModal}
+        onAddToCampaign={() => setShowAddToCampaign(true)}
+        onBulkEdit={() => setShowBulkEdit(true)}
+      />
+
+      {downloadModal && (
+        <DownloadArchiveModal
+          title={downloadModal.title}
+          params={downloadModal.params}
+          onClose={() => setDownloadModal(null)}
+        />
+      )}
+
+      {showAddToCampaign && (
+        <AddToCampaignModal
+          items={gallery
+            .selectedObjects()
+            .map((a) => ({ resource_type: 'audio', resource_id: a.id }))}
+          onClose={() => setShowAddToCampaign(false)}
+          onAdded={() => {
+            setShowAddToCampaign(false)
+            gallery.bulk.exit()
+          }}
+        />
+      )}
+
+      {showBulkEdit && (
+        <BulkEditModal
+          type="audio"
+          items={gallery.selectedObjects()}
+          onClose={() => setShowBulkEdit(false)}
+          onSaved={(edited) => {
+            gallery.applyEdits(edited)
+            setShowBulkEdit(false)
+            gallery.bulk.exit()
+          }}
+        />
+      )}
+    </>
+  )
+}

--- a/frontend/src/views/AudioView.modals.test.jsx
+++ b/frontend/src/views/AudioView.modals.test.jsx
@@ -1,0 +1,94 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { render, screen } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+import AudioView from './AudioView'
+
+// Drive the three modal branches by mocking GalleryLayout to expose its callbacks.
+const navigate = vi.fn()
+vi.mock('../components/media/GalleryLayout', () => ({
+  default: ({ onDownload, onAddToCampaign, onBulkEdit, onSelectItem }) => (
+    <div>
+      <button onClick={() => onDownload({ title: 'T', params: {} })}>fire-download</button>
+      <button onClick={onAddToCampaign}>fire-campaign</button>
+      <button onClick={onBulkEdit}>fire-bulk</button>
+      <button onClick={() => onSelectItem('a1')}>fire-select</button>
+    </div>
+  ),
+}))
+
+const selectedObjects = vi.fn(() => [{ id: 'a1' }, { id: 'a2' }])
+const bulkExit = vi.fn()
+vi.mock('../hooks/useMediaGallery', () => ({
+  default: () => ({
+    data: { total: 2 },
+    selectedObjects,
+    applyEdits: vi.fn(),
+    bulk: { exit: bulkExit },
+  }),
+}))
+
+vi.mock('../context/AuthContext', () => ({
+  useAuth: () => ({ user: { id: 'u1', role: 'admin' } }),
+}))
+vi.mock('react-router-dom', () => ({ useNavigate: () => navigate }))
+
+vi.mock('../components/DownloadArchiveModal', () => ({
+  default: ({ onClose }) => (
+    <div data-testid="dl-modal">
+      <button onClick={onClose}>x</button>
+    </div>
+  ),
+}))
+vi.mock('../components/AddToCampaignModal', () => ({
+  default: ({ items, onAdded }) => (
+    <div data-testid="campaign-modal">
+      {items.map((i) => i.resource_type + ':' + i.resource_id).join(',')}
+      <button onClick={onAdded}>x</button>
+    </div>
+  ),
+}))
+vi.mock('../components/BulkEditModal', () => ({
+  default: ({ type, onClose, onSaved }) => (
+    <div data-testid="bulk-modal">
+      {type}
+      <button onClick={() => onSaved({ a1: { tags: ['x'] } })}>save-bulk</button>
+      <button onClick={onClose}>close-bulk</button>
+    </div>
+  ),
+}))
+
+beforeEach(() => vi.clearAllMocks())
+
+describe('AudioView modals', () => {
+  it('opens and closes the download modal', async () => {
+    render(<AudioView />)
+    await userEvent.click(screen.getByText('fire-download'))
+    expect(screen.getByTestId('dl-modal')).toBeInTheDocument()
+    await userEvent.click(screen.getByText('x'))
+    expect(screen.queryByTestId('dl-modal')).not.toBeInTheDocument()
+  })
+
+  it('opens the add-to-campaign modal with audio resource items', async () => {
+    render(<AudioView />)
+    await userEvent.click(screen.getByText('fire-campaign'))
+    const modal = screen.getByTestId('campaign-modal')
+    expect(modal).toHaveTextContent('audio:a1')
+    expect(modal).toHaveTextContent('audio:a2')
+    await userEvent.click(screen.getByText('x'))
+    expect(bulkExit).toHaveBeenCalled()
+  })
+
+  it('opens the bulk-edit modal with type=audio and saves edits', async () => {
+    render(<AudioView />)
+    await userEvent.click(screen.getByText('fire-bulk'))
+    expect(screen.getByTestId('bulk-modal')).toHaveTextContent('audio')
+    await userEvent.click(screen.getByText('save-bulk'))
+    expect(bulkExit).toHaveBeenCalled()
+  })
+
+  it('navigates to the track detail page on select', async () => {
+    render(<AudioView />)
+    await userEvent.click(screen.getByText('fire-select'))
+    expect(navigate).toHaveBeenCalledWith('/audio/a1')
+  })
+})

--- a/frontend/src/views/AudioView.test.jsx
+++ b/frontend/src/views/AudioView.test.jsx
@@ -1,0 +1,126 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { render, screen, waitFor } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+import { MemoryRouter } from 'react-router-dom'
+import AudioView from './AudioView'
+import api from '../api'
+
+vi.mock('../api', () => ({
+  default: { get: vi.fn(), patch: vi.fn() },
+  mediaUrl: (path) => `http://localhost${path}`,
+}))
+
+vi.mock('react-router-dom', async (importOriginal) => {
+  const actual = await importOriginal()
+  return { ...actual, useNavigate: () => vi.fn() }
+})
+
+vi.mock('../hooks/useUserPrefs', () => ({
+  getUserPrefs: () => ({ cardSize: 'comfortable', librarySort: 'az' }),
+}))
+
+vi.mock('../context/AuthContext', () => ({
+  useAuth: () => ({ user: { id: 'u1', role: 'admin' } }),
+}))
+
+const mockIsFavorite = vi.fn(() => false)
+vi.mock('../context/FavoritesContext', () => ({
+  useFavorites: () => ({ isFavorite: mockIsFavorite, toggleFavorite: vi.fn() }),
+}))
+
+vi.mock('../components/DownloadArchiveModal', () => ({
+  default: () => null,
+}))
+
+vi.mock('../components/LazyGrid', () => ({
+  default: ({ children }) => <>{children}</>,
+}))
+
+vi.mock('../hooks/useSessionState', () => ({
+  default: (_key, _init) => [new Set(), vi.fn()],
+}))
+
+function makeTrack(overrides = {}) {
+  const id = overrides.id ?? `audio-${Math.random().toString(36).slice(2)}`
+  const filename = overrides.filename ?? `track-${id}.mp3`
+  return {
+    id,
+    filename,
+    relative_path: overrides.relative_path ?? `audio/${filename}`,
+    tags: overrides.tags ?? [],
+    duration: 120,
+    title: overrides.title ?? '',
+    artist: '',
+    album: '',
+    has_artwork: false,
+    is_missing: false,
+    file_size: 1000,
+    ...overrides,
+  }
+}
+
+function makeResponse(audio = []) {
+  return { audio, total: audio.length }
+}
+
+function renderView() {
+  return render(
+    <MemoryRouter>
+      <AudioView />
+    </MemoryRouter>
+  )
+}
+
+describe('AudioView', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    mockIsFavorite.mockReturnValue(false)
+  })
+
+  function setupAudio(audio) {
+    api.get.mockImplementation((url) => {
+      if (url === '/audio') return Promise.resolve(makeResponse(audio))
+      if (url === '/audio-folders') return Promise.resolve({ folders: [] })
+      return Promise.resolve({})
+    })
+  }
+
+  it('renders track filenames after loading', async () => {
+    setupAudio([makeTrack({ filename: 'tavern.mp3', relative_path: 'audio/tavern.mp3' })])
+    renderView()
+    await waitFor(() => expect(screen.getByText('tavern.mp3')).toBeInTheDocument())
+  })
+
+  it('shows a spinner while loading', () => {
+    api.get.mockReturnValue(new Promise(() => {}))
+    renderView()
+    expect(document.querySelector('svg')).toBeInTheDocument()
+  })
+
+  it('renders play controls (card + folder) for tracks', async () => {
+    setupAudio([makeTrack({ filename: 'battle.mp3', relative_path: 'audio/battle.mp3' })])
+    renderView()
+    await waitFor(() => expect(screen.getByText('battle.mp3')).toBeInTheDocument())
+    // Both the per-track card play button and the folder "Play" button render.
+    expect(screen.getAllByRole('button', { name: /play/i }).length).toBeGreaterThanOrEqual(2)
+  })
+
+  it('favorites filter hides non-favorite tracks', async () => {
+    const fav = makeTrack({ id: 'fav', filename: 'fav.mp3', relative_path: 'audio/fav.mp3' })
+    const other = makeTrack({
+      id: 'other',
+      filename: 'other.mp3',
+      relative_path: 'audio/other.mp3',
+    })
+    setupAudio([fav, other])
+    mockIsFavorite.mockImplementation((type, id) => type === 'audio' && id === 'fav')
+
+    renderView()
+    await waitFor(() => expect(screen.getByText('fav.mp3')).toBeInTheDocument())
+
+    await userEvent.click(screen.getByText(/favorites only/i))
+
+    expect(screen.getByText('fav.mp3')).toBeInTheDocument()
+    expect(screen.queryByText('other.mp3')).not.toBeInTheDocument()
+  })
+})

--- a/frontend/src/views/FavoritesView.jsx
+++ b/frontend/src/views/FavoritesView.jsx
@@ -5,6 +5,7 @@ import FavoritesSection from '../components/favorites/FavoritesSection'
 import BookFavorite from '../components/favorites/BookFavorite'
 import MapFavorite from '../components/favorites/MapFavorite'
 import TokenFavorite from '../components/favorites/TokenFavorite'
+import AudioFavorite from '../components/favorites/AudioFavorite'
 import SystemFavorite from '../components/favorites/SystemFavorite'
 
 export default function FavoritesView() {
@@ -15,6 +16,7 @@ export default function FavoritesView() {
   const books = items.filter((i) => i.item_type === 'book')
   const maps = items.filter((i) => i.item_type === 'map')
   const tokens = items.filter((i) => i.item_type === 'token')
+  const audio = items.filter((i) => i.item_type === 'audio')
 
   if (items.length === 0) {
     return (
@@ -77,6 +79,15 @@ export default function FavoritesView() {
           title={t('favorites.tokens', { count: tokens.length })}
           items={tokens}
           renderItem={(item, grid) => <TokenFavorite key={item.item_id} item={item} grid={grid} />}
+        />
+      )}
+
+      {audio.length > 0 && (
+        <FavoritesSection
+          type="audio"
+          title={t('favorites.audio', { count: audio.length })}
+          items={audio}
+          renderItem={(item, grid) => <AudioFavorite key={item.item_id} item={item} grid={grid} />}
         />
       )}
     </div>

--- a/frontend/src/views/SearchView.jsx
+++ b/frontend/src/views/SearchView.jsx
@@ -1,7 +1,15 @@
 import { useState, useCallback, useRef, useMemo, useEffect } from 'react'
 import { useNavigate, useSearchParams } from 'react-router-dom'
 import { useTranslation } from 'react-i18next'
-import { LuSearch, LuMap, LuUser, LuBookOpen, LuChevronDown, LuChevronRight } from 'react-icons/lu'
+import {
+  LuSearch,
+  LuMap,
+  LuMusic,
+  LuUser,
+  LuBookOpen,
+  LuChevronDown,
+  LuChevronRight,
+} from 'react-icons/lu'
 import api from '../api'
 import Spinner from '../components/Spinner'
 import BookGroup from '../components/search/BookGroup'
@@ -97,7 +105,8 @@ export default function SearchView() {
   const totalFiltered =
     groupedBooks.reduce((s, g) => s + g.pages.length, 0) +
     (results?.maps?.length ?? 0) +
-    (results?.tokens?.length ?? 0)
+    (results?.tokens?.length ?? 0) +
+    (results?.audio?.length ?? 0)
 
   return (
     <div
@@ -151,6 +160,7 @@ export default function SearchView() {
         (() => {
           const maps = results.maps ?? []
           const tokens = results.tokens ?? []
+          const audio = results.audio ?? []
 
           return (
             <div>
@@ -279,6 +289,36 @@ export default function SearchView() {
                           {tok.relative_path}
                         </div>
                         {tok.tags?.length > 0 && <TagList tags={tok.tags} />}
+                      </div>
+                    ))}
+                </div>
+              )}
+
+              {audio.length > 0 && (
+                <div style={{ marginBottom: 24 }}>
+                  <button onClick={() => toggleSection('audio')} style={sectionHeadStyle}>
+                    {collapsed.audio ? <LuChevronRight size={14} /> : <LuChevronDown size={14} />}
+                    <LuMusic size={14} /> {t('search.audio')}
+                    <span style={{ marginLeft: 'auto', fontSize: 12, fontWeight: 400 }}>
+                      {audio.length}
+                    </span>
+                  </button>
+                  {!collapsed.audio &&
+                    audio.map((a) => (
+                      <div
+                        key={a.id}
+                        onClick={() => navigate(`/audio/${a.id}`)}
+                        style={cardStyle}
+                        onMouseEnter={(e) =>
+                          (e.currentTarget.style.background = 'var(--bg-card-hover)')
+                        }
+                        onMouseLeave={(e) => (e.currentTarget.style.background = 'var(--bg-card)')}
+                      >
+                        <div style={{ fontWeight: 500, fontSize: 15 }}>{a.title || a.filename}</div>
+                        <div style={{ fontSize: 13, color: 'var(--text-muted)', marginTop: 3 }}>
+                          {a.relative_path}
+                        </div>
+                        {a.tags?.length > 0 && <TagList tags={a.tags} />}
                       </div>
                     ))}
                 </div>

--- a/frontend/src/views/SearchView.test.jsx
+++ b/frontend/src/views/SearchView.test.jsx
@@ -28,13 +28,14 @@ function makeBookResult(overrides = {}) {
   }
 }
 
-function makeResponse(books = [], maps = [], tokens = []) {
+function makeResponse(books = [], maps = [], tokens = [], audio = []) {
   return {
     query: 'fireball',
-    total: books.length + maps.length + tokens.length,
+    total: books.length + maps.length + tokens.length + audio.length,
     results: books,
     maps,
     tokens,
+    audio,
   }
 }
 
@@ -233,6 +234,97 @@ describe('SearchView', () => {
 
     await waitFor(() => expect(screen.getByText('goblin.png')).toBeInTheDocument())
     expect(screen.getByRole('button', { name: /tokens/i })).toBeInTheDocument()
+  })
+
+  it('shows audio results in a separate section (title preferred)', async () => {
+    api.get.mockResolvedValue(
+      makeResponse(
+        [],
+        [],
+        [],
+        [
+          {
+            id: 'a1',
+            filename: 'track.mp3',
+            relative_path: 'audio/Ambient/track.mp3',
+            title: 'Mystic Drone',
+            tags: ['ambient'],
+          },
+        ]
+      )
+    )
+    renderView()
+    await userEvent.type(screen.getByRole('textbox'), 'my')
+
+    await waitFor(() => expect(screen.getByText('Mystic Drone')).toBeInTheDocument())
+    expect(screen.getByRole('button', { name: /audio/i })).toBeInTheDocument()
+  })
+
+  it('audio result falls back to filename when title is empty', async () => {
+    api.get.mockResolvedValue(
+      makeResponse(
+        [],
+        [],
+        [],
+        [
+          {
+            id: 'a2',
+            filename: 'noname.mp3',
+            relative_path: 'audio/noname.mp3',
+            title: '',
+            tags: [],
+          },
+        ]
+      )
+    )
+    renderView()
+    await userEvent.type(screen.getByRole('textbox'), 'no')
+    await waitFor(() => expect(screen.getByText('noname.mp3')).toBeInTheDocument())
+  })
+
+  it('collapses the audio section when its header is clicked', async () => {
+    api.get.mockResolvedValue(
+      makeResponse(
+        [],
+        [],
+        [],
+        [{ id: 'a1', filename: 't.mp3', relative_path: 'audio/t.mp3', title: 'Drone', tags: [] }]
+      )
+    )
+    renderView()
+    await userEvent.type(screen.getByRole('textbox'), 'dr')
+    await waitFor(() => expect(screen.getByText('Drone')).toBeInTheDocument())
+    await userEvent.click(screen.getByRole('button', { name: /audio/i }))
+    expect(screen.queryByText('Drone')).not.toBeInTheDocument()
+  })
+
+  it('navigates when an audio result is clicked', async () => {
+    api.get.mockResolvedValue(
+      makeResponse(
+        [],
+        [],
+        [],
+        [{ id: 'a1', filename: 't.mp3', relative_path: 'audio/t.mp3', title: 'Drone', tags: [] }]
+      )
+    )
+    renderView()
+    await userEvent.type(screen.getByRole('textbox'), 'dr')
+    await waitFor(() => screen.getByText('Drone'))
+    // Clicking the result card runs the navigate handler without throwing.
+    await userEvent.click(screen.getByText('Drone'))
+  })
+
+  it('navigates when a map result is clicked', async () => {
+    api.get.mockResolvedValue(
+      makeResponse(
+        [],
+        [{ id: 'm1', filename: 'cave.png', relative_path: 'maps/cave.png', tags: [] }]
+      )
+    )
+    renderView()
+    await userEvent.type(screen.getByRole('textbox'), 'ca')
+    await waitFor(() => screen.getByText('cave.png'))
+    await userEvent.click(screen.getByText('cave.png'))
   })
 
   it('does not fire a search for a single character query', async () => {

--- a/frontend/vite.config.js
+++ b/frontend/vite.config.js
@@ -21,7 +21,10 @@ export default defineConfig({
     setupFiles: ['./src/test/setup.js'],
     globals: true,
     coverage: {
-      provider: 'v8',
+      // Istanbul (not v8) so per-file coverage merges correctly across the many
+      // test files that touch shared components — v8 under-reports cumulative
+      // coverage in that case, which breaks the per-changed-file gate.
+      provider: 'istanbul',
       // Reporters: human-readable text in the terminal, an HTML report under
       // coverage/, and a json-summary that scripts/check-coverage.mjs reads to
       // gate per-file coverage on changed files. No global `thresholds` here by

--- a/requirements-test.txt
+++ b/requirements-test.txt
@@ -1,1 +1,2 @@
 pytest>=7.0
+pytest-cov>=5.0


### PR DESCRIPTION
## Summary

Add a top-level `audio/` library section that behaves like maps/tokens browse by folder, tag (item/folder/tags.json), filter, bulk-select, add to campaigns, favorite, search, and detect missing files — plus a persistent global player with queue/playlist support.

## Type of change

- [ ] Bug fix
- [x] New feature
- [ ] Refactor / cleanup
- [ ] Docs / configuration only

## Testing

<!-- How did you verify this works? Check all that apply. -->

- [x] Backend tests pass (`pytest -q`)
- [x] Frontend tests pass (`npm test`)
- [x] Tested manually in the browser

## Notes for reviewer

<!-- Anything that needs extra context, known limitations, or follow-up work. Delete if not needed. -->
