### PR TITLE
[Fix] Ignore Calibre "Unknown" author from .opf files

### DIFF
--- a/backend/indexer.py
+++ b/backend/indexer.py
@@ -371,10 +371,11 @@ def parse_opf_metadata(opf_path: str) -> dict:
     if title:
         meta["title"] = title
 
+    # Calibre writes "Unknown" as the creator when no author is set — skip it.
     authors = [
-        el.text.strip()
+        author
         for el in root.findall("opf:metadata/dc:creator", _OPF_NS)
-        if el.text and el.text.strip()
+        if el.text and (author := el.text.strip()) and author.lower() != "unknown"
     ]
     if authors:
         meta["authors"] = authors

--- a/backend/tests/test_indexer_opf.py
+++ b/backend/tests/test_indexer_opf.py
@@ -60,6 +60,29 @@ MULTI_AUTHOR_OPF = dedent("""\
     </package>
 """)
 
+# Calibre writes "Unknown" as the creator when no author is set.
+UNKNOWN_AUTHOR_OPF = dedent("""\
+    <?xml version='1.0' encoding='utf-8'?>
+    <package xmlns="http://www.idpf.org/2007/opf" version="2.0">
+        <metadata xmlns:dc="http://purl.org/dc/elements/1.1/" xmlns:opf="http://www.idpf.org/2007/opf">
+            <dc:title>Authorless Book</dc:title>
+            <dc:creator opf:role="aut">Unknown</dc:creator>
+        </metadata>
+    </package>
+""")
+
+# A real author alongside Calibre's "Unknown" placeholder.
+MIXED_UNKNOWN_AUTHOR_OPF = dedent("""\
+    <?xml version='1.0' encoding='utf-8'?>
+    <package xmlns="http://www.idpf.org/2007/opf" version="2.0">
+        <metadata xmlns:dc="http://purl.org/dc/elements/1.1/" xmlns:opf="http://www.idpf.org/2007/opf">
+            <dc:title>Partly Known</dc:title>
+            <dc:creator opf:role="aut">unknown</dc:creator>
+            <dc:creator opf:role="aut">Alice Smith</dc:creator>
+        </metadata>
+    </package>
+""")
+
 
 # ---------------------------------------------------------------------------
 # parse_opf_metadata — full metadata
@@ -124,6 +147,14 @@ class TestParseOpfMetadataMinimal:
     def test_multiple_authors(self):
         path = _write_opf(self.tmp, "multi.opf", MULTI_AUTHOR_OPF)
         assert parse_opf_metadata(path)["authors"] == ["Alice Smith", "Bob Jones"]
+
+    def test_calibre_unknown_author_omitted(self):
+        path = _write_opf(self.tmp, "unknown.opf", UNKNOWN_AUTHOR_OPF)
+        assert "authors" not in parse_opf_metadata(path)
+
+    def test_calibre_unknown_author_filtered_from_real_authors(self):
+        path = _write_opf(self.tmp, "mixed.opf", MIXED_UNKNOWN_AUTHOR_OPF)
+        assert parse_opf_metadata(path)["authors"] == ["Alice Smith"]
 
     def test_nonexistent_file_returns_empty_dict(self):
         result = parse_opf_metadata(os.path.join(self.tmp, "nonexistent.opf"))


### PR DESCRIPTION
## Summary

Calibre writes <dc:creator>Unknown</dc:creator> when no author is set, which Grimoire imported as a literal "Unknown" author. Filter out any creator whose text is "Unknown" (case-insensitive) when parsing OPF metadata.


## Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / cleanup
- [ ] Docs / configuration only

## Testing

<!-- How did you verify this works? Check all that apply. -->

- [x] Backend tests pass (`pytest -q`)
- [ ] Frontend tests pass (`npm test`)
- [x] Tested manually in the browser

## Notes for reviewer

<!-- Anything that needs extra context, known limitations, or follow-up work. Delete if not needed. -->
