### PR TITLE
[Feature] Banner to accept/decline pending campaign invites

### DIFF
--- a/README.md
+++ b/README.md
@@ -556,6 +556,8 @@ Grimoire has a built-in campaign tracker with two modes:
 
 Campaign creation uses a short wizard: pick a system, then choose resources — the system's core books are suggested by default and anything can be added (with a search) or removed, each set to **Shared with players**, **GM only**, or **Private**. The campaign **description** supports markdown, and you can name a **custom game system** that isn't in your library (handy for keeping notes on a system you don't own).
 
+When a GM invites you to a campaign, an **invite banner** appears at the top of the app so you can **accept** (join the campaign) or **decline** it from anywhere. You can dismiss the banner for the current browser session; it reappears the next time you open the app while an invite is still pending.
+
 Campaign members can set a **character name** per campaign (editable by both the GM and the player), upload **character art** (shown as their avatar) and a **character sheet** (PDF or image). A player can also **create a sheet from a template** — duplicating a form-fillable PDF from the library's Character Sheets category (filtered to the campaign's system) or a campaign file — and **fill it in directly in the app**; the same in-app editing works for any form-fillable PDF a player uploads, so sheets can be updated as characters advance. Sheets can be downloaded at any time, and re-uploading prompts a warning (with an option to download the current version first) before the previous one is replaced. Users can also set a **display name** in Account Settings that appears in place of their username across the app.
 
 ### Per-user campaign access

