### PR TITLE
Feature: Add in-process OCR for image-only PDFs (#88)

### DIFF
--- a/.github/workflows/edge.yml
+++ b/.github/workflows/edge.yml
@@ -38,6 +38,7 @@ jobs:
         uses: docker/build-push-action@v6
         with:
           context: .
+          target: ocr
           push: true
           platforms: linux/amd64,linux/arm64/v8
           build-args: |

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -45,10 +45,12 @@ jobs:
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3
 
-      - name: Build and push
+      # Default image: bundles Tesseract OCR (see Dockerfile `ocr` target).
+      - name: Build and push (OCR)
         uses: docker/build-push-action@v6
         with:
           context: .
+          target: ocr
           push: true
           platforms: linux/amd64,linux/arm64/v8
           build-args: |
@@ -59,6 +61,25 @@ jobs:
             ${{ env.IMAGE }}:${{ steps.ver.outputs.major }}
             ${{ env.IMAGE }}:${{ steps.ver.outputs.minor }}
             ${{ env.IMAGE }}:${{ steps.ver.outputs.version }}
+          cache-from: type=gha
+          cache-to: type=gha,mode=max
+
+      # Slim variant: no OCR engine, smaller image (see Dockerfile `slim` target).
+      - name: Build and push (slim, no OCR)
+        uses: docker/build-push-action@v6
+        with:
+          context: .
+          target: slim
+          push: true
+          platforms: linux/amd64,linux/arm64/v8
+          build-args: |
+            APP_VERSION=${{ steps.ver.outputs.version }}
+            COMMIT_HASH=${{ github.sha }}
+          tags: |
+            ${{ env.IMAGE }}:slim
+            ${{ env.IMAGE }}:${{ steps.ver.outputs.major }}-slim
+            ${{ env.IMAGE }}:${{ steps.ver.outputs.minor }}-slim
+            ${{ env.IMAGE }}:${{ steps.ver.outputs.version }}-slim
           cache-from: type=gha
           cache-to: type=gha,mode=max
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -17,8 +17,8 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
 COPY backend/requirements.txt .
 RUN pip install --no-cache-dir --prefix=/install -r requirements.txt
 
-# Stage 3: Runtime image (no build toolchain)
-FROM python:3.12-slim
+# Stage 3: Runtime base shared by both variants (no build toolchain)
+FROM python:3.12-slim AS runtime-base
 
 WORKDIR /app
 
@@ -50,3 +50,19 @@ HEALTHCHECK --interval=30s --timeout=5s --start-period=30s --retries=3 \
 
 ENV WORKERS=2
 CMD ["sh", "-c", "exec python -m uvicorn backend.main:app --host 0.0.0.0 --port 9481 --workers ${WORKERS}"]
+
+# Stage 4a: Slim variant — no OCR engine. Grimoire degrades gracefully: image-only
+# PDFs stay excluded from full-text search, exactly as before OCR was added. Built
+# with `--target slim` and published under the `-slim` tag family.
+FROM runtime-base AS slim
+
+# Stage 4b: Default variant — bundles Tesseract + English language data so image-only
+# PDFs are OCR'd into the full-text index out of the box. Extra languages can be added
+# at runtime by mounting tessdata and setting OCR_LANGUAGES (see README); no rebuild
+# required. This is the last stage, so a plain `docker build` (no --target) yields it.
+FROM runtime-base AS ocr
+
+RUN apt-get update && apt-get install -y --no-install-recommends \
+    tesseract-ocr \
+    tesseract-ocr-eng \
+    && rm -rf /var/lib/apt/lists/*

--- a/README.md
+++ b/README.md
@@ -103,6 +103,8 @@ Or pin to a specific release:
 docker pull hunterreadca/grimoire:1.0.0
 ```
 
+**Image variants:** the default tags (`latest`, `1.0.0`, …) include the Tesseract OCR engine so image-only PDFs are searchable (see [OCR](#ocr)). If you don't need OCR and prefer a smaller image, use the matching `-slim` tag (e.g. `hunterreadca/grimoire:latest`'s slim counterpart `:slim`, or a pinned `:1.0.0-slim`), which omits Tesseract.
+
 ### 4. Minimal `docker-compose.yml`
 
 ```yaml
@@ -454,6 +456,8 @@ After adding files, trigger a **Rescan** in Grimoire (sidebar or Settings → Ma
 | `DATA_PATH` | `/app/data` | Optional path for the database, thumbnails, and search cache inside the container if not mounted at /app/data |
 | `BASE_URL` | `http://localhost:9481` | Public base URL of this instance. Set this to the URL you use to access Grimoire (e.g. `https://grimoire.example.com`) when running behind a reverse proxy — used to build absolute links in OPDS feeds and other places that need a fully-qualified URL. |
 | `VALKEY_URL` | — | Optional Redis-compatible cache URL for rendered page images (e.g. `redis://valkey:6379/0`) |
+| `OCR_ENABLED` | `true` | Optional. Set to `false` to disable OCR of image-only PDFs even on the OCR-capable image. See [OCR](#ocr) below. |
+| `OCR_LANGUAGES` | `eng` | Optional. Tesseract language codes for OCR, e.g. `eng` or `eng+deu+fra`. Extra languages require their tessdata files to be present (see [OCR](#ocr)). |
 | `OPDS_ENABLED` | `false` | Optional, Set to `true` to enable the OPDS catalog. See [OPDS](#opds) below. |
 | `LOG_LEVEL` | `info` | Optional Console/Docker log verbosity: `debug`, `info`, `warning`, `error`, or `critical`. The in-app Logs tab (Settings → Logs) always captures `debug`-level entries regardless of this setting. |
 | `ALLOW_PASSWORD_AUTHENTICATION` | — | Optional, `true` or `false`. When set, pins password authentication on or off and overrides the toggle in Settings → Authentication (the toggle is shown read-only). When unset, the in-app setting is used. First-run admin setup always requires a username and password regardless of this value. |
@@ -483,6 +487,17 @@ volumes:
 On first startup Grimoire scans the library and indexes every PDF page for full-text search. This can take several minutes for large collections. The index is stored in the data volume and subsequent startups are fast.
 
 Use the **Rescan** button in the sidebar to pick up newly added files, or configure a scheduled rescan in **Settings → Maintenance**.
+
+### OCR
+
+Some PDFs contain only scanned page images with no embedded text layer (common with older, scanned game books). These can't be full-text searched from their text layer alone and show an **Image Only** badge.
+
+The default Grimoire image bundles the [Tesseract](https://github.com/tesseract-ocr/tesseract) OCR engine (English), so on first scan these image-only PDFs are run through OCR and their recognised text is added to the search index. Books indexed this way show an **OCR** badge. OCR runs entirely in-process — no extra container or service is required.
+
+- **Disable OCR:** set `OCR_ENABLED=false`. Image-only PDFs are then left unindexed (the pre-OCR behaviour), exactly as on the slim image.
+- **Slim image:** the `-slim` tags (e.g. `hunterreadca/grimoire:v1.5.0-slim`, `:slim`, `:edge-slim`) omit Tesseract for a smaller image. OCR is automatically disabled there and Grimoire degrades gracefully.
+- **Re-queue on upgrade:** when OCR becomes available (upgrading from a slim image, or enabling it), previously image-only books are automatically re-queued for OCR on the next startup scan.
+- **Additional languages:** set `OCR_LANGUAGES` to a `+`-joined list of Tesseract language codes (e.g. `eng+deu+fra`). The extra languages' tessdata files must be present in the image's tessdata directory — mount a directory of `.traineddata` files over it (or point `TESSDATA_PREFIX` at a mounted directory) to add languages without rebuilding.
 
 ### Page rendering
 

--- a/backend/config.py
+++ b/backend/config.py
@@ -21,6 +21,18 @@ THUMB_DIR = os.path.join(DATA_PATH, "thumbnails")
 PAGE_CACHE_DIR = os.path.join(DATA_PATH, "page_cache")
 CAMPAIGN_UPLOAD_DIR = os.path.join(DATA_PATH, "campaign_uploads")
 VALKEY_URL = os.environ.get("VALKEY_URL", "")
+
+# OCR: image-only PDFs (scanned pages with no embedded text layer) can be run
+# through Tesseract so their text is added to the full-text index. The default
+# image bundles Tesseract + English; the `-slim` image omits it and degrades
+# gracefully (image-only PDFs stay unindexed). OCR is auto-disabled when the
+# tesseract binary is absent, so no config is needed to turn it off on slim.
+#   OCR_ENABLED   — "false" force-disables OCR even when tesseract is present.
+#   OCR_LANGUAGES — Tesseract language codes, e.g. "eng" or "eng+deu+fra".
+#                   Extra languages need their tessdata files present (bundle
+#                   them by mounting a tessdata dir and setting TESSDATA_PREFIX).
+OCR_ENABLED = os.environ.get("OCR_ENABLED", "true").lower() == "true"
+OCR_LANGUAGES = os.environ.get("OCR_LANGUAGES", "eng").strip() or "eng"
 _PAGE_CACHE_HEADERS = {"Cache-Control": "max-age=31536000, immutable"}
 
 # Optional override for password authentication. When the env var is set,

--- a/backend/indexer.py
+++ b/backend/indexer.py
@@ -18,6 +18,7 @@ from sqlalchemy import text
 from sqlalchemy.exc import IntegrityError
 from sqlalchemy.orm import Session
 
+from . import ocr
 from .models import GameSystem, Book, GenericMap, MapFolder, Token, TokenFolder, Audio, AudioFolder
 
 logger = logging.getLogger("grimoire.indexer")
@@ -392,19 +393,39 @@ def generate_thumbnail(filepath: str, output_path: str, size: tuple = (300, 400)
     return bool(result[0])
 
 
-def extract_text_from_pdf(filepath: str, should_stop=None) -> list[dict]:
-    """Extract text from all pages of a PDF. Returns list of {page, content}."""
+def extract_text_from_pdf(filepath: str, should_stop=None) -> tuple[list[dict], bool]:
+    """Extract text from all pages of a PDF.
+
+    Returns ``(pages, used_ocr)`` where ``pages`` is a list of
+    ``{page, content}`` dicts and ``used_ocr`` is True if any page's text came
+    from OCR rather than an embedded text layer.
+
+    Pages with an embedded text layer are read directly. Pages with no embedded
+    text are OCR'd when OCR is available (default image); otherwise they are
+    skipped, so a PDF with no extractable text yields an empty list — the
+    caller then marks it ``image-only``.
+    """
     pages = []
+    used_ocr = False
+    ocr_on = ocr.ocr_available()
     try:
         doc = _fitz_open_with_timeout(filepath, should_stop=should_stop)
         for i, page in enumerate(doc):
+            if should_stop and should_stop():
+                break
             page_text = page.get_text().strip()
             if page_text:
                 pages.append({"page": i + 1, "content": page_text})
+            elif ocr_on:
+                pix = page.get_pixmap(matrix=fitz.Matrix(2, 2), alpha=False)
+                ocr_text = ocr.ocr_pixmap(pix, should_stop=should_stop)
+                if ocr_text:
+                    pages.append({"page": i + 1, "content": ocr_text})
+                    used_ocr = True
         doc.close()
     except Exception as e:
         logger.error(f"Text extraction failed for {filepath}: {e}")
-    return pages
+    return pages, used_ocr
 
 
 def _count_eligible_files(directory: Path, extensions: set) -> int:
@@ -1461,7 +1482,7 @@ def index_book_text(book: Book, data_path: str, session: Session, should_stop=No
         return False
 
     logger.info(f"Indexing: extracting text from '{book.filepath}'")
-    pages = extract_text_from_pdf(book.filepath, should_stop=should_stop)
+    pages, used_ocr = extract_text_from_pdf(book.filepath, should_stop=should_stop)
     if not pages:
         logger.info(f"No text extracted from '{book.filename}' — image-only PDF, marking as indexed")
         book.index_error = "image-only"
@@ -1485,7 +1506,9 @@ def index_book_text(book: Book, data_path: str, session: Session, should_stop=No
         )
 
     book.indexed = True
-    book.index_error = ""
+    # "ocr" marks books whose text was (at least partly) recognised via OCR, so
+    # the UI can badge them and startup re-queue can target them. Empty = native.
+    book.index_error = "ocr" if used_ocr else ""
     logger.debug(f"DB: committing index for '{book.filename}'")
     try:
         _run_with_timeout(session.commit, _DB_TIMEOUT, f"commit index '{book.filepath}'")

--- a/backend/main.py
+++ b/backend/main.py
@@ -106,6 +106,18 @@ async def lifespan(app: FastAPI):
         clear_stop()
         _set_status({**_DEFAULT_STATUS})
         try:
+            # If OCR is available, re-queue any books previously skipped as
+            # image-only so this scan runs them through OCR.
+            from . import ocr
+
+            db = SessionLocal()
+            try:
+                ocr.requeue_image_only_books(db)
+            except Exception as e:
+                logger.error(f"OCR re-queue error: {e}")
+            finally:
+                db.close()
+
             logger.info(f"Scanning library at {LIBRARY_PATH}...")
             run_rescan_sync()
         finally:

--- a/backend/ocr.py
+++ b/backend/ocr.py
@@ -1,0 +1,138 @@
+"""Optional OCR support for image-only PDFs.
+
+Image-only PDFs (scanned pages with no embedded text layer) yield no text from
+PyMuPDF's ``get_text()`` and are otherwise excluded from full-text search. When
+Tesseract is available, the indexer renders each such page to an image and runs
+it through OCR here so the recognised text can be added to the FTS index.
+
+Everything is best-effort and degrades gracefully: on the ``-slim`` image the
+tesseract binary is absent, ``ocr_available()`` returns False, and callers fall
+back to the pre-OCR ``image-only`` behaviour. OCR is CPU-heavy and can hang on
+pathological input, so ``ocr_image`` runs Tesseract in a daemon thread with a
+timeout, mirroring the rest of the indexer.
+"""
+
+import logging
+import threading
+
+from PIL import Image
+
+from . import config
+
+logger = logging.getLogger("grimoire.ocr")
+
+# Per-page OCR budget. Scanned pages are slow; anything beyond this is treated
+# as a hang and abandoned so a single bad page can't stall the whole scan.
+_OCR_TIMEOUT = 120  # seconds
+
+# Cached result of the tesseract-binary probe (None = not yet probed).
+_available: bool | None = None
+
+
+def _probe_tesseract() -> bool:
+    """Return True if pytesseract is importable and the tesseract binary runs."""
+    try:
+        import pytesseract  # local import keeps startup light on slim images
+
+        pytesseract.get_tesseract_version()
+        return True
+    except Exception as exc:  # ImportError, TesseractNotFoundError, etc.
+        logger.debug(f"Tesseract not available: {exc}")
+        return False
+
+
+def ocr_available() -> bool:
+    """Whether OCR can run: enabled in config AND tesseract is usable.
+
+    The tesseract probe is cached after the first call; ``OCR_ENABLED`` is read
+    live so tests can toggle it without clearing the cache.
+    """
+    global _available
+    if not config.OCR_ENABLED:
+        return False
+    if _available is None:
+        _available = _probe_tesseract()
+        if _available:
+            logger.info(f"OCR enabled (languages: {config.OCR_LANGUAGES})")
+        else:
+            logger.info("OCR disabled — tesseract binary not found")
+    return _available
+
+
+def reset_availability_cache() -> None:
+    """Clear the cached tesseract probe (used by tests)."""
+    global _available
+    _available = None
+
+
+def requeue_image_only_books(session) -> int:
+    """Reset books previously marked ``image-only`` so the next scan OCRs them.
+
+    Called on startup: when OCR has become available (e.g. after upgrading from
+    the slim image or enabling OCR), previously-skipped image-only PDFs are
+    re-queued by clearing ``indexed``. No-op — returning 0 — when OCR is
+    unavailable, so slim installs never churn. Returns the number re-queued.
+    """
+    if not ocr_available():
+        return 0
+
+    from sqlalchemy import text as _sql_text
+
+    result = session.execute(
+        _sql_text(
+            "UPDATE books SET indexed = 0, index_error = '' "
+            "WHERE index_error = 'image-only' AND indexed = 1"
+        )
+    )
+    count = result.rowcount or 0
+    if count:
+        session.commit()
+        logger.info(f"OCR: re-queued {count} previously image-only book(s) for indexing")
+    return count
+
+
+def _ocr_task(image: Image.Image, result: list, exc: list) -> None:
+    """Worker executed in a daemon thread by ocr_image."""
+    try:
+        import pytesseract
+
+        result[0] = pytesseract.image_to_string(image, lang=config.OCR_LANGUAGES)
+    except Exception as e:
+        exc[0] = e
+
+
+def ocr_image(image: Image.Image, should_stop=None) -> str:
+    """Run OCR on a PIL image, returning the recognised text (stripped).
+
+    Runs in a daemon thread with a timeout so a wedged OCR call can't hang the
+    scan. Returns "" on timeout, error, or empty result — never raises.
+    """
+    result = [None]
+    exc = [None]
+    t = threading.Thread(target=_ocr_task, args=(image, result, exc), daemon=True)
+    t.start()
+    poll_interval = 0.5
+    elapsed = 0.0
+    while t.is_alive() and elapsed < _OCR_TIMEOUT:
+        t.join(poll_interval)
+        elapsed += poll_interval
+        if should_stop and should_stop():
+            logger.warning("OCR aborted by stop request")
+            return ""
+    if t.is_alive():
+        logger.error(f"OCR timed out after {_OCR_TIMEOUT}s")
+        return ""
+    if exc[0] is not None:
+        logger.error(f"OCR failed: {exc[0]}")
+        return ""
+    return (result[0] or "").strip()
+
+
+def ocr_pixmap(pixmap, should_stop=None) -> str:
+    """Run OCR on a PyMuPDF pixmap by converting it to a PIL image first."""
+    try:
+        image = Image.frombytes("RGB", [pixmap.width, pixmap.height], pixmap.samples)
+    except Exception as exc:
+        logger.error(f"Could not convert page pixmap for OCR: {exc}")
+        return ""
+    return ocr_image(image, should_stop=should_stop)

--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -19,3 +19,4 @@ markdownify==0.14.1
 mutagen==1.47.0
 rarfile==4.2
 py7zr==0.22.0
+pytesseract==0.3.13

--- a/backend/routers/books/core.py
+++ b/backend/routers/books/core.py
@@ -49,6 +49,7 @@ def list_books(
                     "has_thumbnail": b.has_thumbnail,
                     "indexed": b.indexed,
                     "index_failed": b.index_failed,
+                    "ocr_indexed": b.index_error == "ocr",
                     "is_explicit": bool(b.is_explicit),
                     "is_missing": bool(b.is_missing),
                 }
@@ -86,6 +87,7 @@ def get_book(book_id: str, current_user: CurrentUser = Depends(get_current_user)
             "year": book.year,
             "indexed": book.indexed,
             "index_failed": book.index_failed,
+            "ocr_indexed": book.index_error == "ocr",
             "is_missing": bool(book.is_missing),
             "mime_type": book.mime_type,
             "has_thumbnail": book.has_thumbnail,

--- a/backend/routers/systems/core.py
+++ b/backend/routers/systems/core.py
@@ -103,6 +103,8 @@ def get_system(system_id: str, current_user: CurrentUser = Depends(get_current_u
                     "year": b.year,
                     "indexed": b.indexed,
                     "index_failed": b.index_failed,
+                    "index_error": b.index_error,
+                    "ocr_indexed": b.index_error == "ocr",
                     "has_thumbnail": b.has_thumbnail,
                     "tags": b.tags or [],
                     "is_explicit": bool(b.is_explicit),

--- a/backend/tests/test_indexer_resilience.py
+++ b/backend/tests/test_indexer_resilience.py
@@ -142,7 +142,7 @@ class TestIndexBookTextIndexFailed:
             db.commit()
             db.refresh(book)
 
-            with patch("backend.indexer.extract_text_from_pdf", return_value=[]):
+            with patch("backend.indexer.extract_text_from_pdf", return_value=([], False)):
                 result = index_book_text(book, "/tmp", db)
 
             db.refresh(book)
@@ -172,13 +172,14 @@ class TestIndexBookTextIndexFailed:
             db.commit()
             db.refresh(book)
 
-            with patch("backend.indexer.extract_text_from_pdf", return_value=pages):
+            with patch("backend.indexer.extract_text_from_pdf", return_value=(pages, False)):
                 result = index_book_text(book, "/tmp", db)
 
             db.refresh(book)
             assert result is True
             assert book.indexed is True
             assert book.index_failed is False
+            assert book.index_error == ""
         finally:
             db.close()
 

--- a/backend/tests/test_ocr.py
+++ b/backend/tests/test_ocr.py
@@ -1,0 +1,249 @@
+"""Tests for the optional OCR path (backend/ocr.py) and its indexer integration.
+
+pytesseract may not be installed in the test environment, so these tests inject
+a fake pytesseract module via sys.modules where a working OCR engine is needed,
+and exercise the real degradation path where it is absent.
+"""
+
+import sys
+import types
+import uuid
+from unittest.mock import patch
+
+from PIL import Image
+
+from backend import config, ocr
+from backend.config import SessionLocal
+from backend.models import Book
+
+
+def _fake_pytesseract(text="recognised text", version="5.0.0"):
+    """Build a stand-in pytesseract module returning fixed OCR output."""
+    mod = types.SimpleNamespace(
+        image_to_string=lambda image, lang=None: text,
+        get_tesseract_version=lambda: version,
+    )
+    return mod
+
+
+# ---------------------------------------------------------------------------
+# ocr_available — availability probe + graceful degradation
+# ---------------------------------------------------------------------------
+
+
+class TestAvailability:
+    def teardown_method(self):
+        ocr.reset_availability_cache()
+        sys.modules.pop("pytesseract", None)
+
+    def test_unavailable_when_pytesseract_missing(self):
+        """No pytesseract installed → OCR degrades to unavailable, no raise."""
+        ocr.reset_availability_cache()
+        with patch.dict(sys.modules, {"pytesseract": None}):
+            with patch.object(config, "OCR_ENABLED", True):
+                assert ocr.ocr_available() is False
+
+    def test_available_when_pytesseract_present(self):
+        ocr.reset_availability_cache()
+        with patch.dict(sys.modules, {"pytesseract": _fake_pytesseract()}):
+            with patch.object(config, "OCR_ENABLED", True):
+                assert ocr.ocr_available() is True
+
+    def test_disabled_by_config_even_when_present(self):
+        """OCR_ENABLED=false force-disables OCR regardless of tesseract."""
+        ocr.reset_availability_cache()
+        with patch.dict(sys.modules, {"pytesseract": _fake_pytesseract()}):
+            with patch.object(config, "OCR_ENABLED", False):
+                assert ocr.ocr_available() is False
+
+
+# ---------------------------------------------------------------------------
+# ocr_image — OCR execution, error and timeout handling
+# ---------------------------------------------------------------------------
+
+
+class TestOcrImage:
+    def teardown_method(self):
+        sys.modules.pop("pytesseract", None)
+
+    def test_returns_recognised_text(self):
+        img = Image.new("RGB", (10, 10), "white")
+        with patch.dict(sys.modules, {"pytesseract": _fake_pytesseract("  hello  ")}):
+            assert ocr.ocr_image(img) == "hello"
+
+    def test_returns_empty_on_error(self):
+        """A failing OCR call is swallowed and returns ""; never raises."""
+        img = Image.new("RGB", (10, 10), "white")
+
+        def _boom(image, lang=None):
+            raise RuntimeError("tesseract exploded")
+
+        mod = types.SimpleNamespace(image_to_string=_boom, get_tesseract_version=lambda: "5")
+        with patch.dict(sys.modules, {"pytesseract": mod}):
+            assert ocr.ocr_image(img) == ""
+
+    def test_stop_request_aborts(self):
+        """A stop request abandons an in-flight (blocking) OCR call, returning ""."""
+        import time
+
+        img = Image.new("RGB", (10, 10), "white")
+
+        def _slow(image, lang=None):
+            time.sleep(5)  # simulate a long-running OCR the stop request interrupts
+            return "text"
+
+        mod = types.SimpleNamespace(image_to_string=_slow, get_tesseract_version=lambda: "5")
+        with patch.dict(sys.modules, {"pytesseract": mod}):
+            assert ocr.ocr_image(img, should_stop=lambda: True) == ""
+
+
+# ---------------------------------------------------------------------------
+# extract_text_from_pdf — OCR fallback for pages with no text layer
+# ---------------------------------------------------------------------------
+
+
+class TestExtractOcrFallback:
+    def teardown_method(self):
+        ocr.reset_availability_cache()
+
+    def test_ocr_used_when_no_text_layer(self, tmp_path):
+        """A page with no embedded text is OCR'd when OCR is available."""
+        import fitz
+
+        pdf_path = tmp_path / "image_only.pdf"
+        doc = fitz.open()
+        doc.new_page()  # blank page — get_text() returns ""
+        doc.save(str(pdf_path))
+        doc.close()
+
+        from backend import indexer
+
+        with patch.object(ocr, "ocr_available", return_value=True):
+            with patch.object(ocr, "ocr_pixmap", return_value="scanned words"):
+                pages, used_ocr = indexer.extract_text_from_pdf(str(pdf_path))
+
+        assert used_ocr is True
+        assert pages == [{"page": 1, "content": "scanned words"}]
+
+    def test_no_ocr_when_unavailable(self, tmp_path):
+        """With OCR unavailable, a text-less page yields no pages (image-only)."""
+        import fitz
+
+        pdf_path = tmp_path / "image_only.pdf"
+        doc = fitz.open()
+        doc.new_page()
+        doc.save(str(pdf_path))
+        doc.close()
+
+        from backend import indexer
+
+        with patch.object(ocr, "ocr_available", return_value=False):
+            pages, used_ocr = indexer.extract_text_from_pdf(str(pdf_path))
+
+        assert used_ocr is False
+        assert pages == []
+
+
+# ---------------------------------------------------------------------------
+# index_book_text — OCR marker on indexed books
+# ---------------------------------------------------------------------------
+
+
+class TestIndexMarker:
+    def test_ocr_indexed_book_marked(self):
+        from backend import indexer
+
+        uid = str(uuid.uuid4())[:8]
+        db = SessionLocal()
+        try:
+            book = Book(
+                title=f"OCRBook-{uid}",
+                filename=f"book-{uid}.pdf",
+                filepath=f"/tmp/nonexistent-{uid}.pdf",
+                relative_path=f"book-{uid}.pdf",
+                mime_type="application/pdf",
+                indexed=False,
+                index_failed=False,
+            )
+            db.add(book)
+            db.commit()
+            db.refresh(book)
+
+            pages = [{"page": 1, "content": "ocr text"}]
+            with patch(
+                "backend.indexer.extract_text_from_pdf", return_value=(pages, True)
+            ):
+                result = indexer.index_book_text(book, "/tmp", db)
+
+            db.refresh(book)
+            assert result is True
+            assert book.indexed is True
+            assert book.index_error == "ocr"
+        finally:
+            db.close()
+
+
+# ---------------------------------------------------------------------------
+# requeue_image_only_books — startup re-queue when OCR becomes available
+# ---------------------------------------------------------------------------
+
+
+class TestRequeue:
+    def teardown_method(self):
+        ocr.reset_availability_cache()
+
+    def test_requeues_image_only_when_available(self):
+        uid = str(uuid.uuid4())[:8]
+        db = SessionLocal()
+        try:
+            book = Book(
+                title=f"IO-{uid}",
+                filename=f"io-{uid}.pdf",
+                filepath=f"/tmp/io-{uid}.pdf",
+                relative_path=f"io-{uid}.pdf",
+                mime_type="application/pdf",
+                indexed=True,
+                index_error="image-only",
+            )
+            db.add(book)
+            db.commit()
+            book_id = book.id
+
+            with patch.object(ocr, "ocr_available", return_value=True):
+                count = ocr.requeue_image_only_books(db)
+
+            assert count >= 1
+            db.expire_all()
+            refreshed = db.query(Book).filter_by(id=book_id).first()
+            assert refreshed.indexed is False
+            assert refreshed.index_error == ""
+        finally:
+            db.close()
+
+    def test_noop_when_unavailable(self):
+        uid = str(uuid.uuid4())[:8]
+        db = SessionLocal()
+        try:
+            book = Book(
+                title=f"IO-{uid}",
+                filename=f"io2-{uid}.pdf",
+                filepath=f"/tmp/io2-{uid}.pdf",
+                relative_path=f"io2-{uid}.pdf",
+                mime_type="application/pdf",
+                indexed=True,
+                index_error="image-only",
+            )
+            db.add(book)
+            db.commit()
+            book_id = book.id
+
+            with patch.object(ocr, "ocr_available", return_value=False):
+                count = ocr.requeue_image_only_books(db)
+
+            assert count == 0
+            db.expire_all()
+            refreshed = db.query(Book).filter_by(id=book_id).first()
+            assert refreshed.indexed is True
+            assert refreshed.index_error == "image-only"
+        finally:
+            db.close()

--- a/docs/data-model.md
+++ b/docs/data-model.md
@@ -107,7 +107,7 @@ links from `campaign_resources`/`favorites`, which are *not* declared foreign ke
 | Table | Purpose | Key columns / constraints |
 | --- | --- | --- |
 | `game_systems` | A TTRPG system (D&D 5e, PbtA, …). | `name`, `slug` unique. `is_system_agnostic` flags cross-system content. |
-| `books` | One PDF/document in the library. | `filepath` unique. `game_system_id` FK. Index `ix_books_indexer_queue` on `(indexed, mime_type)` drives the indexer. `indexed`/`index_failed`/`is_missing` track scan state. |
+| `books` | One PDF/document in the library. | `filepath` unique. `game_system_id` FK. Index `ix_books_indexer_queue` on `(indexed, mime_type)` drives the indexer. `indexed`/`index_failed`/`is_missing` track scan state. `index_error` holds the failure message, or the sentinel `image-only` (no text layer, not OCR'd) / `ocr` (indexed via OCR). |
 | `book_folders` | Tags auto-applied to a book subcategory folder path. | `path` unique. |
 
 ### Media — [`backend/models/media.py`](../backend/models/media.py)

--- a/frontend/src/components/system/BookRow.jsx
+++ b/frontend/src/components/system/BookRow.jsx
@@ -434,7 +434,7 @@ export default function BookRow({
             </span>
           ) : (
             <>
-              {book.indexed && book.index_error !== 'image-only' && (
+              {book.indexed && book.index_error !== 'image-only' && book.index_error !== 'ocr' && (
                 <span
                   title={t('bookRow.indexedTitle')}
                   style={{
@@ -446,6 +446,21 @@ export default function BookRow({
                   }}
                 >
                   {t('bookRow.indexed')}
+                </span>
+              )}
+              {book.indexed && book.index_error === 'ocr' && (
+                <span
+                  title={t('bookRow.ocrIndexedTitle')}
+                  style={{
+                    fontSize: 11,
+                    color: 'var(--green)',
+                    background: 'rgba(90,154,90,0.1)',
+                    padding: '1px 6px',
+                    borderRadius: 8,
+                    border: '1px solid rgba(90,154,90,0.35)',
+                  }}
+                >
+                  {t('bookRow.ocrIndexed')}
                 </span>
               )}
               {book.indexed && book.index_error === 'image-only' && (

--- a/frontend/src/components/system/BookRow.test.jsx
+++ b/frontend/src/components/system/BookRow.test.jsx
@@ -100,6 +100,23 @@ describe('BookRow', () => {
     expect(badge.title).toBe('This PDF contains only scanned images — no text layer to search')
   })
 
+  // --- OCR badge ---
+
+  it('shows "OCR" badge when indexed via OCR (index_error is ocr)', () => {
+    render(<BookRow book={makeBook({ indexed: true, index_error: 'ocr' })} onOpen={() => {}} />)
+    expect(screen.getByText('OCR')).toBeInTheDocument()
+  })
+
+  it('does not show the plain "Indexed" badge for OCR-indexed books', () => {
+    render(<BookRow book={makeBook({ indexed: true, index_error: 'ocr' })} onOpen={() => {}} />)
+    expect(screen.queryByText('Indexed')).not.toBeInTheDocument()
+  })
+
+  it('"OCR" badge has the correct tooltip', () => {
+    render(<BookRow book={makeBook({ indexed: true, index_error: 'ocr' })} onOpen={() => {}} />)
+    expect(screen.getByText('OCR').title).toBe('Full-text indexed via OCR (scanned pages)')
+  })
+
   // --- index_failed badge ---
 
   it('shows "Index Failed" badge when index_failed is true', () => {

--- a/frontend/src/locales/de-DE.json
+++ b/frontend/src/locales/de-DE.json
@@ -1063,6 +1063,8 @@
     "indexedTitle": "Volltext indiziert",
     "imageOnly": "Nur Bild",
     "imageOnlyTitle": "Dieses PDF enthält nur gescannte Bilder — keine Textebene zum Durchsuchen",
+    "ocrIndexed": "OCR",
+    "ocrIndexedTitle": "Volltext per OCR indexiert (gescannte Seiten)",
     "indexFailed": "Indizierung fehlgeschlagen",
     "indexFailedTitle": "Indizierung fehlgeschlagen",
     "indexFailedWithError": "Indizierung fehlgeschlagen: {{error}}",

--- a/frontend/src/locales/en-CA.json
+++ b/frontend/src/locales/en-CA.json
@@ -1063,6 +1063,8 @@
     "indexedTitle": "Full-text indexed",
     "imageOnly": "Image Only",
     "imageOnlyTitle": "This PDF contains only scanned images — no text layer to search",
+    "ocrIndexed": "OCR",
+    "ocrIndexedTitle": "Full-text indexed via OCR (scanned pages)",
     "indexFailed": "Index Failed",
     "indexFailedTitle": "Index failed",
     "indexFailedWithError": "Index failed: {{error}}",

--- a/frontend/src/locales/en-US.json
+++ b/frontend/src/locales/en-US.json
@@ -1063,6 +1063,8 @@
     "indexedTitle": "Full-text indexed",
     "imageOnly": "Image Only",
     "imageOnlyTitle": "This PDF contains only scanned images — no text layer to search",
+    "ocrIndexed": "OCR",
+    "ocrIndexedTitle": "Full-text indexed via OCR (scanned pages)",
     "indexFailed": "Index Failed",
     "indexFailedTitle": "Index failed",
     "indexFailedWithError": "Index failed: {{error}}",

--- a/frontend/src/locales/es-ES.json
+++ b/frontend/src/locales/es-ES.json
@@ -1063,6 +1063,8 @@
     "indexedTitle": "Indexado en texto completo",
     "imageOnly": "Solo imagen",
     "imageOnlyTitle": "Este PDF contiene solo imágenes escaneadas: no hay capa de texto para buscar",
+    "ocrIndexed": "OCR",
+    "ocrIndexedTitle": "Indexado en texto completo mediante OCR (páginas escaneadas)",
     "indexFailed": "Error de indexación",
     "indexFailedTitle": "Error de indexación",
     "indexFailedWithError": "Error de indexación: {{error}}",

--- a/frontend/src/locales/es-MX.json
+++ b/frontend/src/locales/es-MX.json
@@ -1063,6 +1063,8 @@
     "indexedTitle": "Indexado en texto completo",
     "imageOnly": "Solo imagen",
     "imageOnlyTitle": "Este PDF contiene solo imágenes escaneadas: no hay capa de texto para buscar",
+    "ocrIndexed": "OCR",
+    "ocrIndexedTitle": "Indexado en texto completo mediante OCR (páginas escaneadas)",
     "indexFailed": "Error de indexación",
     "indexFailedTitle": "Error de indexación",
     "indexFailedWithError": "Error de indexación: {{error}}",

--- a/frontend/src/locales/fr-CA.json
+++ b/frontend/src/locales/fr-CA.json
@@ -1063,6 +1063,8 @@
     "indexedTitle": "Indexé en texte intégral",
     "imageOnly": "Images uniquement",
     "imageOnlyTitle": "Ce PDF ne contient que des images numérisées — aucune couche de texte consultable",
+    "ocrIndexed": "OCR",
+    "ocrIndexedTitle": "Indexé en texte intégral via OCR (pages numérisées)",
     "indexFailed": "Échec d'indexation",
     "indexFailedTitle": "Échec de l'indexation",
     "indexFailedWithError": "Échec de l'indexation : {{error}}",

--- a/frontend/src/locales/fr-FR.json
+++ b/frontend/src/locales/fr-FR.json
@@ -1063,6 +1063,8 @@
     "indexedTitle": "Indexé en texte intégral",
     "imageOnly": "Images uniquement",
     "imageOnlyTitle": "Ce PDF ne contient que des images numérisées — aucune couche de texte consultable",
+    "ocrIndexed": "OCR",
+    "ocrIndexedTitle": "Indexé en texte intégral via OCR (pages numérisées)",
     "indexFailed": "Échec d'indexation",
     "indexFailedTitle": "Échec de l'indexation",
     "indexFailedWithError": "Échec de l'indexation : {{error}}",

--- a/frontend/src/locales/nl-NL.json
+++ b/frontend/src/locales/nl-NL.json
@@ -1063,6 +1063,8 @@
     "indexedTitle": "Volledige tekst geïndexeerd",
     "imageOnly": "Alleen afbeelding",
     "imageOnlyTitle": "Deze pdf bevat alleen gescande afbeeldingen — geen tekstlaag om te doorzoeken",
+    "ocrIndexed": "OCR",
+    "ocrIndexedTitle": "Volledig geïndexeerd via OCR (gescande pagina's)",
     "indexFailed": "Indexering mislukt",
     "indexFailedTitle": "Indexering mislukt",
     "indexFailedWithError": "Indexering mislukt: {{error}}",

--- a/frontend/src/locales/pt-BR.json
+++ b/frontend/src/locales/pt-BR.json
@@ -1063,6 +1063,8 @@
     "indexedTitle": "Indexado em texto completo",
     "imageOnly": "Apenas imagem",
     "imageOnlyTitle": "Este PDF contém apenas imagens digitalizadas — sem camada de texto para buscar",
+    "ocrIndexed": "OCR",
+    "ocrIndexedTitle": "Indexado em texto completo via OCR (páginas digitalizadas)",
     "indexFailed": "Falha na indexação",
     "indexFailedTitle": "Falha na indexação",
     "indexFailedWithError": "Falha na indexação: {{error}}",

--- a/frontend/src/locales/pt-PT.json
+++ b/frontend/src/locales/pt-PT.json
@@ -1063,6 +1063,8 @@
     "indexedTitle": "Indexado em texto completo",
     "imageOnly": "Apenas imagem",
     "imageOnlyTitle": "Este PDF contém apenas imagens digitalizadas — sem camada de texto para pesquisar",
+    "ocrIndexed": "OCR",
+    "ocrIndexedTitle": "Indexado em texto completo via OCR (páginas digitalizadas)",
     "indexFailed": "Falha na indexação",
     "indexFailedTitle": "Falha na indexação",
     "indexFailedWithError": "Falha na indexação: {{error}}",


### PR DESCRIPTION
## Summary

Index image-only PDFs (scanned pages with no text layer) into full-text search via Tesseract, running in-process rather than as a sidecar service.

## Type of change

- [ ] Bug fix
- [x] New feature
- [ ] Refactor / cleanup
- [ ] Docs / configuration only

## Testing

<!-- How did you verify this works? Check all that apply. -->

- [x] Backend tests pass (`pytest -q`)
- [x] Frontend tests pass (`npm test`)
- [x] Tested manually in the browser

## Notes for reviewer

<!-- Anything that needs extra context, known limitations, or follow-up work. Delete if not needed. -->
