### PR TITLE
Fix: GM editing a player's availability updates the player's row (#170)

### DIFF
--- a/frontend/src/components/campaigns/AvailabilityChart.jsx
+++ b/frontend/src/components/campaigns/AvailabilityChart.jsx
@@ -155,7 +155,7 @@ export default function AvailabilityChart({
                           status={entry.status}
                           isCancelled={false}
                           isOwner={isOwner && isMyRow}
-                          onSet={(status) => onSetAvailability(date, status)}
+                          onSet={(status) => onSetAvailability(date, status, row.user_id)}
                           onCancel={() => onCancelDate(date)}
                           availOptions={translatedAvailOptions}
                         />

--- a/frontend/src/components/campaigns/AvailabilityChart.test.jsx
+++ b/frontend/src/components/campaigns/AvailabilityChart.test.jsx
@@ -1,0 +1,165 @@
+import { describe, it, expect, vi } from 'vitest'
+import { render, screen, fireEvent, within } from '@testing-library/react'
+import AvailabilityChart from './AvailabilityChart'
+
+const availability = {
+  next_sessions: ['2026-07-01'],
+  cancelled_dates: [],
+  rows: [
+    {
+      user_id: 'gm1',
+      username: 'Gandalf',
+      is_owner: true,
+      dates: { '2026-07-01': { status: 'available', is_cancelled: false } },
+    },
+    {
+      user_id: 'player1',
+      username: 'Frodo',
+      is_owner: false,
+      dates: { '2026-07-01': { status: null, is_cancelled: false } },
+    },
+  ],
+}
+
+// Open a row's editable cell menu and pick a status. The chart renders one
+// status-picker button per editable cell, in row order.
+function pickStatusForCell(cellIndex, label) {
+  const buttons = screen.getAllByTitle((_, el) =>
+    ['Available', 'Set availability'].includes(el?.getAttribute('title'))
+  )
+  fireEvent.click(buttons[cellIndex])
+  // The status options render as <button>; the legend renders the same labels
+  // as <span>, so scope to the picker menu by role.
+  fireEvent.click(screen.getByRole('button', { name: label }))
+}
+
+describe('AvailabilityChart', () => {
+  it("threads the player's user_id when the GM edits a player row", () => {
+    const onSetAvailability = vi.fn()
+    render(
+      <AvailabilityChart
+        availability={availability}
+        userId="gm1"
+        isOwner={true}
+        onSetAvailability={onSetAvailability}
+        onCancelDate={vi.fn()}
+      />
+    )
+
+    // Cell index 1 is the player's row (index 0 is the GM's own row).
+    pickStatusForCell(1, 'Unavailable')
+
+    expect(onSetAvailability).toHaveBeenCalledWith('2026-07-01', 'unavailable', 'player1')
+  })
+
+  it("passes the GM's own user_id when the GM edits their own row", () => {
+    const onSetAvailability = vi.fn()
+    render(
+      <AvailabilityChart
+        availability={availability}
+        userId="gm1"
+        isOwner={true}
+        onSetAvailability={onSetAvailability}
+        onCancelDate={vi.fn()}
+      />
+    )
+
+    pickStatusForCell(0, 'Tentative')
+
+    expect(onSetAvailability).toHaveBeenCalledWith('2026-07-01', 'tentative', 'gm1')
+  })
+
+  it('renders a player as a read-only icon/dash for a non-owner viewer', () => {
+    const onSetAvailability = vi.fn()
+    render(
+      <AvailabilityChart
+        availability={availability}
+        userId="player1"
+        isOwner={false}
+        onSetAvailability={onSetAvailability}
+        onCancelDate={vi.fn()}
+      />
+    )
+
+    // A non-owner sees their own row editable and other rows read-only. The
+    // GM row (status 'available') renders as a status icon, not a button.
+    const gmRow = screen.getByText('Gandalf').closest('tr')
+    expect(within(gmRow).queryByRole('button')).toBeNull()
+
+    // The "(you)" badge shows on the viewer's own non-owner row.
+    expect(screen.getByText('(you)')).toBeTruthy()
+  })
+
+  it('shows an em-dash for a read-only cell with no status', () => {
+    const noStatus = {
+      next_sessions: ['2026-07-01'],
+      cancelled_dates: [],
+      rows: [
+        {
+          user_id: 'gm1',
+          username: 'Gandalf',
+          is_owner: true,
+          dates: { '2026-07-01': { status: null, is_cancelled: false } },
+        },
+        {
+          user_id: 'player1',
+          username: 'Frodo',
+          is_owner: false,
+          dates: { '2026-07-01': { status: null, is_cancelled: false } },
+        },
+      ],
+    }
+    // Viewer is the player; the GM's row is read-only with no status → em-dash.
+    const { container } = render(
+      <AvailabilityChart
+        availability={noStatus}
+        userId="player1"
+        isOwner={false}
+        onSetAvailability={vi.fn()}
+        onCancelDate={vi.fn()}
+      />
+    )
+    expect(container.textContent).toContain('—')
+  })
+
+  it('shows the uncancel control on a cancelled date for the GM', () => {
+    const onCancelDate = vi.fn()
+    const cancelled = {
+      next_sessions: ['2026-07-01'],
+      cancelled_dates: ['2026-07-01'],
+      rows: [
+        {
+          user_id: 'gm1',
+          username: 'Gandalf',
+          is_owner: true,
+          dates: { '2026-07-01': { status: 'available', is_cancelled: true } },
+        },
+      ],
+    }
+    render(
+      <AvailabilityChart
+        availability={cancelled}
+        userId="gm1"
+        isOwner={true}
+        onSetAvailability={vi.fn()}
+        onCancelDate={onCancelDate}
+      />
+    )
+
+    fireEvent.click(screen.getByRole('button', { name: 'Un-cancel session' }))
+    expect(onCancelDate).toHaveBeenCalledWith('2026-07-01')
+  })
+
+  it('returns null when there are no upcoming sessions', () => {
+    const { container } = render(
+      <AvailabilityChart
+        availability={{ next_sessions: [], cancelled_dates: [], rows: [] }}
+        userId="gm1"
+        isOwner={true}
+        onSetAvailability={vi.fn()}
+        onCancelDate={vi.fn()}
+      />
+    )
+    expect(container.firstChild).toBeNull()
+  })
+})

--- a/frontend/src/components/campaigns/ScheduleTab.jsx
+++ b/frontend/src/components/campaigns/ScheduleTab.jsx
@@ -25,8 +25,12 @@ export default function ScheduleTab({ campaign, isOwner, userId }) {
     loadAvailability()
   }, [campaign.id])
 
-  const handleSetAvailability = async (date, status) => {
-    await campaigns.setAvailability(campaign.id, date, { status })
+  const handleSetAvailability = async (date, status, targetUserId) => {
+    // Include user_id only when the GM is editing another member's row; the
+    // backend defaults to the caller when it's absent.
+    const body =
+      targetUserId && targetUserId !== userId ? { status, user_id: targetUserId } : { status }
+    await campaigns.setAvailability(campaign.id, date, body)
     loadAvailability()
   }
 

--- a/frontend/src/components/campaigns/ScheduleTab.test.jsx
+++ b/frontend/src/components/campaigns/ScheduleTab.test.jsx
@@ -1,0 +1,186 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { render, screen, waitFor, fireEvent } from '@testing-library/react'
+import ScheduleTab from './ScheduleTab'
+
+vi.mock('../../api', () => ({
+  campaigns: {
+    getSchedule: vi.fn(),
+    getAvailability: vi.fn(),
+    setAvailability: vi.fn(),
+    cancelDate: vi.fn(),
+    setSchedule: vi.fn(),
+    deleteSchedule: vi.fn(),
+  },
+}))
+
+// Stub the editor/summary children so we can drive ScheduleTab's callbacks
+// (onSaved/onDeleted/onEdit) directly without depending on their internals.
+vi.mock('./ScheduleEditor', () => ({
+  default: ({ onSaved, onDeleted }) => (
+    <div>
+      <button
+        onClick={() =>
+          onSaved({
+            definition: { days: [2], frequency: 'weekly', time_utc: '19:00' },
+            enabled: true,
+            next_sessions: ['2026-07-08'],
+          })
+        }
+      >
+        mock-save
+      </button>
+      <button onClick={() => onDeleted()}>mock-delete</button>
+    </div>
+  ),
+}))
+
+vi.mock('./ScheduleSummary', () => ({
+  default: ({ onEdit }) => <button onClick={onEdit}>mock-edit</button>,
+}))
+
+import { campaigns } from '../../api'
+
+const campaign = { id: 'c1' }
+
+const scheduleData = {
+  definition: { days: [1], frequency: 'weekly', time_utc: '18:00' },
+  enabled: true,
+  next_sessions: ['2026-07-01'],
+}
+
+const availability = {
+  next_sessions: ['2026-07-01'],
+  cancelled_dates: [],
+  rows: [
+    {
+      user_id: 'gm1',
+      username: 'Gandalf',
+      is_owner: true,
+      dates: { '2026-07-01': { status: 'available', is_cancelled: false } },
+    },
+    {
+      user_id: 'player1',
+      username: 'Frodo',
+      is_owner: false,
+      dates: { '2026-07-01': { status: null, is_cancelled: false } },
+    },
+  ],
+}
+
+beforeEach(() => {
+  vi.clearAllMocks()
+  campaigns.getSchedule.mockResolvedValue(scheduleData)
+  campaigns.getAvailability.mockResolvedValue(availability)
+  campaigns.setAvailability.mockResolvedValue({})
+  campaigns.cancelDate.mockResolvedValue({})
+})
+
+function clickStatusForCell(cellIndex, label) {
+  const buttons = screen.getAllByTitle((_, el) =>
+    ['Available', 'Set availability'].includes(el?.getAttribute('title'))
+  )
+  fireEvent.click(buttons[cellIndex])
+  fireEvent.click(screen.getByRole('button', { name: label }))
+}
+
+describe('ScheduleTab handleSetAvailability', () => {
+  it("sends user_id when the GM edits another member's row", async () => {
+    render(<ScheduleTab campaign={campaign} isOwner={true} userId="gm1" />)
+    await waitFor(() => expect(screen.getByText('Frodo')).toBeTruthy())
+
+    clickStatusForCell(1, 'Unavailable')
+
+    await waitFor(() =>
+      expect(campaigns.setAvailability).toHaveBeenCalledWith('c1', '2026-07-01', {
+        status: 'unavailable',
+        user_id: 'player1',
+      })
+    )
+  })
+
+  it('omits user_id when the GM edits their own row', async () => {
+    render(<ScheduleTab campaign={campaign} isOwner={true} userId="gm1" />)
+    await waitFor(() => expect(screen.getByText('Gandalf')).toBeTruthy())
+
+    clickStatusForCell(0, 'Tentative')
+
+    await waitFor(() =>
+      expect(campaigns.setAvailability).toHaveBeenCalledWith('c1', '2026-07-01', {
+        status: 'tentative',
+      })
+    )
+  })
+
+  it('reloads availability after a change', async () => {
+    render(<ScheduleTab campaign={campaign} isOwner={true} userId="gm1" />)
+    await waitFor(() => expect(screen.getByText('Frodo')).toBeTruthy())
+    campaigns.getAvailability.mockClear()
+
+    clickStatusForCell(1, 'Unavailable')
+
+    await waitFor(() => expect(campaigns.getAvailability).toHaveBeenCalledWith('c1'))
+  })
+
+  it('cancels a date through the GM cell menu', async () => {
+    render(<ScheduleTab campaign={campaign} isOwner={true} userId="gm1" />)
+    await waitFor(() => expect(screen.getByText('Gandalf')).toBeTruthy())
+
+    // Open the GM's own cell menu (cell 0) and pick the cancel-session action.
+    const buttons = screen.getAllByTitle((_, el) =>
+      ['Available', 'Set availability'].includes(el?.getAttribute('title'))
+    )
+    fireEvent.click(buttons[0])
+    fireEvent.click(screen.getByRole('button', { name: /Cancel session/i }))
+
+    await waitFor(() => expect(campaigns.cancelDate).toHaveBeenCalledWith('c1', '2026-07-01'))
+  })
+
+  it('renders the schedule editor when no schedule is defined', async () => {
+    campaigns.getSchedule.mockResolvedValue({ definition: null, enabled: false, next_sessions: [] })
+    campaigns.getAvailability.mockResolvedValue({
+      next_sessions: [],
+      cancelled_dates: [],
+      rows: [],
+    })
+    render(<ScheduleTab campaign={campaign} isOwner={true} userId="gm1" />)
+
+    // With no definition, the (mocked) editor renders instead of the summary.
+    await waitFor(() => expect(screen.getByText('mock-save')).toBeTruthy())
+    expect(screen.queryByText('mock-edit')).toBeNull()
+  })
+
+  it('switches to the editor from the summary and saves a new schedule', async () => {
+    render(<ScheduleTab campaign={campaign} isOwner={true} userId="gm1" />)
+    await waitFor(() => expect(screen.getByText('mock-edit')).toBeTruthy())
+
+    // Summary → Edit shows the editor.
+    fireEvent.click(screen.getByText('mock-edit'))
+    expect(screen.getByText('mock-save')).toBeTruthy()
+
+    // Saving applies the result, closes the editor, and reloads availability.
+    campaigns.getAvailability.mockClear()
+    fireEvent.click(screen.getByText('mock-save'))
+    await waitFor(() => expect(screen.getByText('mock-edit')).toBeTruthy())
+    expect(campaigns.getAvailability).toHaveBeenCalledWith('c1')
+  })
+
+  it('clears the schedule when the editor reports a deletion', async () => {
+    campaigns.getSchedule.mockResolvedValue({ definition: null, enabled: false, next_sessions: [] })
+    campaigns.getAvailability.mockResolvedValue({
+      next_sessions: [],
+      cancelled_dates: [],
+      rows: [],
+    })
+    render(<ScheduleTab campaign={campaign} isOwner={true} userId="gm1" />)
+    await waitFor(() => expect(screen.getByText('mock-delete')).toBeTruthy())
+
+    campaigns.getAvailability.mockClear()
+    fireEvent.click(screen.getByText('mock-delete'))
+
+    // After deletion the empty-state prompt appears and availability reloads.
+    await waitFor(() =>
+      expect(screen.getByText('No schedule defined yet. Set one above.')).toBeTruthy()
+    )
+    expect(campaigns.getAvailability).toHaveBeenCalledWith('c1')
+  })
+})


### PR DESCRIPTION
## Summary

## Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / cleanup
- [ ] Docs / configuration only

## Testing

- [x] Backend tests pass (`pytest -q`)
- [x] Frontend tests pass (`npm test`)
- [x] Tested manually in the browser
