### PR TITLE
[Fix] Cache uploaded campaign files with validators (#154)

### DIFF
--- a/backend/file_cache.py
+++ b/backend/file_cache.py
@@ -1,0 +1,79 @@
+"""Shared helper for serving on-disk files with HTTP cache validators.
+
+Starlette's ``FileResponse`` emits ``ETag``/``Last-Modified`` (derived from the
+file's mtime + size) but does *not* honour ``If-None-Match``/``If-Modified-Since``
+— it only handles ``Range`` requests. This helper adds conditional-request
+handling so a client that already holds a fresh copy gets a cheap ``304 Not
+Modified`` instead of the full body, and attaches a shared ``Cache-Control``
+policy so every uploaded/served file behaves the same way.
+
+Uploaded files (campaign banners, character art, sheets, file resources) are
+mutable — re-uploaded under the same URL — so we cache with revalidation rather
+than the ``immutable`` policy used for content-addressed rendered pages. Because
+the validator is derived from mtime + size, a re-upload naturally invalidates the
+cached copy.
+"""
+
+import os
+from email.utils import formatdate, parsedate
+
+from fastapi import Request
+from fastapi.responses import FileResponse, Response
+from starlette.responses import md5_hexdigest
+
+# Cache for 5 minutes, then revalidate against the validators below. "private"
+# keeps these access-controlled responses out of shared/proxy caches.
+UPLOAD_CACHE_CONTROL = "private, max-age=300, must-revalidate"
+
+
+def _validators(stat_result: os.stat_result) -> tuple[str, str]:
+    """Return the (etag, last_modified) pair Starlette's FileResponse would emit."""
+    etag_base = f"{stat_result.st_mtime}-{stat_result.st_size}"
+    etag = f'"{md5_hexdigest(etag_base.encode(), usedforsecurity=False)}"'
+    last_modified = formatdate(stat_result.st_mtime, usegmt=True)
+    return etag, last_modified
+
+
+def _not_modified(request: Request, etag: str, last_modified: str) -> bool:
+    """True when the client's cached copy is still fresh per RFC 9110 §13.
+
+    ``If-None-Match`` takes precedence over ``If-Modified-Since`` when present.
+    """
+    if_none_match = request.headers.get("if-none-match")
+    if if_none_match is not None:
+        if if_none_match.strip() == "*":
+            return True
+        candidates = {tag.strip().removeprefix("W/") for tag in if_none_match.split(",")}
+        return etag in candidates or etag.removeprefix("W/") in candidates
+
+    if_modified_since = request.headers.get("if-modified-since")
+    if if_modified_since is not None:
+        client = parsedate(if_modified_since)
+        current = parsedate(last_modified)
+        if client is not None and current is not None:
+            return current <= client
+    return False
+
+
+def cached_file_response(request: Request, path: str, **kwargs) -> Response:
+    """Serve ``path`` with cache validators, returning 304 when the client is fresh.
+
+    Accepts the same keyword arguments as ``FileResponse`` (``filename``,
+    ``media_type``, …). Any caller-supplied ``headers`` are preserved and the
+    shared ``Cache-Control`` is added unless the caller already set one.
+    """
+    etag, last_modified = _validators(os.stat(path))
+
+    headers = dict(kwargs.pop("headers", None) or {})
+    headers.setdefault("Cache-Control", UPLOAD_CACHE_CONTROL)
+
+    if _not_modified(request, etag, last_modified):
+        return Response(
+            status_code=304,
+            headers={
+                "ETag": etag,
+                "Last-Modified": last_modified,
+                "Cache-Control": headers["Cache-Control"],
+            },
+        )
+    return FileResponse(path, headers=headers, **kwargs)

--- a/backend/routers/campaigns/uploads.py
+++ b/backend/routers/campaigns/uploads.py
@@ -9,11 +9,11 @@ import io
 import os
 import uuid
 
-from fastapi import Depends, File, Form, HTTPException, UploadFile
-from fastapi.responses import FileResponse
+from fastapi import Depends, File, Form, HTTPException, Request, UploadFile
 
 from ...auth import CurrentUser, get_current_user
 from ...config import CAMPAIGN_UPLOAD_DIR, SessionLocal
+from ...file_cache import cached_file_response
 from ...models import Campaign, CampaignMember
 from ._helpers import assert_can_manage, can_view, get_campaign_or_404
 
@@ -115,7 +115,9 @@ def upload_banner(
         db.close()
 
 
-def get_banner(campaign_id: str, current_user: CurrentUser = Depends(get_current_user)):
+def get_banner(
+    campaign_id: str, request: Request, current_user: CurrentUser = Depends(get_current_user)
+):
     db = SessionLocal()
     try:
         c = get_campaign_or_404(db, campaign_id)
@@ -126,7 +128,7 @@ def get_banner(campaign_id: str, current_user: CurrentUser = Depends(get_current
         path = os.path.join(_BANNER_DIR, c.banner_path)
         if not os.path.isfile(path):
             raise HTTPException(404, "No banner")
-        return FileResponse(path)
+        return cached_file_response(request, path)
     finally:
         db.close()
 
@@ -174,7 +176,10 @@ def upload_member_art(
 
 
 def get_member_art(
-    campaign_id: str, member_id: str, current_user: CurrentUser = Depends(get_current_user)
+    campaign_id: str,
+    member_id: str,
+    request: Request,
+    current_user: CurrentUser = Depends(get_current_user),
 ):
     db = SessionLocal()
     try:
@@ -187,7 +192,7 @@ def get_member_art(
         path = os.path.join(_ART_DIR, member.character_art_path)
         if not os.path.isfile(path):
             raise HTTPException(404, "No art")
-        return FileResponse(path)
+        return cached_file_response(request, path)
     finally:
         db.close()
 
@@ -244,7 +249,10 @@ def upload_member_sheet(
 
 
 def get_member_sheet(
-    campaign_id: str, member_id: str, current_user: CurrentUser = Depends(get_current_user)
+    campaign_id: str,
+    member_id: str,
+    request: Request,
+    current_user: CurrentUser = Depends(get_current_user),
 ):
     db = SessionLocal()
     try:
@@ -257,8 +265,10 @@ def get_member_sheet(
         path = os.path.join(_SHEET_DIR, member.character_sheet_path)
         if not os.path.isfile(path):
             raise HTTPException(404, "No sheet")
-        return FileResponse(
-            path, filename=member.character_sheet_filename or member.character_sheet_path
+        return cached_file_response(
+            request,
+            path,
+            filename=member.character_sheet_filename or member.character_sheet_path,
         )
     finally:
         db.close()
@@ -473,7 +483,10 @@ def upload_campaign_image(
 
 
 def get_campaign_file(
-    campaign_id: str, file_id: str, current_user: CurrentUser = Depends(get_current_user)
+    campaign_id: str,
+    file_id: str,
+    request: Request,
+    current_user: CurrentUser = Depends(get_current_user),
 ):
     from ...models import CampaignFile, CampaignResource, CampaignResourceShare
 
@@ -507,6 +520,8 @@ def get_campaign_file(
         path = os.path.join(_FILES_DIR, cf.stored_path)
         if not os.path.isfile(path):
             raise HTTPException(404, "File not found")
-        return FileResponse(path, filename=cf.filename, media_type=cf.mime_type)
+        return cached_file_response(
+            request, path, filename=cf.filename, media_type=cf.mime_type
+        )
     finally:
         db.close()

--- a/backend/tests/test_campaigns.py
+++ b/backend/tests/test_campaigns.py
@@ -1118,6 +1118,130 @@ class TestCharacterUploads:
         assert m["has_art"] is False
 
 
+class TestUploadCaching:
+    """Uploaded/served files carry cache validators + Cache-Control, revalidate
+    to 304, and change their validator when the file is replaced (issue #154)."""
+
+    @pytest.fixture()
+    def member(self, client, gm_headers, player_headers, player_id):
+        c = client.post(
+            "/api/campaigns",
+            json={"name": f"Cache {uid()}", "is_gm_campaign": True},
+            headers=gm_headers,
+        ).json()
+        client.post(
+            f"/api/campaigns/{c['id']}/invite", json={"user_id": player_id}, headers=gm_headers
+        )
+        client.patch(
+            f"/api/campaigns/{c['id']}/members/{player_id}",
+            json={"status": "accepted"},
+            headers=player_headers,
+        )
+        body = client.get(f"/api/campaigns/{c['id']}", headers=gm_headers).json()
+        member_id = next(m["id"] for m in body["members"] if not m.get("is_owner"))
+        return c, member_id
+
+    def _upload_banner(self, client, gm_headers, cid, color=(120, 80, 200)):
+        resp = client.post(
+            f"/api/campaigns/{cid}/banner",
+            files={"file": ("banner.png", _png_bytes(color), "image/png")},
+            headers=gm_headers,
+        )
+        assert resp.status_code == 200, resp.text
+
+    def test_banner_has_cache_headers(self, client, gm_headers, member):
+        c, _ = member
+        self._upload_banner(client, gm_headers, c["id"])
+        img = client.get(f"/api/campaigns/{c['id']}/banner", headers=gm_headers)
+        assert img.status_code == 200
+        assert "private" in img.headers["cache-control"]
+        assert "max-age=" in img.headers["cache-control"]
+        assert img.headers.get("etag")
+        assert img.headers.get("last-modified")
+
+    def test_banner_conditional_request_returns_304(self, client, gm_headers, member):
+        c, _ = member
+        self._upload_banner(client, gm_headers, c["id"])
+        first = client.get(f"/api/campaigns/{c['id']}/banner", headers=gm_headers)
+        etag = first.headers["etag"]
+        revalidated = client.get(
+            f"/api/campaigns/{c['id']}/banner",
+            headers={**gm_headers, "If-None-Match": etag},
+        )
+        assert revalidated.status_code == 304
+
+    def test_if_modified_since_returns_304(self, client, gm_headers, member):
+        c, _ = member
+        self._upload_banner(client, gm_headers, c["id"])
+        first = client.get(f"/api/campaigns/{c['id']}/banner", headers=gm_headers)
+        last_modified = first.headers["last-modified"]
+        revalidated = client.get(
+            f"/api/campaigns/{c['id']}/banner",
+            headers={**gm_headers, "If-Modified-Since": last_modified},
+        )
+        assert revalidated.status_code == 304
+
+    def test_wildcard_if_none_match_returns_304(self, client, gm_headers, member):
+        c, _ = member
+        self._upload_banner(client, gm_headers, c["id"])
+        revalidated = client.get(
+            f"/api/campaigns/{c['id']}/banner",
+            headers={**gm_headers, "If-None-Match": "*"},
+        )
+        assert revalidated.status_code == 304
+
+    def test_reupload_changes_validator(self, client, gm_headers, member):
+        c, _ = member
+        self._upload_banner(client, gm_headers, c["id"], color=(10, 20, 30))
+        etag = client.get(f"/api/campaigns/{c['id']}/banner", headers=gm_headers).headers["etag"]
+        # A differently sized/mtimed image invalidates the mtime+size-derived ETag.
+        self._upload_banner(client, gm_headers, c["id"], color=(200, 200, 200))
+        new_etag = client.get(
+            f"/api/campaigns/{c['id']}/banner", headers=gm_headers
+        ).headers["etag"]
+        assert new_etag != etag
+
+    def test_art_and_sheet_have_cache_headers(self, client, gm_headers, member):
+        c, member_id = member
+        client.post(
+            f"/api/campaigns/{c['id']}/members/{member_id}/art",
+            files={"file": ("art.png", _png_bytes(), "image/png")},
+            headers=gm_headers,
+        )
+        art = client.get(
+            f"/api/campaigns/{c['id']}/members/{member_id}/art", headers=gm_headers
+        )
+        assert art.status_code == 200
+        assert "max-age=" in art.headers["cache-control"]
+        assert art.headers.get("etag")
+
+        client.post(
+            f"/api/campaigns/{c['id']}/members/{member_id}/sheet",
+            files={"file": ("hero.pdf", b"%PDF-1.4 fake", "application/pdf")},
+            headers=gm_headers,
+        )
+        sheet = client.get(
+            f"/api/campaigns/{c['id']}/members/{member_id}/sheet", headers=gm_headers
+        )
+        assert sheet.status_code == 200
+        assert "max-age=" in sheet.headers["cache-control"]
+        assert sheet.headers.get("etag")
+
+    def test_campaign_file_has_cache_headers(self, client, gm_headers, member):
+        c, _ = member
+        res = client.post(
+            f"/api/campaigns/{c['id']}/files",
+            files={"file": ("h.txt", b"hello world", "text/plain")},
+            headers=gm_headers,
+        ).json()
+        dl = client.get(
+            f"/api/campaigns/{c['id']}/files/{res['resource_id']}", headers=gm_headers
+        )
+        assert dl.status_code == 200
+        assert "max-age=" in dl.headers["cache-control"]
+        assert dl.headers.get("etag")
+
+
 # ---------------------------------------------------------------------------
 # In-app character sheets: AcroForm fields + duplicate from a template
 # ---------------------------------------------------------------------------

--- a/docs/api.md
+++ b/docs/api.md
@@ -301,6 +301,8 @@ Guests authenticate via [`/api/auth/guest-login`](#auth) and may write only thei
 
 Files are stored on disk under `DATA_PATH/campaign_uploads/`. Banners are keyed by campaign id; character art and sheets are keyed by the **CampaignMember id** (`member.id` from the campaign-detail response), so a player in multiple campaigns gets a distinct file per membership. Image uploads (banner, art) accept PNG/JPEG/WebP/GIF up to 5 MB; sheets additionally accept PDF up to 15 MB. Serving endpoints accept the `?token=` query param for use in `<img>`/download URLs.
 
+The GET (serving) endpoints for banners, art, sheets, and campaign files (`/files/:file_id`) set `Cache-Control: private, max-age=300, must-revalidate` along with `ETag`/`Last-Modified` validators derived from the file's mtime + size. A conditional request (`If-None-Match`/`If-Modified-Since`) with a matching validator returns `304 Not Modified`; re-uploading a file changes its validator so clients refetch.
+
 | Endpoint | Method | Auth | Description |
 |----------|--------|------|-------------|
 | `/api/campaigns/:id/banner` | POST | owner | Upload/replace campaign banner (multipart `file`) |


### PR DESCRIPTION
## Summary

Campaign banners, character art, sheets, and file resources were served via bare FileResponse with no Cache-Control, so browsers re-downloaded them on every view. Starlette's FileResponse emits ETag/Last-Modified but does not honour conditional requests (only Range), so no 304 revalidation happened.

## Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / cleanup
- [ ] Docs / configuration only

## Testing

<!-- How did you verify this works? Check all that apply. -->

- [x] Backend tests pass (`pytest -q`)
- [x] Frontend tests pass (`npm test`)
- [x] Tested manually in the browser

## Notes for reviewer

<!-- Anything that needs extra context, known limitations, or follow-up work. Delete if not needed. -->