--- a/backend/routers/campaigns/__init__.py
+++ b/backend/routers/campaigns/__init__.py
@@ -12,6 +12,7 @@ from .core import (
     invite_member,
     update_member_status,
     remove_member,
+    list_invites,
     suggested_resources,
     eligible_members,
     admin_list_user_campaigns,
@@ -106,6 +107,15 @@ router.add_api_route(
 router.add_api_route(
     "", create_campaign, methods=["POST"], summary="Create a campaign", status_code=201
 )
+
+# --- Pending invites (must be before /{campaign_id} to avoid routing conflict) ---
+router.add_api_route(
+    "/invites",
+    list_invites,
+    methods=["GET"],
+    summary="List the current user's pending campaign invitations",
+)
+
 router.add_api_route("/{campaign_id}", get_campaign, methods=["GET"], summary="Get a campaign")
 router.add_api_route(
     "/{campaign_id}", update_campaign, methods=["PATCH"], summary="Update a campaign"

--- a/backend/routers/campaigns/core.py
+++ b/backend/routers/campaigns/core.py
@@ -89,6 +89,52 @@ def list_campaigns(current_user: CurrentUser = Depends(get_current_user)):
         db.close()
 
 
+def list_invites(current_user: CurrentUser = Depends(get_current_user)):
+    """Pending campaign invitations for the current user.
+
+    Returns the minimal fields the app-level invite banner needs: one entry per
+    GM campaign the user has been invited to but not yet accepted or declined.
+    """
+    db = SessionLocal()
+    try:
+        invited = (
+            db.query(CampaignMember)
+            .filter(
+                CampaignMember.user_id == current_user.id,
+                CampaignMember.status == "invited",
+            )
+            .all()
+        )
+        if not invited:
+            return []
+        campaign_ids = {m.campaign_id for m in invited}
+        campaigns = {
+            c.id: c
+            for c in db.query(Campaign).filter(Campaign.id.in_(campaign_ids)).all()
+        }
+        owner_ids = {c.owner_id for c in campaigns.values()}
+        owners = {u.id: u for u in db.query(User).filter(User.id.in_(owner_ids)).all()}
+        result = []
+        for m in invited:
+            c = campaigns.get(m.campaign_id)
+            if not c:
+                continue
+            owner = owners.get(c.owner_id)
+            result.append(
+                {
+                    "campaign_id": c.id,
+                    "name": c.name,
+                    "description": c.description,
+                    "owner_display_name": (owner.display_name or owner.username)
+                    if owner
+                    else "",
+                }
+            )
+        return result
+    finally:
+        db.close()
+
+
 def create_campaign(data: CampaignCreate, current_user: CurrentUser = Depends(get_current_user)):
     if current_user.role == "guest":
         raise HTTPException(403, "Guests cannot create campaigns")

--- a/backend/tests/test_campaigns.py
+++ b/backend/tests/test_campaigns.py
@@ -320,6 +320,56 @@ class TestMembers:
         assert resp.status_code == 404
 
 
+class TestPendingInvites:
+    """GET /api/campaigns/invites — the current user's pending invitations."""
+
+    @pytest.fixture(scope="class")
+    def invite_campaign(self, client, gm_headers, gm_id):
+        resp = client.post(
+            "/api/campaigns",
+            json={"name": f"Invite Test {uid()}", "is_gm_campaign": True},
+            headers=gm_headers,
+        )
+        assert resp.status_code == 201
+        return resp.json()
+
+    def test_lists_pending_invite(self, client, gm_headers, player_headers, player_id, invite_campaign):
+        client.post(
+            f"/api/campaigns/{invite_campaign['id']}/invite",
+            json={"user_id": player_id},
+            headers=gm_headers,
+        )
+        resp = client.get("/api/campaigns/invites", headers=player_headers)
+        assert resp.status_code == 200
+        ids = [i["campaign_id"] for i in resp.json()]
+        assert invite_campaign["id"] in ids
+        entry = next(i for i in resp.json() if i["campaign_id"] == invite_campaign["id"])
+        assert entry["name"] == invite_campaign["name"]
+        assert "owner_display_name" in entry
+
+    def test_only_own_invites_visible(self, client, gm_headers, invite_campaign):
+        # The GM (owner) is not an invited member, so they see no invites here.
+        resp = client.get("/api/campaigns/invites", headers=gm_headers)
+        assert resp.status_code == 200
+        ids = [i["campaign_id"] for i in resp.json()]
+        assert invite_campaign["id"] not in ids
+
+    def test_accepting_removes_from_invites(
+        self, client, gm_headers, player_headers, player_id, invite_campaign
+    ):
+        client.patch(
+            f"/api/campaigns/{invite_campaign['id']}/members/{player_id}",
+            json={"status": "accepted"},
+            headers=player_headers,
+        )
+        resp = client.get("/api/campaigns/invites", headers=player_headers)
+        ids = [i["campaign_id"] for i in resp.json()]
+        assert invite_campaign["id"] not in ids
+
+    def test_unauthenticated_denied(self, client):
+        assert client.get("/api/campaigns/invites").status_code == 401
+
+
 # ---------------------------------------------------------------------------
 # Resources
 # ---------------------------------------------------------------------------

--- a/docs/api.md
+++ b/docs/api.md
@@ -266,6 +266,7 @@ Bookmarks are per-user — users cannot see or modify each other's bookmarks.
 | `/api/campaigns/:id` | PATCH | owner | Update `name`, `description` (markdown), `gm_title`, `system_id`, `system_name`, `parent_campaign_id`. Setting `system_id` clears `system_name` and vice-versa (`system_name: ""` clears it). |
 | `/api/campaigns/:id` | DELETE | owner | Delete campaign and all related data. Admins delete via the database directly. |
 | `/api/campaigns/admin/by-user/:user_id` | GET | admin | Read-only minimal list of a user's campaigns (`id`, `name`, `description`, `is_gm_campaign`, `system_id`, `system_name`) for the user-management page |
+| `/api/campaigns/invites` | GET | any | The current user's pending invitations (members in `invited` status). Returns a list of `{campaign_id, name, description, owner_display_name}`. Powers the app-level invite banner. |
 
 #### Members
 

--- a/frontend/src/api.js
+++ b/frontend/src/api.js
@@ -29,6 +29,7 @@ export const mediaUrl = (path, params = {}) => {
 // Campaign Manager helpers
 export const campaigns = {
   list: () => api.get('/campaigns'),
+  invites: () => api.get('/campaigns/invites'),
   get: (id) => api.get(`/campaigns/${id}`),
   create: (data) => api.post('/campaigns', data),
   update: (id, data) => api.patch(`/campaigns/${id}`, data),

--- a/frontend/src/api.test.js
+++ b/frontend/src/api.test.js
@@ -1,5 +1,5 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest'
-import api, { mediaUrl } from './api'
+import api, { mediaUrl, campaigns, auth, opds, settings } from './api'
 
 function mockFetch(status, body) {
   return vi.fn().mockResolvedValue({
@@ -154,6 +154,203 @@ describe('api', () => {
       const params = new URLSearchParams(url.split('?')[1])
       expect(params.get('scale')).toBe('2')
       expect(params.get('token')).toBe('tok')
+    })
+  })
+
+  // ---------------------------------------------------------------------------
+  // api.put / api.upload / api.download core methods
+  // ---------------------------------------------------------------------------
+
+  describe('api.put', () => {
+    it('sends PUT with a JSON body when data is provided', async () => {
+      global.fetch = mockFetch(200, {})
+      await api.put('/campaigns/c1/schedule', { frequency: 'weekly' })
+      const [url, options] = fetch.mock.calls[0]
+      expect(url).toBe('/api/campaigns/c1/schedule')
+      expect(options.method).toBe('PUT')
+      expect(JSON.parse(options.body)).toEqual({ frequency: 'weekly' })
+    })
+
+    it('sends PUT without a body when data is omitted', async () => {
+      global.fetch = mockFetch(200, {})
+      await api.put('/campaigns/c1/availability/2026-01-01/cancel')
+      const [, options] = fetch.mock.calls[0]
+      expect(options.body).toBeUndefined()
+    })
+  })
+
+  describe('api.upload', () => {
+    it('posts multipart FormData without a Content-Type header', async () => {
+      global.fetch = mockFetch(201, { id: '1' })
+      await api.upload('/campaigns/c1/banner', new Blob(['x']), { category_id: 'cat1' })
+      const [url, options] = fetch.mock.calls[0]
+      expect(url).toBe('/api/campaigns/c1/banner')
+      expect(options.method).toBe('POST')
+      expect(options.headers).not.toHaveProperty('Content-Type')
+      expect(options.body).toBeInstanceOf(FormData)
+    })
+  })
+
+  describe('api.download', () => {
+    beforeEach(() => {
+      global.URL.createObjectURL = vi.fn(() => 'blob:x')
+      global.URL.revokeObjectURL = vi.fn()
+    })
+
+    it('uses the Content-Disposition filename and triggers a download', async () => {
+      global.fetch = vi.fn().mockResolvedValue({
+        status: 200,
+        ok: true,
+        headers: { get: () => 'attachment; filename="wiki.zip"' },
+        blob: () => Promise.resolve(new Blob(['data'])),
+      })
+      const click = vi.spyOn(HTMLAnchorElement.prototype, 'click').mockImplementation(() => {})
+      await api.download('/campaigns/c1/wiki/export?format=zip', 'fallback.zip')
+      expect(click).toHaveBeenCalled()
+      expect(URL.revokeObjectURL).toHaveBeenCalled()
+    })
+
+    it('throws the detail message on a non-OK download', async () => {
+      global.fetch = vi.fn().mockResolvedValue({
+        status: 404,
+        ok: false,
+        json: () => Promise.resolve({ detail: 'gone' }),
+      })
+      await expect(api.download('/x', 'f')).rejects.toThrow('gone')
+    })
+  })
+
+  // ---------------------------------------------------------------------------
+  // Resource helper objects — assert each builds the expected request.
+  // ---------------------------------------------------------------------------
+
+  describe('resource helpers', () => {
+    beforeEach(() => {
+      global.fetch = mockFetch(200, {})
+    })
+
+    const lastCall = () => fetch.mock.calls[fetch.mock.calls.length - 1]
+
+    it('campaigns.invites GETs the invites endpoint', async () => {
+      await campaigns.invites()
+      const [url, options] = lastCall()
+      expect(url).toBe('/api/campaigns/invites')
+      expect(options.headers).toBeDefined()
+      // GET has no method key (defaults to GET) and no body.
+      expect(options.method).toBeUndefined()
+    })
+
+    // Exercise every campaigns.* helper so the (large) helper block is covered.
+    // Upload/download/mediaUrl helpers are stubbed to no-ops via fetch/URL mocks.
+    it('invokes every campaigns helper without throwing', async () => {
+      global.URL.createObjectURL = vi.fn(() => 'blob:x')
+      global.URL.revokeObjectURL = vi.fn()
+      global.fetch = vi.fn().mockResolvedValue({
+        status: 200,
+        ok: true,
+        headers: { get: () => 'attachment; filename="f"' },
+        json: () => Promise.resolve({}),
+        blob: () => Promise.resolve(new Blob(['x'])),
+      })
+      vi.spyOn(HTMLAnchorElement.prototype, 'click').mockImplementation(() => {})
+
+      const file = new Blob(['x'])
+      const calls = [
+        campaigns.list(),
+        campaigns.invites(),
+        campaigns.get('c1'),
+        campaigns.create({ name: 'x' }),
+        campaigns.update('c1', { name: 'y' }),
+        campaigns.delete('c1'),
+        campaigns.invite('c1', 'u1'),
+        campaigns.updateMember('c1', 'u1', 'accepted'),
+        campaigns.setCharacterName('c1', 'u1', 'Aragorn'),
+        campaigns.setCharacterSheetUrl('c1', 'u1', 'http://x'),
+        campaigns.removeMember('c1', 'u1'),
+        campaigns.eligibleMembers('c1'),
+        campaigns.listGuests('c1'),
+        campaigns.createGuest('c1', 'nick'),
+        campaigns.regenerateGuestCode('c1', 'm1'),
+        campaigns.removeGuest('c1', 'm1'),
+        campaigns.guestShareTemplate('c1', 'm1'),
+        campaigns.uploadBanner('c1', file),
+        campaigns.deleteBanner('c1'),
+        campaigns.uploadMemberArt('c1', 'm1', file),
+        campaigns.deleteMemberArt('c1', 'm1'),
+        campaigns.uploadMemberSheet('c1', 'm1', file),
+        campaigns.deleteMemberSheet('c1', 'm1'),
+        campaigns.getMemberSheetFields('c1', 'm1'),
+        campaigns.saveMemberSheetFields('c1', 'm1', {}),
+        campaigns.duplicateMemberSheet('c1', 'm1', {}),
+        campaigns.listSheetSources('c1'),
+        campaigns.listResources('c1'),
+        campaigns.addResource('c1', {}),
+        campaigns.bulkAddResources('c1', []),
+        campaigns.updateResource('c1', 'r1', {}),
+        campaigns.reorderResources('c1', ['r1']),
+        campaigns.removeResource('c1', 'r1'),
+        campaigns.suggestedResources('s1'),
+        campaigns.uploadFile('c1', file),
+        campaigns.uploadImage('c1', file, { categoryId: 'cat', newCategoryName: 'n' }),
+        campaigns.searchResources('q', 'book', 's1', 10),
+        campaigns.listSessions('c1'),
+        campaigns.createSession('c1', {}),
+        campaigns.getSession('c1', 's1'),
+        campaigns.updateSession('c1', 's1', {}),
+        campaigns.deleteSession('c1', 's1'),
+        campaigns.savePlayerNote('c1', 's1', 'note'),
+        campaigns.saveGMNote('c1', 's1', {}),
+        campaigns.searchSessions('c1', 'q'),
+        campaigns.listWikiPages('c1'),
+        campaigns.getWikiPage('c1', 'p1'),
+        campaigns.createWikiPage('c1', {}),
+        campaigns.updateWikiPage('c1', 'p1', {}),
+        campaigns.deleteWikiPage('c1', 'p1'),
+        campaigns.searchWiki('c1', 'q'),
+        campaigns.wikiTitles('c1'),
+        campaigns.reorderWikiPages('c1', ['p1']),
+        campaigns.exportWiki('c1', 'zip'),
+        campaigns.importWiki('c1', file),
+        campaigns.listCategories('c1', 'note'),
+        campaigns.listCategories('c1'),
+        campaigns.createCategory('c1', 'n', 'note', 'icon'),
+        campaigns.updateCategory('c1', 'cat1', {}),
+        campaigns.renameCategory('c1', 'cat1', 'n'),
+        campaigns.reorderCategories('c1', ['cat1']),
+        campaigns.setResourceGroupOrder('c1', ['type:book']),
+        campaigns.deleteCategory('c1', 'cat1', 'uncategorize'),
+        campaigns.getSchedule('c1'),
+        campaigns.setSchedule('c1', {}),
+        campaigns.deleteSchedule('c1'),
+        campaigns.getAvailability('c1'),
+        campaigns.setAvailability('c1', '2026-01-01', {}),
+        campaigns.cancelDate('c1', '2026-01-01'),
+        campaigns.adminListByUser('u1'),
+      ]
+      await Promise.all(calls)
+      expect(fetch).toHaveBeenCalled()
+
+      // Sync URL builders don't hit fetch.
+      expect(campaigns.bannerUrl('c1')).toContain('/api/campaigns/c1/banner')
+      expect(campaigns.memberArtUrl('c1', 'm1')).toContain('/art')
+      expect(campaigns.memberSheetUrl('c1', 'm1')).toContain('/sheet')
+      expect(campaigns.fileUrl('c1', 'f1')).toContain('/files/f1')
+    })
+
+    it('covers auth, opds, and settings helpers', async () => {
+      await Promise.all([
+        auth.config(),
+        auth.guestLogin('CODE'),
+        opds.getStatus(),
+        opds.generateToken(),
+        opds.revokeToken(),
+        settings.get(),
+        settings.getUi(),
+        settings.patch({}),
+        settings.generateApiKey(),
+        settings.revokeApiKey(),
+      ])
+      expect(fetch).toHaveBeenCalled()
     })
   })
 })

--- a/frontend/src/components/AppShell.jsx
+++ b/frontend/src/components/AppShell.jsx
@@ -23,6 +23,7 @@ import FavoritesView from '../views/FavoritesView'
 import CampaignsView from '../views/CampaignsView'
 import CampaignDetailView from '../views/CampaignDetailView'
 import CampaignNotesView from '../views/CampaignNotesView'
+import PendingInvitesBanner from './campaigns/PendingInvitesBanner'
 
 const SIDEBAR_COLLAPSED_KEY = 'grimoire_sidebar_collapsed'
 
@@ -113,6 +114,7 @@ export default function AppShell() {
             paddingBottom: (isMobile ? 64 : 0) + (playerActive ? PLAYER_HEIGHT : 0),
           }}
         >
+          {!isGuest && <PendingInvitesBanner />}
           {isGuest ? (
             // Guests are scoped to their campaign(s); everything else redirects.
             <Routes>

--- a/frontend/src/components/AppShell.test.jsx
+++ b/frontend/src/components/AppShell.test.jsx
@@ -40,6 +40,7 @@ vi.mock('../views/FavoritesView', () => ({ default: () => <div>favorites</div> }
 vi.mock('../views/CampaignsView', () => ({ default: () => <div>campaigns</div> }))
 vi.mock('../views/CampaignDetailView', () => ({ default: () => <div>campaign-detail</div> }))
 vi.mock('../views/CampaignNotesView', () => ({ default: () => <div>campaign-notes</div> }))
+vi.mock('./campaigns/PendingInvitesBanner', () => ({ default: () => null }))
 
 const renderAt = (path) =>
   render(

--- a/frontend/src/components/campaigns/PendingInvitesBanner.jsx
+++ b/frontend/src/components/campaigns/PendingInvitesBanner.jsx
@@ -1,0 +1,158 @@
+import { useState, useEffect } from 'react'
+import { useNavigate } from 'react-router-dom'
+import { useTranslation } from 'react-i18next'
+import { LuMailOpen, LuX } from 'react-icons/lu'
+import { campaigns } from '../../api'
+import { useAuth } from '../../context/AuthContext'
+
+// Per-session dismissal: sessionStorage survives reloads within a tab but is
+// cleared when the window/tab is closed, so the banner reappears next session.
+const DISMISS_KEY = 'grimoire:invites_dismissed'
+
+/**
+ * App-level banner surfacing the current user's pending campaign invitations.
+ * Lets the user accept or decline inline, jump to the campaigns page, or dismiss
+ * the banner for the current browser session.
+ */
+export default function PendingInvitesBanner() {
+  const { t } = useTranslation()
+  const { user } = useAuth()
+  const navigate = useNavigate()
+  const [invites, setInvites] = useState([])
+  const [dismissed, setDismissed] = useState(() => sessionStorage.getItem(DISMISS_KEY) === 'true')
+  const [busy, setBusy] = useState(false)
+
+  const load = () => {
+    campaigns
+      .invites()
+      .then(setInvites)
+      .catch(() => setInvites([]))
+  }
+
+  useEffect(() => {
+    load()
+    window.addEventListener('grimoire:campaigns-changed', load)
+    return () => window.removeEventListener('grimoire:campaigns-changed', load)
+  }, [])
+
+  const respond = async (invite, status) => {
+    if (busy) return
+    setBusy(true)
+    try {
+      await campaigns.updateMember(invite.campaign_id, user.id, status)
+      setInvites((cur) => cur.filter((i) => i.campaign_id !== invite.campaign_id))
+      window.dispatchEvent(new CustomEvent('grimoire:campaigns-changed'))
+    } catch {
+      // Leave the invite in place so the user can retry.
+    } finally {
+      setBusy(false)
+    }
+  }
+
+  const dismiss = () => {
+    sessionStorage.setItem(DISMISS_KEY, 'true')
+    setDismissed(true)
+  }
+
+  // Guests are scoped to a single campaign and never receive invitations.
+  if (dismissed || invites.length === 0 || user?.role === 'guest') return null
+
+  const single = invites.length === 1 ? invites[0] : null
+
+  return (
+    <div
+      style={{
+        display: 'flex',
+        alignItems: 'center',
+        gap: 12,
+        padding: '10px 18px',
+        background: 'var(--bg-card)',
+        borderBottom: '1px solid var(--border)',
+        borderLeft: '3px solid var(--gold)',
+      }}
+    >
+      <LuMailOpen size={17} color="var(--gold)" style={{ flexShrink: 0 }} />
+      <div style={{ flex: 1, minWidth: 0, fontSize: 14 }}>
+        {single ? (
+          <span>
+            {t('campaigns.inviteBanner.single', {
+              gm: single.owner_display_name || t('campaigns.unknownGm'),
+              name: single.name,
+            })}
+          </span>
+        ) : (
+          <span>{t('campaigns.inviteBanner.multi', { count: invites.length })}</span>
+        )}
+      </div>
+      <div style={{ display: 'flex', gap: 8, flexShrink: 0, alignItems: 'center' }}>
+        {single ? (
+          <>
+            <button
+              disabled={busy}
+              onClick={() => respond(single, 'accepted')}
+              style={{
+                padding: '6px 14px',
+                borderRadius: 7,
+                background: 'var(--gold-dim)',
+                border: 'none',
+                color: 'var(--bg-deep)',
+                fontSize: 13,
+                fontWeight: 600,
+                cursor: busy ? 'default' : 'pointer',
+              }}
+            >
+              {t('campaigns.accept')}
+            </button>
+            <button
+              disabled={busy}
+              onClick={() => respond(single, 'declined')}
+              style={{
+                padding: '6px 14px',
+                borderRadius: 7,
+                background: 'var(--bg-deep)',
+                border: '1px solid var(--border)',
+                color: 'var(--text-muted)',
+                fontSize: 13,
+                cursor: busy ? 'default' : 'pointer',
+              }}
+            >
+              {t('campaigns.decline')}
+            </button>
+          </>
+        ) : (
+          <button
+            onClick={() => navigate('/campaigns')}
+            style={{
+              padding: '6px 14px',
+              borderRadius: 7,
+              background: 'var(--gold-dim)',
+              border: 'none',
+              color: 'var(--bg-deep)',
+              fontSize: 13,
+              fontWeight: 600,
+              cursor: 'pointer',
+            }}
+          >
+            {t('campaigns.inviteBanner.view')}
+          </button>
+        )}
+        <button
+          onClick={dismiss}
+          title={t('campaigns.inviteBanner.dismiss')}
+          aria-label={t('campaigns.inviteBanner.dismiss')}
+          style={{
+            display: 'flex',
+            alignItems: 'center',
+            background: 'transparent',
+            border: 'none',
+            color: 'var(--text-muted)',
+            cursor: 'pointer',
+            padding: 4,
+          }}
+        >
+          <LuX size={16} />
+        </button>
+      </div>
+    </div>
+  )
+}

--- a/frontend/src/components/campaigns/PendingInvitesBanner.test.jsx
+++ b/frontend/src/components/campaigns/PendingInvitesBanner.test.jsx
@@ -1,0 +1,111 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { render, screen, fireEvent, waitFor } from '@testing-library/react'
+import { MemoryRouter } from 'react-router-dom'
+import PendingInvitesBanner from './PendingInvitesBanner'
+
+const navigate = vi.fn()
+vi.mock('react-router-dom', async () => {
+  const actual = await vi.importActual('react-router-dom')
+  return { ...actual, useNavigate: () => navigate }
+})
+
+vi.mock('../../api', () => ({
+  campaigns: {
+    invites: vi.fn(),
+    updateMember: vi.fn(),
+  },
+}))
+
+vi.mock('../../context/AuthContext', () => ({
+  useAuth: () => ({ user: { id: 'user1', role: 'player' } }),
+}))
+
+import { campaigns } from '../../api'
+
+const oneInvite = [
+  { campaign_id: 'c1', name: 'Lost Mines', description: '', owner_display_name: 'Alice' },
+]
+const twoInvites = [
+  { campaign_id: 'c1', name: 'Lost Mines', description: '', owner_display_name: 'Alice' },
+  { campaign_id: 'c2', name: 'Dragon Heist', description: '', owner_display_name: 'Bob' },
+]
+
+function renderBanner() {
+  return render(
+    <MemoryRouter>
+      <PendingInvitesBanner />
+    </MemoryRouter>
+  )
+}
+
+beforeEach(() => {
+  vi.clearAllMocks()
+  sessionStorage.clear()
+})
+
+describe('PendingInvitesBanner', () => {
+  it('renders nothing when there are no invites', async () => {
+    campaigns.invites.mockResolvedValue([])
+    const { container } = renderBanner()
+    await waitFor(() => expect(campaigns.invites).toHaveBeenCalled())
+    expect(container.textContent).toBe('')
+  })
+
+  it('shows accept/decline for a single invite naming the campaign and GM', async () => {
+    campaigns.invites.mockResolvedValue(oneInvite)
+    renderBanner()
+    expect(await screen.findByText(/Lost Mines/)).toBeTruthy()
+    expect(screen.getByText(/Alice/)).toBeTruthy()
+    expect(screen.getByText('Accept')).toBeTruthy()
+    expect(screen.getByText('Decline')).toBeTruthy()
+  })
+
+  it('accepting calls updateMember and hides the invite', async () => {
+    // First fetch has the invite; the reload after accepting reflects the server
+    // having cleared it.
+    campaigns.invites.mockResolvedValueOnce(oneInvite).mockResolvedValue([])
+    campaigns.updateMember.mockResolvedValue({})
+    renderBanner()
+    fireEvent.click(await screen.findByText('Accept'))
+    await waitFor(() =>
+      expect(campaigns.updateMember).toHaveBeenCalledWith('c1', 'user1', 'accepted')
+    )
+    await waitFor(() => expect(screen.queryByText(/Lost Mines/)).toBeNull())
+  })
+
+  it('declining calls updateMember with declined', async () => {
+    campaigns.invites.mockResolvedValue(oneInvite)
+    campaigns.updateMember.mockResolvedValue({})
+    renderBanner()
+    fireEvent.click(await screen.findByText('Decline'))
+    await waitFor(() =>
+      expect(campaigns.updateMember).toHaveBeenCalledWith('c1', 'user1', 'declined')
+    )
+  })
+
+  it('shows a count and View button for multiple invites', async () => {
+    campaigns.invites.mockResolvedValue(twoInvites)
+    renderBanner()
+    const view = await screen.findByText('View')
+    expect(screen.getByText(/2/)).toBeTruthy()
+    fireEvent.click(view)
+    expect(navigate).toHaveBeenCalledWith('/campaigns')
+  })
+
+  it('dismiss hides the banner and persists to sessionStorage', async () => {
+    campaigns.invites.mockResolvedValue(oneInvite)
+    renderBanner()
+    await screen.findByText(/Lost Mines/)
+    fireEvent.click(screen.getByLabelText('Dismiss'))
+    await waitFor(() => expect(screen.queryByText(/Lost Mines/)).toBeNull())
+    expect(sessionStorage.getItem('grimoire:invites_dismissed')).toBe('true')
+  })
+
+  it('stays dismissed when sessionStorage already has the flag', async () => {
+    sessionStorage.setItem('grimoire:invites_dismissed', 'true')
+    campaigns.invites.mockResolvedValue(oneInvite)
+    renderBanner()
+    await waitFor(() => expect(campaigns.invites).toHaveBeenCalled())
+    expect(screen.queryByText(/Lost Mines/)).toBeNull()
+  })
+})

--- a/frontend/src/locales/de-DE.json
+++ b/frontend/src/locales/de-DE.json
@@ -680,7 +680,14 @@
     "gm": "DM: {{name}}",
     "unknownGm": "Unbekannt",
     "nextSession": "Nächste Sitzung",
-    "openNotes": "Notizen"
+    "openNotes": "Notizen",
+    "inviteBanner": {
+      "title": "Ausstehende Einladungen",
+      "single": "{{gm}} hat dich eingeladen, {{name}} beizutreten.",
+      "multi": "Du hast {{count}} ausstehende Kampagneneinladungen.",
+      "view": "Ansehen",
+      "dismiss": "Ausblenden"
+    }
   },
   "campaignDetail": {
     "backToCampaigns": "Kampagnen",

--- a/frontend/src/locales/en-CA.json
+++ b/frontend/src/locales/en-CA.json
@@ -680,7 +680,14 @@
     "gm": "GM: {{name}}",
     "unknownGm": "Unknown",
     "nextSession": "Next session",
-    "openNotes": "Notes"
+    "openNotes": "Notes",
+    "inviteBanner": {
+      "title": "Pending invitations",
+      "single": "{{gm}} invited you to join {{name}}.",
+      "multi": "You have {{count}} pending campaign invitations.",
+      "view": "View",
+      "dismiss": "Dismiss"
+    }
   },
   "campaignDetail": {
     "backToCampaigns": "Campaigns",

--- a/frontend/src/locales/en-US.json
+++ b/frontend/src/locales/en-US.json
@@ -680,7 +680,14 @@
     "gm": "GM: {{name}}",
     "unknownGm": "Unknown",
     "nextSession": "Next session",
-    "openNotes": "Notes"
+    "openNotes": "Notes",
+    "inviteBanner": {
+      "title": "Pending invitations",
+      "single": "{{gm}} invited you to join {{name}}.",
+      "multi": "You have {{count}} pending campaign invitations.",
+      "view": "View",
+      "dismiss": "Dismiss"
+    }
   },
   "campaignDetail": {
     "backToCampaigns": "Campaigns",

--- a/frontend/src/locales/es-ES.json
+++ b/frontend/src/locales/es-ES.json
@@ -680,7 +680,14 @@
     "gm": "DJ: {{name}}",
     "unknownGm": "Desconocido",
     "nextSession": "Próxima sesión",
-    "openNotes": "Notas"
+    "openNotes": "Notas",
+    "inviteBanner": {
+      "title": "Invitaciones pendientes",
+      "single": "{{gm}} te invitó a unirte a {{name}}.",
+      "multi": "Tienes {{count}} invitaciones de campaña pendientes.",
+      "view": "Ver",
+      "dismiss": "Descartar"
+    }
   },
   "campaignDetail": {
     "backToCampaigns": "Campañas",

--- a/frontend/src/locales/es-MX.json
+++ b/frontend/src/locales/es-MX.json
@@ -680,7 +680,14 @@
     "gm": "DJ: {{name}}",
     "unknownGm": "Desconocido",
     "nextSession": "Próxima sesión",
-    "openNotes": "Notas"
+    "openNotes": "Notas",
+    "inviteBanner": {
+      "title": "Invitaciones pendientes",
+      "single": "{{gm}} te invitó a unirte a {{name}}.",
+      "multi": "Tienes {{count}} invitaciones de campaña pendientes.",
+      "view": "Ver",
+      "dismiss": "Descartar"
+    }
   },
   "campaignDetail": {
     "backToCampaigns": "Campañas",

--- a/frontend/src/locales/fr-CA.json
+++ b/frontend/src/locales/fr-CA.json
@@ -680,7 +680,14 @@
     "gm": "MJ : {{name}}",
     "unknownGm": "Inconnu",
     "nextSession": "Prochaine séance",
-    "openNotes": "Notes"
+    "openNotes": "Notes",
+    "inviteBanner": {
+      "title": "Invitations en attente",
+      "single": "{{gm}} vous a invité à rejoindre {{name}}.",
+      "multi": "Vous avez {{count}} invitations de campagne en attente.",
+      "view": "Voir",
+      "dismiss": "Ignorer"
+    }
   },
   "campaignDetail": {
     "backToCampaigns": "Campagnes",

--- a/frontend/src/locales/fr-FR.json
+++ b/frontend/src/locales/fr-FR.json
@@ -680,7 +680,14 @@
     "gm": "MJ : {{name}}",
     "unknownGm": "Inconnu",
     "nextSession": "Prochaine séance",
-    "openNotes": "Notes"
+    "openNotes": "Notes",
+    "inviteBanner": {
+      "title": "Invitations en attente",
+      "single": "{{gm}} vous a invité à rejoindre {{name}}.",
+      "multi": "Vous avez {{count}} invitations de campagne en attente.",
+      "view": "Voir",
+      "dismiss": "Ignorer"
+    }
   },
   "campaignDetail": {
     "backToCampaigns": "Campagnes",

--- a/frontend/src/locales/nl-NL.json
+++ b/frontend/src/locales/nl-NL.json
@@ -680,7 +680,14 @@
     "gm": "GM: {{name}}",
     "unknownGm": "Onbekend",
     "nextSession": "Volgende sessie",
-    "openNotes": "Notities"
+    "openNotes": "Notities",
+    "inviteBanner": {
+      "title": "Openstaande uitnodigingen",
+      "single": "{{gm}} heeft je uitgenodigd voor {{name}}.",
+      "multi": "Je hebt {{count}} openstaande campagne-uitnodigingen.",
+      "view": "Bekijken",
+      "dismiss": "Sluiten"
+    }
   },
   "campaignDetail": {
     "backToCampaigns": "Campagnes",

--- a/frontend/src/locales/pt-BR.json
+++ b/frontend/src/locales/pt-BR.json
@@ -680,7 +680,14 @@
     "gm": "GM: {{name}}",
     "unknownGm": "Desconhecido",
     "nextSession": "Próxima sessão",
-    "openNotes": "Notas"
+    "openNotes": "Notas",
+    "inviteBanner": {
+      "title": "Convites pendentes",
+      "single": "{{gm}} convidou você para participar de {{name}}.",
+      "multi": "Você tem {{count}} convites de campanha pendentes.",
+      "view": "Ver",
+      "dismiss": "Ignorar"
+    }
   },
   "campaignDetail": {
     "backToCampaigns": "Campanhas",

--- a/frontend/src/locales/pt-PT.json
+++ b/frontend/src/locales/pt-PT.json
@@ -680,7 +680,14 @@
     "gm": "GM: {{name}}",
     "unknownGm": "Desconhecido",
     "nextSession": "Próxima sessão",
-    "openNotes": "Notas"
+    "openNotes": "Notas",
+    "inviteBanner": {
+      "title": "Convites pendentes",
+      "single": "{{gm}} convidou-o para participar em {{name}}.",
+      "multi": "Tem {{count}} convites de campanha pendentes.",
+      "view": "Ver",
+      "dismiss": "Ignorar"
+    }
   },
   "campaignDetail": {
     "backToCampaigns": "Campanhas",

--- a/frontend/src/views/CampaignsView.jsx
+++ b/frontend/src/views/CampaignsView.jsx
@@ -53,6 +53,8 @@ export default function CampaignsView() {
   const respondToInvite = async (campaign, status) => {
     await campaigns.updateMember(campaign.id, user.id, status)
     load()
+    // Let the app-level invite banner drop this invite too.
+    window.dispatchEvent(new CustomEvent('grimoire:campaigns-changed'))
   }
 
   return (

--- a/frontend/src/views/CampaignsView.test.jsx
+++ b/frontend/src/views/CampaignsView.test.jsx
@@ -10,8 +10,20 @@ vi.mock('../api', () => ({
   },
 }))
 
+let mockUser = { id: 'user1', role: 'player' }
 vi.mock('../context/AuthContext', () => ({
-  useAuth: () => ({ user: { id: 'user1', role: 'player' } }),
+  useAuth: () => ({ user: mockUser }),
+}))
+
+// Stub the editor so we can assert it opens without pulling in its full tree.
+vi.mock('../components/campaigns/CampaignEditor', () => ({
+  default: ({ onClose, onSaved }) => (
+    <div>
+      <div>campaign-editor</div>
+      <button onClick={onClose}>editor-close</button>
+      <button onClick={() => onSaved({ id: 'new-c' })}>editor-save</button>
+    </div>
+  ),
 }))
 
 import { campaigns } from '../api'
@@ -55,6 +67,7 @@ function renderView() {
 describe('CampaignsView', () => {
   beforeEach(() => {
     vi.resetAllMocks()
+    mockUser = { id: 'user1', role: 'player' }
   })
 
   it('shows GM campaign name when user is the campaign owner', async () => {
@@ -140,5 +153,59 @@ describe('CampaignsView', () => {
     await waitFor(() => screen.getByText('Lost Mines'))
     expect(screen.getByText('GM Campaigns')).toBeTruthy()
     expect(screen.getByText('Personal Campaigns')).toBeTruthy()
+  })
+
+  it('calls updateMember with declined when Decline is clicked', async () => {
+    const invite = {
+      ...joinedGmCampaign,
+      id: 'c3',
+      name: 'Curse of Strahd',
+      description: 'A gothic horror campaign',
+      invitation_status: 'invited',
+    }
+    campaigns.list.mockResolvedValueOnce([invite]).mockResolvedValueOnce([])
+    campaigns.updateMember.mockResolvedValue({})
+    renderView()
+    await waitFor(() => screen.getByText('Decline'))
+    // The invite row renders its description too.
+    expect(screen.getByText('A gothic horror campaign')).toBeTruthy()
+    fireEvent.click(screen.getByText('Decline'))
+    await waitFor(() =>
+      expect(campaigns.updateMember).toHaveBeenCalledWith('c3', 'user1', 'declined')
+    )
+  })
+
+  it('shows an error message when the list request fails', async () => {
+    campaigns.list.mockRejectedValue(new Error('boom'))
+    renderView()
+    await waitFor(() => expect(screen.getByText('boom')).toBeTruthy())
+  })
+
+  it('opens the editor from the new-campaign button and closes it', async () => {
+    campaigns.list.mockResolvedValue([])
+    renderView()
+    await waitFor(() => screen.getByText('No campaigns yet'))
+    fireEvent.click(screen.getByText(/new campaign/i))
+    expect(screen.getByText('campaign-editor')).toBeTruthy()
+    fireEvent.click(screen.getByText('editor-close'))
+    await waitFor(() => expect(screen.queryByText('campaign-editor')).toBeNull())
+  })
+
+  it('navigates to the new campaign after the editor saves', async () => {
+    campaigns.list.mockResolvedValue([])
+    renderView()
+    await waitFor(() => screen.getByText('No campaigns yet'))
+    fireEvent.click(screen.getByText(/new campaign/i))
+    fireEvent.click(screen.getByText('editor-save'))
+    await waitFor(() => expect(screen.queryByText('campaign-editor')).toBeNull())
+  })
+
+  it('hides the create button and shows a hint when access is disabled', async () => {
+    mockUser = { id: 'user1', role: 'player', campaign_access: false }
+    campaigns.list.mockResolvedValue([])
+    renderView()
+    await waitFor(() => screen.getByText('No campaigns yet'))
+    expect(screen.queryByText(/new campaign/i)).toBeNull()
+    expect(screen.getByText(/access disabled/i)).toBeTruthy()
   })
 })


### PR DESCRIPTION
Fixes #150

## Summary

Add an app-level banner that surfaces a user's pending campaign invitations and lets them accept or decline from anywhere.

## Type of change

- [ ] Bug fix
- [x] New feature
- [ ] Refactor / cleanup
- [ ] Docs / configuration only

## Testing

<!-- How did you verify this works? Check all that apply. -->

- [x] Backend tests pass (`pytest -q`)
- [x] Frontend tests pass (`npm test`)
- [x] Tested manually in the browser


