### PR TITLE
Enhancement: Add container HEALTHCHECK and move build toolchain out of runtime image (#155)

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -6,20 +6,24 @@ RUN npm install
 COPY frontend/ ./
 RUN npm run build
 
-# Stage 2: Python app
-FROM python:3.12-slim
+# Stage 2: Build Python dependencies (compilers live here, not in the runtime image)
+FROM python:3.12-slim AS backend-builder
 
 RUN apt-get update && apt-get install -y --no-install-recommends \
-    libmupdf-dev \
-    mupdf-tools \
     gcc \
     g++ \
     && rm -rf /var/lib/apt/lists/*
 
+COPY backend/requirements.txt .
+RUN pip install --no-cache-dir --prefix=/install -r requirements.txt
+
+# Stage 3: Runtime image (no build toolchain)
+FROM python:3.12-slim
+
 WORKDIR /app
 
-COPY backend/requirements.txt .
-RUN pip install --no-cache-dir -r requirements.txt
+# Bring in the pre-built Python packages from the builder stage.
+COPY --from=backend-builder /install /usr/local
 
 COPY backend/ ./backend/
 COPY --from=frontend-builder /app/frontend/dist ./frontend/dist
@@ -33,5 +37,8 @@ ENV COMMIT_HASH=${COMMIT_HASH}
 ENV PYTHONUNBUFFERED=1
 
 EXPOSE 9481
+
+HEALTHCHECK --interval=30s --timeout=5s --start-period=30s --retries=3 \
+    CMD python -c "import urllib.request,sys; sys.exit(0 if urllib.request.urlopen('http://127.0.0.1:9481/api/health', timeout=4).status == 200 else 1)" || exit 1
 
 CMD ["python", "-m", "uvicorn", "backend.main:app", "--host", "0.0.0.0", "--port", "9481", "--workers", "2"]

--- a/README.md
+++ b/README.md
@@ -144,6 +144,19 @@ docker compose up -d
 docker build --build-arg APP_VERSION=1.0.0 -t grimoire:1.0.0 .
 ```
 
+### 7. Container health
+
+The image ships a `HEALTHCHECK` that probes the unauthenticated `GET /api/health`
+endpoint. It verifies the app is serving on port 9481 and can reach the database
+(and Valkey, when configured), so `docker ps` shows `(healthy)` / `(unhealthy)`
+rather than just "running". Orchestrators can gate startup on it:
+
+```yaml
+depends_on:
+  grimoire:
+    condition: service_healthy
+```
+
 ---
 
 ## Running without Docker

--- a/backend/main.py
+++ b/backend/main.py
@@ -7,10 +7,19 @@ from contextlib import asynccontextmanager
 from fastapi import APIRouter, Depends, FastAPI, Request
 from fastapi.responses import FileResponse, JSONResponse
 from fastapi.staticfiles import StaticFiles
+from sqlalchemy import text
 
 from . import scheduler, session_creator
 from .auth import get_current_user
-from .config import DATA_PATH, LIBRARY_PATH, OPDS_ENABLED, SessionLocal, VERSION, logger
+from .config import (
+    DATA_PATH,
+    LIBRARY_PATH,
+    OPDS_ENABLED,
+    SessionLocal,
+    VERSION,
+    _valkey,
+    logger,
+)
 from .routers import (
     audio as audio_router,
     auth as auth_router,
@@ -150,6 +159,40 @@ if os.path.isdir(_assets_dir):
     app.mount("/assets", StaticFiles(directory=_assets_dir), name="assets")
 
 # --- Public (unauthenticated) routes -----------------------------------------
+@app.get("/api/health", tags=["maintenance"], summary="Liveness/readiness probe")
+def health():
+    """Unauthenticated readiness probe used by the container HEALTHCHECK.
+
+    Verifies the app can reach its dependencies: the database (always) and the
+    Valkey/Redis page cache (only when configured). Returns HTTP 200 with a
+    per-check status when everything is reachable, and HTTP 503 otherwise so
+    orchestrators mark a wedged container unhealthy rather than "up".
+    """
+    checks = {}
+    healthy = True
+
+    db = SessionLocal()
+    try:
+        db.execute(text("SELECT 1"))
+        checks["database"] = "ok"
+    except Exception:
+        checks["database"] = "error"
+        healthy = False
+    finally:
+        db.close()
+
+    if _valkey is not None:
+        try:
+            _valkey.ping()
+            checks["valkey"] = "ok"
+        except Exception:
+            checks["valkey"] = "error"
+            healthy = False
+
+    body = {"status": "ok" if healthy else "unhealthy", "checks": checks}
+    return JSONResponse(body, status_code=200 if healthy else 503)
+
+
 app.include_router(auth_router.public_router)
 app.include_router(oidc_router.public_router)
 app.include_router(library_router.public_router)

--- a/backend/tests/test_health.py
+++ b/backend/tests/test_health.py
@@ -1,0 +1,53 @@
+"""Tests for the unauthenticated /api/health probe used by the HEALTHCHECK."""
+from unittest.mock import MagicMock
+
+import backend.main as main
+
+
+def test_health_ok_no_auth(client):
+    """Health is reachable without a token and reports the DB as ok."""
+    resp = client.get("/api/health")
+    assert resp.status_code == 200
+    body = resp.json()
+    assert body["status"] == "ok"
+    assert body["checks"]["database"] == "ok"
+
+
+def test_health_reports_db_error(client, monkeypatch):
+    """A failing DB check returns 503 and marks the app unhealthy."""
+
+    def boom():
+        session = MagicMock()
+        session.execute.side_effect = RuntimeError("db down")
+        return session
+
+    monkeypatch.setattr(main, "SessionLocal", boom)
+    resp = client.get("/api/health")
+    assert resp.status_code == 503
+    body = resp.json()
+    assert body["status"] == "unhealthy"
+    assert body["checks"]["database"] == "error"
+
+
+def test_health_checks_valkey_when_configured(client, monkeypatch):
+    """When Valkey is configured, a successful ping is reported."""
+    fake = MagicMock()
+    fake.ping.return_value = True
+    monkeypatch.setattr(main, "_valkey", fake)
+    resp = client.get("/api/health")
+    assert resp.status_code == 200
+    body = resp.json()
+    assert body["checks"]["valkey"] == "ok"
+    fake.ping.assert_called_once()
+
+
+def test_health_reports_valkey_error(client, monkeypatch):
+    """A failing Valkey ping marks the app unhealthy with a 503."""
+    fake = MagicMock()
+    fake.ping.side_effect = RuntimeError("valkey down")
+    monkeypatch.setattr(main, "_valkey", fake)
+    resp = client.get("/api/health")
+    assert resp.status_code == 503
+    body = resp.json()
+    assert body["status"] == "unhealthy"
+    assert body["checks"]["valkey"] == "error"

--- a/docs/api.md
+++ b/docs/api.md
@@ -15,7 +15,7 @@ The live API is self-documented via OpenAPI. With the server running:
 
 ## Authentication
 
-All endpoints except `/api/auth/status`, `/api/auth/setup`, `/api/auth/login`, `/api/auth/guest-login`, and `/api/auth/config` require a JWT.
+All endpoints except `/api/health`, `/api/auth/status`, `/api/auth/setup`, `/api/auth/login`, `/api/auth/guest-login`, and `/api/auth/config` require a JWT.
 
 **Header** (preferred for API clients):
 ```
@@ -40,6 +40,12 @@ Tokens are returned by `/api/auth/login` and expire after **30 days**.
 ---
 
 ## Endpoints
+
+### Health
+
+| Endpoint | Method | Auth | Description |
+|----------|--------|------|-------------|
+| `/api/health` | GET | — | Unauthenticated readiness probe used by the container `HEALTHCHECK`. Checks the database (always) and Valkey (only when configured). Returns `200` with `{"status": "ok", "checks": {...}}` when all dependencies are reachable, or `503` with `{"status": "unhealthy", ...}` otherwise. |
 
 ### Auth
 

--- a/docs/docker-install.md
+++ b/docs/docker-install.md
@@ -263,6 +263,7 @@ Your library and all your data (bookmarks, metadata, accounts) are stored in a s
 **The page won't load at `localhost:9481`**
 - Make sure Docker Desktop is running (check for the whale icon in your taskbar/menu bar).
 - Run `docker compose up -d` again from your Grimoire folder and wait a few seconds before refreshing.
+- Check whether the container reports itself healthy with `docker ps` — the `STATUS` column shows `(healthy)` once Grimoire is serving. If it stays `(unhealthy)`, run `docker compose logs grimoire` to see why.
 
 **I see an error about the port being in use**
 - Something else on your computer is using port 9481. In `docker-compose.yml`, change `"9481:9481"` to `"9482:9481"` (or any other unused port) and then access the app at `http://localhost:9482`.


### PR DESCRIPTION
## Summary

Split the Dockerfile into a builder stage (with gcc/g++) and a slim runtime stage that copies the pre-built packages, so the compilers no longer ship in the final image. Also drop libmupdf-dev/mupdf-tools from runtime — pymupdf bundles its own MuPDF and nothing shells out to mutool.

Add an unauthenticated GET /api/health probe that checks the database (always) and Valkey (when configured), returning 503 if a dependency is unreachable, and wire it into a HEALTHCHECK so orchestrators can gate on container health instead of just "process alive".

## Type of change

- [ ] Bug fix
- [x] New feature
- [x] Refactor / cleanup
- [x] Docs / configuration only

## Testing

<!-- How did you verify this works? Check all that apply. -->

- [x] Backend tests pass (`pytest -q`)
- [x] Frontend tests pass (`npm test`)
- [x] Tested manually in the browser

## Notes for reviewer

<!-- Anything that needs extra context, known limitations, or follow-up work. Delete if not needed. -->
