### PR TITLE
[Fix]: match category keywords on whole tokens, not substrings (#188)

### DIFF
--- a/backend/indexer.py
+++ b/backend/indexer.py
@@ -120,13 +120,47 @@ def _normalize_folder(name: str) -> str:
     return re.sub(r"[-_\s]+", " ", name.lower()).strip()
 
 
+def _token_matches_keyword(token: str, kw_token: str) -> bool:
+    """Match a single folder token against a single keyword on word boundaries.
+
+    Accepts an exact match or a simple English plural of the keyword
+    (``supplement`` -> ``supplements``, ``bestiary`` -> ``bestiaries``) so that
+    folders like ``Supplements`` or ``Maps`` still classify, while incidental
+    substrings (``mm`` inside ``gamma``) no longer do.
+    """
+    if token == kw_token:
+        return True
+    if token == kw_token + "s":
+        return True
+    if token == kw_token + "es":
+        return True
+    if kw_token.endswith("y") and token == kw_token[:-1] + "ies":
+        return True
+    return False
+
+
+def _keyword_matches(keyword: str, tokens: list[str]) -> bool:
+    """Return True if ``keyword`` matches ``tokens`` on whole-word boundaries.
+
+    Single-word keywords must match a whole token (so ``mm`` no longer matches
+    inside ``gamma``). Multi-word keywords (e.g. ``character sheet``) match as a
+    contiguous run of tokens.
+    """
+    kw_tokens = keyword.split()
+    n = len(kw_tokens)
+    for i in range(len(tokens) - n + 1):
+        if all(_token_matches_keyword(tokens[i + j], kw_tokens[j]) for j in range(n)):
+            return True
+    return False
+
+
 def guess_category(filepath: str) -> str:
     """Infer book category from path segments, innermost folder takes priority."""
     segments = filepath.replace("\\", "/").split("/")
     for segment in reversed(segments[:-1]):
-        normalized = _normalize_folder(segment)
+        tokens = _normalize_folder(segment).split()
         for category, keywords in CATEGORY_MAP.items():
-            if any(kw in normalized for kw in keywords):
+            if any(_keyword_matches(kw, tokens) for kw in keywords):
                 return category
     # 4+ segments means a named subfolder exists under the system root
     if len(segments) > 3:

--- a/backend/tests/test_indexer_category.py
+++ b/backend/tests/test_indexer_category.py
@@ -102,8 +102,6 @@ class TestSubfoldersWithinCategory:
         assert result == "supplement"
 
     def test_homebrew_subfolder_still_homebrew(self):
-        # Use a subfolder name that doesn't accidentally contain a category keyword
-        # as a substring (e.g. "Community" contains "mm" which matches "core").
         result = guess_category("books/D&D 5e/homebrew/Personal/custom.pdf")
         assert result == "homebrew"
 
@@ -124,6 +122,46 @@ class TestSubfoldersWithinCategory:
         # books/System/adventures/AP Name/Part 1/chapter.pdf → adventure
         result = guess_category("books/PF2e/adventures/Abomination Vaults/Part 1/ruins.pdf")
         assert result == "adventure"
+
+
+class TestWholeWordKeywordMatching:
+    """Regression tests for issue #188: keywords must match whole tokens, not substrings.
+
+    Short keywords like ``mm`` (core) previously matched inside unrelated words
+    (``ga**mm**a``), misclassifying campaign books as Core.
+    """
+
+    def test_gamma_world_under_campaigns_is_adventure(self):
+        # "gamma" contains the substring "mm" (a core keyword) but is not the
+        # token "mm"; the explicit campaigns/ folder should win.
+        result = guess_category("books/Gamma World/campaigns/Gamma World/gw.pdf")
+        assert result == "adventure"
+
+    def test_gamma_token_alone_does_not_match_core(self):
+        # A folder literally named "Gamma World" must not classify as core.
+        result = guess_category("books/System/Gamma World/gw.pdf")
+        assert result == "gamma-world"
+
+    def test_hollow_world_under_campaigns_is_adventure(self):
+        result = guess_category("books/D&D BECMI/campaigns/Hollow World/hw.pdf")
+        assert result == "adventure"
+
+    def test_rules_cyclopedia_still_matches_core(self):
+        # Genuine whole-token match on "rules" is preserved.
+        result = guess_category("books/D&D BECMI/core/Rules Cyclopedia/rc.pdf")
+        assert result == "core"
+
+    def test_map_substring_does_not_false_match(self):
+        # "map" is a keyword; "Champaign" / "Mapper" style substrings should not hit.
+        result = guess_category("books/System/Roadmapping/notes.pdf")
+        assert result == "roadmapping"
+
+    def test_multiword_keyword_still_matches(self):
+        # Multi-word keywords (character sheet) match as contiguous tokens.
+        assert guess_category("books/D&D 5e/Character Sheet/blank.pdf") == "character-sheet"
+
+    def test_multiword_keyword_battle_map(self):
+        assert guess_category("books/D&D 5e/Battle Map/grid.pdf") == "map"
 
 
 class TestIsSystemAgnosticFolder:


### PR DESCRIPTION
## Summary

Books under a top-level campaigns/ folder were sometimes misclassified as Core because guess_category() tested CATEGORY_MAP keywords with substring matching. Short keywords collided with unrelated words (e.g. "mm" matched inside "gamma"), so "Gamma World" resolved to core and shadowed the explicit campaigns/ folder.

## Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / cleanup
- [ ] Docs / configuration only

## Testing

<!-- How did you verify this works? Check all that apply. -->

- [x] Backend tests pass (`pytest -q`)
- [x] Frontend tests pass (`npm test`)
- [x] Tested manually in the browser

