### PR TITLE
Fix: Defer OCR to a resumable background queue with env variables to control the configuration.

### DIFF
--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -1,16 +1,16 @@
 # Contributing to Grimoire
 
-Thanks for your interest in contributing! Contributions of all kinds are welcome — bug reports, feature ideas, documentation improvements, code, and translations.
+Thanks for your interest in contributing! Contributions of all kinds are welcome - bug reports, feature ideas, documentation improvements, code, and translations.
 
 ## Reporting a bug or requesting a feature
 
 Open a [GitHub issue](https://github.com/hunter-read/grimoire/issues/new/choose) and pick the template that fits:
 
-- **Bug Report** — something is broken or behaving unexpectedly
-- **Feature Request** — an idea or improvement you'd like to see
-- **Question / Help** — not sure how something works, or need help getting set up
+- **Bug Report** - something is broken or behaving unexpectedly
+- **Feature Request** - an idea or improvement you'd like to see
+- **Question / Help** - not sure how something works, or need help getting set up
 
-> Before opening a new issue, a quick search of [existing issues](https://github.com/hunter-read/grimoire/issues) can save time — someone may have already reported the same thing.
+> Before opening a new issue, a quick search of [existing issues](https://github.com/hunter-read/grimoire/issues) can save time - someone may have already reported the same thing.
 
 ### Getting useful logs for bug reports
 
@@ -39,7 +39,7 @@ Join the [Discord server](https://discord.gg/9Sd4CGZC63) to chat, share feedback
 
 ## Contributing code
 
-1. **Open an issue first** for anything beyond a small fix — it's worth aligning on the approach before you invest time writing code.
+1. **Open an issue first** for anything beyond a small fix - it's worth aligning on the approach before you invest time writing code.
 2. Fork the repo and create a feature branch off `main`.
 3. Make your changes. Run the test suites before opening a PR:
 

--- a/.github/SECURITY.md
+++ b/.github/SECURITY.md
@@ -16,10 +16,10 @@ You'll receive a response as soon as possible. For valid vulnerabilities, a fix 
 
 The more detail you provide, the faster the issue can be assessed and fixed:
 
-- **Description** — what the vulnerability is and what it allows an attacker to do
-- **Steps to reproduce** — a minimal sequence of steps or a proof-of-concept
-- **Impact** — who is affected and under what conditions
-- **Suggested fix** — if you have one (optional but appreciated)
+- **Description** - what the vulnerability is and what it allows an attacker to do
+- **Steps to reproduce** - a minimal sequence of steps or a proof-of-concept
+- **Impact** - who is affected and under what conditions
+- **Suggested fix** - if you have one (optional but appreciated)
 
 ## Scope
 

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 <div align="center">
   <img src="frontend/static/grimoire-logo.svg" alt="Grimoire" width="144">
 
-  # Grimoire — Self-Hosted TTRPG Library Manager
+  # Grimoire - Self-Hosted TTRPG Library Manager
 
   [![Discord](https://img.shields.io/badge/discord-join-5865F2?logo=discord&logoColor=white)](https://discord.gg/9Sd4CGZC63)
   [![CI](https://github.com/hunter-read/grimoire/actions/workflows/ci.yml/badge.svg)](https://github.com/hunter-read/grimoire/actions/workflows/ci.yml)
@@ -20,22 +20,22 @@ A Docker-based web application for managing your tabletop RPG PDF collection. Br
 
 ## Features
 
-- **Library Browser** — Organizes your collection by game system with automatic folder detection
-- **Full-Text Search** — Every page of every PDF is indexed with SQLite FTS5 for instant search; also finds maps, tokens, and audio by filename, folder, or tag
-- **Page-by-Page Viewer** — PDFs rendered as images for fast mobile viewing with pinch-to-zoom, swipe navigation, and spread mode
-- **Map Gallery** — Browse battlemaps by directory structure with tag filtering, grid metadata, and full-res download
-- **Token Browser** — Browse and tag character tokens and portrait assets
-- **Audio Library** — Browse ambient tracks, soundscapes, music, and sound effects by directory structure with tag filtering and in-browser playback (MP3, OGG, Opus, FLAC, WAV, M4A, AAC). Reads embedded duration and title/artist/album tags, and uses folder `cover`/`folder` images or embedded album art for artwork
-- **Global Audio Player** — A persistent pop-out player that keeps playing while you navigate. Build a local queue by playing a whole folder, queueing tracks one at a time ("Play Next"), having a GM play a campaign resource group, or playing all the audio embedded in a wiki note. Expand it to see and reorder upcoming tracks, with a repeat-current-track toggle
-- **Bookmarks** — Per-user page and text-selection bookmarks with inline highlights
-- **Favorites** — Save systems, books, maps, tokens, and audio for quick access
-- **View Modes** — Toggle the systems, books, maps, tokens, and audio grids between card, compact, and list layouts; each content type remembers its own default (configurable in Account Settings) while the in-page toggle is a per-tab override. Cards and list rows include quick download and favorite buttons.
-- **Metadata Editor** — Add descriptions, tags, genre, publisher links, and character builder URLs
-- **Bulk Actions** — Multi-select books, maps, tokens, and audio (click, shift-click for a range, ⌘/Ctrl-click to toggle) then bulk tag, add to a campaign, or edit metadata via a carousel
-- **Campaigns** — Track GM-run and personal campaigns; a markdown notes wiki with deep linking, Markdown/JSON/LegendKeeper import & export, character art and sheets, linked resources, and scheduling
-- **OPDS Catalog** — Each user can generate a personal OPDS feed URL to connect e-reader apps directly to their library
-- **Docker Ready** — One command to run, mount your library directory, done
-- **Responsive** — Works on desktop, tablet, and phone with mobile navigation
+- **Library Browser** - Organizes your collection by game system with automatic folder detection
+- **Full-Text Search** - Every page of every PDF is indexed with SQLite FTS5 for instant search; also finds maps, tokens, and audio by filename, folder, or tag
+- **Page-by-Page Viewer** - PDFs rendered as images for fast mobile viewing with pinch-to-zoom, swipe navigation, and spread mode
+- **Map Gallery** - Browse battlemaps by directory structure with tag filtering, grid metadata, and full-res download
+- **Token Browser** - Browse and tag character tokens and portrait assets
+- **Audio Library** - Browse ambient tracks, soundscapes, music, and sound effects by directory structure with tag filtering and in-browser playback (MP3, OGG, Opus, FLAC, WAV, M4A, AAC). Reads embedded duration and title/artist/album tags, and uses folder `cover`/`folder` images or embedded album art for artwork
+- **Global Audio Player** - A persistent pop-out player that keeps playing while you navigate. Build a local queue by playing a whole folder, queueing tracks one at a time ("Play Next"), having a GM play a campaign resource group, or playing all the audio embedded in a wiki note. Expand it to see and reorder upcoming tracks, with a repeat-current-track toggle
+- **Bookmarks** - Per-user page and text-selection bookmarks with inline highlights
+- **Favorites** - Save systems, books, maps, tokens, and audio for quick access
+- **View Modes** - Toggle the systems, books, maps, tokens, and audio grids between card, compact, and list layouts; each content type remembers its own default (configurable in Account Settings) while the in-page toggle is a per-tab override. Cards and list rows include quick download and favorite buttons.
+- **Metadata Editor** - Add descriptions, tags, genre, publisher links, and character builder URLs
+- **Bulk Actions** - Multi-select books, maps, tokens, and audio (click, shift-click for a range, ⌘/Ctrl-click to toggle) then bulk tag, add to a campaign, or edit metadata via a carousel
+- **Campaigns** - Track GM-run and personal campaigns; a markdown notes wiki with deep linking, Markdown/JSON/LegendKeeper import & export, character art and sheets, linked resources, and scheduling
+- **OPDS Catalog** - Each user can generate a personal OPDS feed URL to connect e-reader apps directly to their library
+- **Docker Ready** - One command to run, mount your library directory, done
+- **Responsive** - Works on desktop, tablet, and phone with mobile navigation
 
 ## Quick Start
 
@@ -114,12 +114,12 @@ services:
   grimoire:
     image: hunterreadca/grimoire:latest
     ports:
-      - "9481:9481"
+ - "9481:9481"
     environment:
       SECRET_KEY: "generate-with-openssl-rand-hex-32"
     volumes:
-      - /path/to/your/library:/app/library:ro   # read-only — use Filebrowser or Calibre to manage files
-      - /path/to/grimoire/data:/app/data
+ - /path/to/your/library:/app/library:ro   # read-only - use Filebrowser or Calibre to manage files
+ - /path/to/grimoire/data:/app/data
 ```
 
 ### 5. Example compose files
@@ -163,7 +163,7 @@ The database, search index, and rendered thumbnails are all stored under `DATA_P
 
 ## Upgrading
 
-Pull the new image and restart (`docker compose pull && docker compose up -d`). Database schema changes are applied automatically on startup via [Alembic](https://alembic.sqlalchemy.org/) — **no manual action is required** when upgrading, including from versions that predate Alembic. On first run under the new system, an existing database is detected and stamped at the correct baseline, so only genuinely new migrations run thereafter. Back up `DATA_PATH` before upgrading, as always.
+Pull the new image and restart (`docker compose pull && docker compose up -d`). Database schema changes are applied automatically on startup via [Alembic](https://alembic.sqlalchemy.org/) - **no manual action is required** when upgrading, including from versions that predate Alembic. On first run under the new system, an existing database is detected and stamped at the correct baseline, so only genuinely new migrations run thereafter. Back up `DATA_PATH` before upgrading, as always.
 
 ## Running from source
 
@@ -173,11 +173,11 @@ Prefer to build the image yourself or run Grimoire directly on the host (Python 
 
 ## Library Structure
 
-### Books — one folder per game system
+### Books - one folder per game system
 
 Each top-level folder under `books/` becomes a **game system**. Subfolders are auto-detected as categories based on their name.
 
-Folder name matching is **case-insensitive**, and hyphens, underscores, and spaces are interchangeable — `Character-Sheets`, `character_sheets`, and `Character Sheets` all map to the same category.
+Folder name matching is **case-insensitive**, and hyphens, underscores, and spaces are interchangeable - `Character-Sheets`, `character_sheets`, and `Character Sheets` all map to the same category.
 
 | Category | Recognized folder names | What goes here |
 |---|---|---|
@@ -197,7 +197,7 @@ Folder name matching is **case-insensitive**, and hyphens, underscores, and spac
 
 #### Subfolders within a category
 
-Any category folder can contain named subfolders to group related books together. Grimoire detects these automatically and displays them as collapsible folder groups within the category section — no configuration needed.
+Any category folder can contain named subfolders to group related books together. Grimoire detects these automatically and displays them as collapsible folder groups within the category section - no configuration needed.
 
 ```
 books/
@@ -222,7 +222,7 @@ Books without a subfolder are shown ungrouped at the top of their category secti
 
 #### Archive files
 
-Archive files placed anywhere under `books/` are shown alongside your books in their category — handy for bundling a set of related files (a maps pack, a COMP/CON export, loose handouts) next to the book they belong to. Recognized extensions:
+Archive files placed anywhere under `books/` are shown alongside your books in their category - handy for bundling a set of related files (a maps pack, a COMP/CON export, loose handouts) next to the book they belong to. Recognized extensions:
 
 | Type | Extensions |
 |---|---|
@@ -231,11 +231,11 @@ Archive files placed anywhere under `books/` are shown alongside your books in t
 | 7-Zip | `.7z`, `.cb7` |
 | Tar | `.tar`, `.cbt`, `.tar.gz`, `.tgz`, `.tar.bz2`, `.tbz2` |
 
-Archives are treated as opaque downloads — Grimoire does not extract or read their contents, so clicking one downloads the file rather than opening the reader. They're also included when you download a whole system, category, or subfolder as an archive. Comic-book archives (`.cbz`, `.cbr`, `.cb7`, `.cbt`) additionally get a cover thumbnail generated from the first image inside them.
+Archives are treated as opaque downloads - Grimoire does not extract or read their contents, so clicking one downloads the file rather than opening the reader. They're also included when you download a whole system, category, or subfolder as an archive. Comic-book archives (`.cbz`, `.cbr`, `.cb7`, `.cbt`) additionally get a cover thumbnail generated from the first image inside them.
 
 #### System-agnostic collections
 
-Some books don't belong to a single game system — reference material, zines, art books, or rulesets like Ironsworn or Mothership that span multiple systems. Create a folder whose name is one of the recognized system-agnostic names and Grimoire will display its contents in a separate **System-Agnostic** section on the library page, outside the normal game-system grid.
+Some books don't belong to a single game system - reference material, zines, art books, or rulesets like Ironsworn or Mothership that span multiple systems. Create a folder whose name is one of the recognized system-agnostic names and Grimoire will display its contents in a separate **System-Agnostic** section on the library page, outside the normal game-system grid.
 
 **Recognized folder names** (case-insensitive):
 
@@ -245,7 +245,7 @@ Some books don't belong to a single game system — reference material, zines, a
 | `Generic` | `books/Generic/` |
 | `Any` | `books/Any/` |
 
-Subfolders directly under the agnostic root become **custom category headings** — whatever you name them is what appears in the UI. There is no keyword matching; the folder name is used as-is (slugified).
+Subfolders directly under the agnostic root become **custom category headings** - whatever you name them is what appears in the UI. There is no keyword matching; the folder name is used as-is (slugified).
 
 ```
 books/
@@ -296,8 +296,8 @@ Grimoire reads [OPF](https://idpf.org/epub/20/spec/OPF_2.0.1_draft.htm) sidecar 
 
 The scanner checks two locations for each book file, in priority order:
 
-1. **`<bookname>.opf`** — a sidecar file with the same stem as the PDF, in the same directory. Suits hand-crafted or single-file layouts.
-2. **`metadata.opf`** — a file named `metadata.opf` in the same directory. This is the format Calibre uses when it exports each book into its own subfolder.
+1. **`<bookname>.opf`** - a sidecar file with the same stem as the PDF, in the same directory. Suits hand-crafted or single-file layouts.
+2. **`metadata.opf`** - a file named `metadata.opf` in the same directory. This is the format Calibre uses when it exports each book into its own subfolder.
 
 A typical Calibre export looks like this and is fully supported:
 
@@ -317,11 +317,11 @@ books/
 
 OPF metadata is only applied when a book is **first indexed**, and ordinary rescans leave existing books alone, so edits made via the web UI are not overwritten. To pick up an OPF or `tags.json` you added or corrected after the initial scan, choose a metadata-refresh mode in the rescan dialog (available on the global Rescan button and every per-folder rescan button):
 
-- **Find new files** — the default: add new files, flag missing ones, leave existing records untouched.
-- **Update missing metadata** — additionally fill **empty** book fields from sidecar files, without touching anything you've already set (non-destructive).
-- **Replace all metadata** — overwrite fields with whatever the sidecar files provide (this discards UI edits the sidecar covers).
+- **Find new files** - the default: add new files, flag missing ones, leave existing records untouched.
+- **Update missing metadata** - additionally fill **empty** book fields from sidecar files, without touching anything you've already set (non-destructive).
+- **Replace all metadata** - overwrite fields with whatever the sidecar files provide (this discards UI edits the sidecar covers).
 
-### Maps — organize by creator or collection
+### Maps - organize by creator or collection
 
 ```
 maps/
@@ -331,7 +331,7 @@ maps/
 
 The folder name is shown as a group header in the map gallery.
 
-### Tokens — organize by type
+### Tokens - organize by type
 
 ```
 tokens/
@@ -339,7 +339,7 @@ tokens/
     └── token-file.png
 ```
 
-### Audio — organize by category or creator
+### Audio - organize by category or creator
 
 ```
 audio/
@@ -386,8 +386,8 @@ Grimoire mounts your library folder **read-only** and never modifies your files.
 
 Two tools integrate especially well:
 
-- **[Filebrowser Quantum](docs/file-management.md#filebrowser-quantum)** — drag-and-drop file uploads from any browser, no desktop app needed
-- **[Calibre](docs/file-management.md#calibre)** — full book management with metadata editing; Grimoire reads the `.opf` sidecar files Calibre writes ([see OPF support](#book-metadata-from-opf-files))
+- **[Filebrowser Quantum](docs/file-management.md#filebrowser-quantum)** - drag-and-drop file uploads from any browser, no desktop app needed
+- **[Calibre](docs/file-management.md#calibre)** - full book management with metadata editing; Grimoire reads the `.opf` sidecar files Calibre writes ([see OPF support](#book-metadata-from-opf-files))
 
 See [docs/file-management.md](docs/file-management.md) for Docker Compose examples for each tool.
 
@@ -401,19 +401,21 @@ After adding files, trigger a **Rescan** in Grimoire (sidebar or Settings → Ma
 
 | Variable | Default | Description |
 |---|---|---|
-| `SECRET_KEY` | — | **Required.** JWT signing secret. Generate: `openssl rand -hex 32` |
+| `SECRET_KEY` | - | **Required.** JWT signing secret. Generate: `openssl rand -hex 32` |
 | `WORKERS` | `2` | Number of uvicorn worker processes |
 | `LIBRARY_PATH` | `/app/library` | Optional path to your library directory inside the container if not mounted at /app/library |
 | `DATA_PATH` | `/app/data` | Optional path for the database, thumbnails, and search cache inside the container if not mounted at /app/data |
-| `BASE_URL` | `http://localhost:9481` | Public base URL of this instance. Set this to the URL you use to access Grimoire (e.g. `https://grimoire.example.com`) when running behind a reverse proxy — used to build absolute links in OPDS feeds and other places that need a fully-qualified URL. |
-| `VALKEY_URL` | — | Optional Redis-compatible cache URL for rendered page images (e.g. `redis://valkey:6379/0`) |
+| `BASE_URL` | `http://localhost:9481` | Public base URL of this instance. Set this to the URL you use to access Grimoire (e.g. `https://grimoire.example.com`) when running behind a reverse proxy - used to build absolute links in OPDS feeds and other places that need a fully-qualified URL. |
+| `VALKEY_URL` | - | Optional Redis-compatible cache URL for rendered page images (e.g. `redis://valkey:6379/0`) |
 | `OCR_ENABLED` | `true` | Optional. Set to `false` to disable OCR of image-only PDFs even on the OCR-capable image. See [OCR](#ocr) below. |
 | `OCR_LANGUAGES` | `eng` | Optional. Tesseract language codes for OCR, e.g. `eng` or `eng+deu+fra`. Extra languages require their tessdata files to be present (see [OCR](#ocr)). |
+| `OCR_CONCURRENCY` | `1` | Optional. Number of scanned books OCR'd in parallel by the background OCR worker. Raise on multi-core hosts with spare CPU; keep at `1` on small boxes. Set to `0` to turn OCR off (same as `OCR_ENABLED=false`). See [OCR performance](#ocr-performance--resource-tuning). |
+| `OCR_DPI` | `150` | Optional. Resolution scanned pages are rasterized at before OCR (clamped 72–600). Higher = more accurate but slower and more memory per page. See [OCR performance](#ocr-performance--resource-tuning). |
 | `OPDS_ENABLED` | `false` | Optional, Set to `true` to enable the OPDS catalog. See [OPDS](#opds) below. |
 | `LOG_LEVEL` | `info` | Optional Console/Docker log verbosity: `debug`, `info`, `warning`, `error`, or `critical`. The in-app Logs tab (Settings → Logs) always captures `debug`-level entries regardless of this setting. |
-| `ALLOW_PASSWORD_AUTHENTICATION` | — | Optional, `true` or `false`. When set, pins password authentication on or off and overrides the toggle in Settings → Authentication (the toggle is shown read-only). When unset, the in-app setting is used. First-run admin setup always requires a username and password regardless of this value. |
-| `GUEST_ACCESS_ENABLED` | — | Optional, `true` or `false`. When set, pins guest invite codes on or off and overrides the toggle in Settings → Authentication (the toggle is shown read-only). When unset, the in-app setting is used. See [Guest invites](#guest-invites) below. |
-| `OIDC_*` env vars | — | Optional. Each OIDC setting (`OIDC_ENABLED`, `OIDC_ISSUER_URL`, `OIDC_TOKEN_ISSUER`, `OIDC_AUTHORIZATION_ENDPOINT`, `OIDC_TOKEN_ENDPOINT`, `OIDC_USERINFO_ENDPOINT`, `OIDC_JWKS_URI`, `OIDC_END_SESSION_ENDPOINT`, `OIDC_CLIENT_ID`, `OIDC_CLIENT_SECRET`, `OIDC_SIGNING_ALG`, `OIDC_BUTTON_TEXT`, `OIDC_GROUPS_CLAIM`, `OIDC_PERMISSIONS_CLAIM`, `OIDC_MATCH_BY`, `OIDC_AUTO_LAUNCH`, `OIDC_AUTO_REGISTER`) can be pinned via env. When set, the field is read-only in Settings → Authentication. When unset, the in-app value is used. See [OpenID Connect](#openid-connect) below. |
+| `ALLOW_PASSWORD_AUTHENTICATION` | - | Optional, `true` or `false`. When set, pins password authentication on or off and overrides the toggle in Settings → Authentication (the toggle is shown read-only). When unset, the in-app setting is used. First-run admin setup always requires a username and password regardless of this value. |
+| `GUEST_ACCESS_ENABLED` | - | Optional, `true` or `false`. When set, pins guest invite codes on or off and overrides the toggle in Settings → Authentication (the toggle is shown read-only). When unset, the in-app setting is used. See [Guest invites](#guest-invites) below. |
+| `OIDC_*` env vars | - | Optional. Each OIDC setting (`OIDC_ENABLED`, `OIDC_ISSUER_URL`, `OIDC_TOKEN_ISSUER`, `OIDC_AUTHORIZATION_ENDPOINT`, `OIDC_TOKEN_ENDPOINT`, `OIDC_USERINFO_ENDPOINT`, `OIDC_JWKS_URI`, `OIDC_END_SESSION_ENDPOINT`, `OIDC_CLIENT_ID`, `OIDC_CLIENT_SECRET`, `OIDC_SIGNING_ALG`, `OIDC_BUTTON_TEXT`, `OIDC_GROUPS_CLAIM`, `OIDC_PERMISSIONS_CLAIM`, `OIDC_MATCH_BY`, `OIDC_AUTO_LAUNCH`, `OIDC_AUTO_REGISTER`) can be pinned via env. When set, the field is read-only in Settings → Authentication. When unset, the in-app value is used. See [OpenID Connect](#openid-connect) below. |
 | `AUTH_RATE_LIMIT` | `10/minute` | Per-IP throttle applied to the credential-checking endpoints (`/api/auth/login`, `/api/auth/setup`, `/api/auth/guest-login`, and the API-key-guarded `/api/stats`). Exceeding it returns `429`. Uses a [`limits`](https://limits.readthedocs.io/en/stable/quickstart.html#rate-limit-string-notation) string like `20/minute` or `100/hour`. See [Security hardening](#security-hardening) below. |
 | `RATE_LIMIT_ENABLED` | `true` | Optional. Set to `false` to disable auth rate limiting entirely. |
 | `TRUST_FORWARDED_FOR` | `true` | Optional. When `true`, the rate limiter keys on the left-most `X-Forwarded-For` address so each client gets its own bucket behind a reverse proxy. Set to `false` only if Grimoire is exposed directly (no trusted proxy), so a spoofed header can't sidestep the limit. |
@@ -422,11 +424,11 @@ After adding files, trigger a **Rescan** in Grimoire (sidebar or Settings → Ma
 
 ```yaml
 volumes:
-  # Your library — read-only is fine, Grimoire never modifies your files
-  - /path/to/your/library:/app/library:ro
+  # Your library - read-only is fine, Grimoire never modifies your files
+ - /path/to/your/library:/app/library:ro
 
   # Persistent data (database, thumbnails, page cache)
-  - grimoire_data:/app/data
+ - grimoire_data:/app/data
 ```
 
 ---
@@ -443,12 +445,31 @@ Use the **Rescan** button in the sidebar to pick up newly added files, or config
 
 Some PDFs contain only scanned page images with no embedded text layer (common with older, scanned game books). These can't be full-text searched from their text layer alone and show an **Image Only** badge.
 
-The default Grimoire image bundles the [Tesseract](https://github.com/tesseract-ocr/tesseract) OCR engine (English), so on first scan these image-only PDFs are run through OCR and their recognised text is added to the search index. Books indexed this way show an **OCR** badge. OCR runs entirely in-process — no extra container or service is required.
+The default Grimoire image bundles the [Tesseract](https://github.com/tesseract-ocr/tesseract) OCR engine (English), so scanned image-only PDFs are run through OCR and their recognised text is added to the search index. Books indexed this way show an **OCR** badge. No extra container or service is required.
 
-- **Disable OCR:** set `OCR_ENABLED=false`. Image-only PDFs are then left unindexed (the pre-OCR behaviour), exactly as on the slim image.
-- **Slim image:** the `-slim` tags (e.g. `hunterreadca/grimoire:v1.5.0-slim`, `:slim`, `:edge-slim`) omit Tesseract for a smaller image. OCR is automatically disabled there and Grimoire degrades gracefully.
-- **Re-queue on upgrade:** when OCR becomes available (upgrading from a slim image, or enabling it), previously image-only books are automatically re-queued for OCR on the next startup scan.
-- **Additional languages:** set `OCR_LANGUAGES` to a `+`-joined list of Tesseract language codes (e.g. `eng+deu+fra`). The extra languages' tessdata files must be present in the image's tessdata directory — mount a directory of `.traineddata` files over it (or point `TESSDATA_PREFIX` at a mounted directory) to add languages without rebuilding.
+OCR runs quietly in the background, so it never holds up the rest of your library. A scan indexes all your regular (text-based) books, maps, tokens, and audio first - those are searchable right away - and then works through the scanned books afterward. Even if you add 100+ scanned books at once, the rest of your library stays available while they're being processed.
+
+Scanned books are also processed **page by page**, and progress is saved as it goes. If the server restarts (or you stop and start a scan), OCR simply picks up where it left off instead of starting the book over - so even a very large scanned book will finish, however long it takes.
+
+- **Progress:** the admin scan status shows an OCR phase with a progress bar and the book currently being processed.
+- **Disable OCR:** set `OCR_ENABLED=false`. Scanned image-only PDFs are then left unindexed, the same as on the slim image.
+- **Slim image:** the `-slim` tags (e.g. `hunterreadca/grimoire:v1.5.0-slim`, `:slim`, `:edge-slim`) omit Tesseract for a smaller image. OCR is automatically disabled there.
+- **Upgrading to OCR:** if you enable OCR later (or switch from a slim image), any books that were previously skipped as image-only are automatically queued for OCR on the next scan.
+- **Additional languages:** set `OCR_LANGUAGES` to a `+`-joined list of Tesseract language codes (e.g. `eng+deu+fra`). The extra languages' data files must be present in the image - mount a directory of `.traineddata` files (or point `TESSDATA_PREFIX` at one) to add languages without rebuilding.
+
+#### Speeding up OCR
+
+Scanning a large book takes a while, and it happens quietly in the background - you can browse and search the rest of your library the whole time, and OCR picks up where it left off if the server restarts. If you have a big collection of scanned books and want it to finish faster, two optional settings help:
+
+- **`OCR_CONCURRENCY`** - how many scanned books to work on at once. The default is `1`, which is gentle on small devices. If you're running on a machine with several CPU cores and plenty of memory to spare, raising this (e.g. `2`–`8`) processes books in parallel and gets through the queue faster. On a small device like a Raspberry Pi, leave it at `1`. Set it to `0` to turn OCR off entirely - handy if OCR keeps failing or running your machine out of memory and you just want it to stop, without switching to the slim image.
+  - Each parallel worker uses roughly 50–250 MB of RAM depending on the pdf page image size, so make sure you have that much to spare per unit, and don't set it higher than the number of CPU cores (virtual/hyper-threaded cores count) or the workers just compete for the same processors without going any faster.
+- **`OCR_DPI`** - how sharp the scanned pages are rendered before reading them (default `150`). Lowering it (e.g. `120`) makes OCR faster and lighter; raising it (e.g. `200`–`300`) can improve results on faint or low-quality scans at the cost of speed. Note: OCR scanned books can be individually rescaned at a higher DPI if needed from the application.
+
+A rough guide: a small always-on device (like a Pi) is happiest at the defaults; a typical NAS can handle `OCR_CONCURRENCY=2`; a powerful desktop or server can go higher. It's safe to start low and raise it later - the queue just continues faster.
+
+#### Re-OCR a single book at a higher DPI
+
+`OCR_DPI` sets the resolution for the whole library, and `150` is usually plenty. But the occasional faint or low-quality scan reads better at a higher resolution. Rather than raise the global default (and re-OCR everything), you can re-OCR just that one book: on an OCR-badged book row, click the **Re-OCR** button, optionally enter a DPI (e.g. `300`), and run it. The book is re-read in the background at that resolution while the rest of the library is untouched; leave the DPI blank to re-OCR at the global default. The button appears only for scanned/OCR'd books and requires GM or admin.
 
 ### Page rendering
 
@@ -464,15 +485,15 @@ Rendered pages are cached to disk by default. Provide a `VALKEY_URL` to use an i
 
 ### Auth rate limiting
 
-The credential-checking endpoints — `/api/auth/login`, `/api/auth/setup`, `/api/auth/guest-login`, and the API-key-guarded `/api/stats` — are rate-limited per client IP to slow online password / invite-code brute-forcing. The default is **`10/minute`** per IP; exceeding it returns HTTP `429`. Tune it with `AUTH_RATE_LIMIT` (a [`limits`](https://limits.readthedocs.io/en/stable/quickstart.html#rate-limit-string-notation) string such as `20/minute` or `100/hour`), or turn it off with `RATE_LIMIT_ENABLED=false`.
+The credential-checking endpoints - `/api/auth/login`, `/api/auth/setup`, `/api/auth/guest-login`, and the API-key-guarded `/api/stats` - are rate-limited per client IP to slow online password / invite-code brute-forcing. The default is **`10/minute`** per IP; exceeding it returns HTTP `429`. Tune it with `AUTH_RATE_LIMIT` (a [`limits`](https://limits.readthedocs.io/en/stable/quickstart.html#rate-limit-string-notation) string such as `20/minute` or `100/hour`), or turn it off with `RATE_LIMIT_ENABLED=false`.
 
-**Behind a reverse proxy:** keying is done on the left-most `X-Forwarded-For` address by default (`TRUST_FORWARDED_FOR=true`) so each real client — not the proxy — gets its own bucket. Make sure your proxy sets `X-Forwarded-For`. If Grimoire is exposed directly with no trusted proxy in front, set `TRUST_FORWARDED_FOR=false` so a spoofed header can't be used to sidestep the limit.
+**Behind a reverse proxy:** keying is done on the left-most `X-Forwarded-For` address by default (`TRUST_FORWARDED_FOR=true`) so each real client - not the proxy - gets its own bucket. Make sure your proxy sets `X-Forwarded-For`. If Grimoire is exposed directly with no trusted proxy in front, set `TRUST_FORWARDED_FOR=false` so a spoofed header can't be used to sidestep the limit.
 
 **Multiple replicas:** when `VALKEY_URL` is set the limit counters are shared through Valkey so the limit is enforced consistently across all workers/replicas; without it each process keeps its own in-memory counters (and the limiter falls back to in-memory automatically if Valkey becomes unreachable).
 
 ### Security headers
 
-Every response carries a `Content-Security-Policy` scoped to what the SPA actually loads (own scripts, inline styles used by React, Google Fonts, and `data:`/`blob:` images for rendered pages), plus `X-Content-Type-Options: nosniff`, `X-Frame-Options: DENY` (matching the CSP `frame-ancestors 'none'`), and `Referrer-Policy: strict-origin-when-cross-origin`. `Strict-Transport-Security` is emitted **only when the request is HTTPS** — either directly or via an `X-Forwarded-Proto: https` header from your TLS-terminating proxy — so it is never sent over plain HTTP.
+Every response carries a `Content-Security-Policy` scoped to what the SPA actually loads (own scripts, inline styles used by React, Google Fonts, and `data:`/`blob:` images for rendered pages), plus `X-Content-Type-Options: nosniff`, `X-Frame-Options: DENY` (matching the CSP `frame-ancestors 'none'`), and `Referrer-Policy: strict-origin-when-cross-origin`. `Strict-Transport-Security` is emitted **only when the request is HTTPS** - either directly or via an `X-Forwarded-Proto: https` header from your TLS-terminating proxy - so it is never sent over plain HTTP.
 
 ---
 
@@ -507,11 +528,11 @@ Drop a `users.json` file into your data directory before first start and Grimoir
 |---|---|---|
 | `username` | Yes | Login username |
 | `password` | Yes | Plaintext password **or** a pre-hashed `$bcrypt-sha256$` string |
-| `role` | No | `admin`, `gm`, or `player` — defaults to `player` if missing |
-| `denyExplicit` | No | `true` to restrict explicit content for this user — defaults to `false` |
+| `role` | No | `admin`, `gm`, or `player` - defaults to `player` if missing |
+| `denyExplicit` | No | `true` to restrict explicit content for this user - defaults to `false` |
 
 **Rules:**
-- At least one entry must have `"role": "admin"` — the file is rejected otherwise.
+- At least one entry must have `"role": "admin"` - the file is rejected otherwise.
 - Entries whose username already exists in the database are silently skipped.
 - On parse or validation errors the file is left untouched so you can fix and restart.
 
@@ -540,7 +561,7 @@ docker compose up -d
 
 | Role | What they can do |
 |---|---|
-| `admin` | Everything — user management, app settings, metadata editing, rescan |
+| `admin` | Everything - user management, app settings, metadata editing, rescan |
 | `gm` | Read everything, edit metadata, create GM campaigns |
 | `player` | Read-only access, personal campaigns, session notes |
 | `guest` | Code-only account scoped to a single campaign. No access to the library, maps, tokens, audio, or search. See [Guest invites](#guest-invites). |
@@ -553,18 +574,18 @@ Create additional accounts in **Settings → Users** after logging in as admin.
 
 Grimoire has a built-in campaign tracker with two modes:
 
-- **GM Campaigns** — Created by GMs or admins. Supports player invitations, a banner image, character art and character sheets per member (uploaded file or an external link), resource linking with per-resource visibility, a markdown wiki for notes, and scheduling.
-- **Personal Campaigns** — Private to a single user. No sharing.
+- **GM Campaigns** - Created by GMs or admins. Supports player invitations, a banner image, character art and character sheets per member (uploaded file or an external link), resource linking with per-resource visibility, a markdown wiki for notes, and scheduling.
+- **Personal Campaigns** - Private to a single user. No sharing.
 
-Campaign creation uses a short wizard: pick a system, then choose resources — the system's core books are suggested by default and anything can be added (with a search) or removed, each set to **Shared with players**, **GM only**, or **Private**. The campaign **description** supports markdown, and you can name a **custom game system** that isn't in your library (handy for keeping notes on a system you don't own).
+Campaign creation uses a short wizard: pick a system, then choose resources - the system's core books are suggested by default and anything can be added (with a search) or removed, each set to **Shared with players**, **GM only**, or **Private**. The campaign **description** supports markdown, and you can name a **custom game system** that isn't in your library (handy for keeping notes on a system you don't own).
 
 When a GM invites you to a campaign, an **invite banner** appears at the top of the app so you can **accept** (join the campaign) or **decline** it from anywhere. You can dismiss the banner for the current browser session; it reappears the next time you open the app while an invite is still pending.
 
-Campaign members can set a **character name** per campaign (editable by both the GM and the player), upload **character art** (shown as their avatar) and a **character sheet** (PDF or image). A player can also **create a sheet from a template** — duplicating a form-fillable PDF from the library's Character Sheets category (filtered to the campaign's system) or a campaign file — and **fill it in directly in the app**: the real PDF is rendered in the browser and the player types into the form fields on the page itself, then saves a filled copy. The same in-app editing works for any form-fillable PDF a player uploads, so sheets can be updated as characters advance. Sheets can be downloaded at any time, and re-uploading prompts a warning (with an option to download the current version first) before the previous one is replaced. Users can also set a **display name** in Account Settings that appears in place of their username across the app.
+Campaign members can set a **character name** per campaign (editable by both the GM and the player), upload **character art** (shown as their avatar) and a **character sheet** (PDF or image). A player can also **create a sheet from a template** - duplicating a form-fillable PDF from the library's Character Sheets category (filtered to the campaign's system) or a campaign file - and **fill it in directly in the app**: the real PDF is rendered in the browser and the player types into the form fields on the page itself, then saves a filled copy. The same in-app editing works for any form-fillable PDF a player uploads, so sheets can be updated as characters advance. Sheets can be downloaded at any time, and re-uploading prompts a warning (with an option to download the current version first) before the previous one is replaced. Users can also set a **display name** in Account Settings that appears in place of their username across the app.
 
 ### Per-user campaign access
 
-Each user has a **campaign access** toggle (admins manage it per user in **Settings → Users**; enabled by default). Disabling it does **not** delete any existing campaigns — it only:
+Each user has a **campaign access** toggle (admins manage it per user in **Settings → Users**; enabled by default). Disabling it does **not** delete any existing campaigns - it only:
 
 - Prevents the user from creating campaigns, being added to new ones, and editing/linking resources.
 - Keeps their read access to campaigns they already own or belong to; in member lists they are flagged as **Access disabled**.
@@ -574,30 +595,30 @@ When OIDC is configured, this flag can be driven by the provider's [permissions 
 
 ### Guest invites
 
-Guests let you share a single campaign with people who don't have full accounts — for example a player who's only joining one game. A guest is a code-only account: no password, no OIDC, and no access to the library, maps, tokens, audio, or search. They can only see the campaign they were invited to (and its shared resources, wiki, and schedule), and can edit only their **own** character name, character art, character sheet, session notes, and availability.
+Guests let you share a single campaign with people who don't have full accounts - for example a player who's only joining one game. A guest is a code-only account: no password, no OIDC, and no access to the library, maps, tokens, audio, or search. They can only see the campaign they were invited to (and its shared resources, wiki, and schedule), and can edit only their **own** character name, character art, character sheet, session notes, and availability.
 
 - **Enable it server-wide** in **Settings → Authentication → Guest Access**, or pin it with the `GUEST_ACCESS_ENABLED` environment variable. It's off by default.
-- **Invite from a GM campaign** — open the members roster and use **Guests** (admins and GMs only). Add a guest with a nickname; each guest gets a unique 10-character invite code. A campaign can have multiple guests.
+- **Invite from a GM campaign** - open the members roster and use **Guests** (admins and GMs only). Add a guest with a nickname; each guest gets a unique 10-character invite code. A campaign can have multiple guests.
 - **Share the code** with the built-in **Share** button: copy a ready-made message, copy a version for a Discord DM, or open a pre-filled email. The message includes a deep link (`/guest?code=…`) and the code itself.
-- **Manage codes** — regenerate a guest's code (invalidating the old one) or remove the guest entirely (which deletes their guest account and contributions).
+- **Manage codes** - regenerate a guest's code (invalidating the old one) or remove the guest entirely (which deletes their guest account and contributions).
 - **Guests log in** from the login screen via **Have an invite code?**, which works even on OIDC-only servers where password login is disabled. In the app a guest sees the nickname their GM gave them and a **GUEST** role.
-- **Admin overview** — **Settings → Users** lists every guest account (grouped separately from full users) with its nickname, the campaign it's attached to, and who invited it. From there an admin can **convert a guest to a permanent user**: give it a username (and a password when password auth is enabled) and it keeps its campaign membership and character.
+- **Admin overview** - **Settings → Users** lists every guest account (grouped separately from full users) with its nickname, the campaign it's attached to, and who invited it. From there an admin can **convert a guest to a permanent user**: give it a username (and a password when password auth is enabled) and it keeps its campaign membership and character.
 
 ### Notes wiki
 
-Each campaign has a full-page markdown **wiki** (opened from the campaign overview) for building out the world — a place for session recaps, lore, NPCs, and plans:
+Each campaign has a full-page markdown **wiki** (opened from the campaign overview) for building out the world - a place for session recaps, lore, NPCs, and plans:
 
 - **Markdown** with tables, images, and the usual formatting, edited side-by-side with a live preview.
-- **Visibility per page** — *GM only*, *Public* (all members), or *Private* (specific members — e.g. a secret shared with one player). Change it straight from the visibility badge on the page: the badge is a dropdown, and for *Private* pages it lists members so you can grant or revoke access without opening the editor.
-- **GM secrets inline** — wrap text in `||double pipes||` (or use the **GM secret** button) to hide just that span inside an otherwise shared page. The GM sees it highlighted; players never receive it — it's stripped on the server before the page is sent. (Personal campaigns keep everything, since only you can read them.)
-- **Nested pages** — organize the sidebar as a tree: any page can hold subpages, to any depth (a "category" is just a page with children). Drag pages to re-nest them, add a subpage from the parent row, and collapse/expand branches. Deleting a page lifts its subpages up to the parent rather than removing them.
-- **Page links** — write `[[Page Title]]` to link pages; missing targets are auto-created as stubs, and each page shows what links back to it.
-- **Grimoire embeds** — drop a book (optionally at a page), map, token, audio track (plays in the global player; a note with several can be played as a playlist via "Play all"), or campaign file straight into a page. The embed picker lists the campaign's **linked resources** (link new library content in the Resources panel first). You can also **upload an image** right from the picker — it's embedded inline and added to your linked resources, filed under an existing category or a new one you name on the spot (e.g. *NPC art*).
-- **Import & export** (GM only) — export the whole wiki as a Markdown `.zip` (one file per page with YAML frontmatter — an Obsidian-style vault) or a JSON bundle, and import pages from Markdown, a Grimoire JSON bundle, or a **LegendKeeper** export (`.json`, `.lk`, or `.zip` — both the per-page export and the current `{version, resources}` bundle). LegendKeeper HTML and ProseMirror page bodies are converted to Markdown and the page hierarchy is preserved; LegendKeeper-only block types (e.g. secrets, embeds) are dropped, matching LegendKeeper's own export caveats. Imports are non-destructive — pages are always added, never overwritten.
+- **Visibility per page** - *GM only*, *Public* (all members), or *Private* (specific members - e.g. a secret shared with one player). Change it straight from the visibility badge on the page: the badge is a dropdown, and for *Private* pages it lists members so you can grant or revoke access without opening the editor.
+- **GM secrets inline** - wrap text in `||double pipes||` (or use the **GM secret** button) to hide just that span inside an otherwise shared page. The GM sees it highlighted; players never receive it - it's stripped on the server before the page is sent. (Personal campaigns keep everything, since only you can read them.)
+- **Nested pages** - organize the sidebar as a tree: any page can hold subpages, to any depth (a "category" is just a page with children). Drag pages to re-nest them, add a subpage from the parent row, and collapse/expand branches. Deleting a page lifts its subpages up to the parent rather than removing them.
+- **Page links** - write `[[Page Title]]` to link pages; missing targets are auto-created as stubs, and each page shows what links back to it.
+- **Grimoire embeds** - drop a book (optionally at a page), map, token, audio track (plays in the global player; a note with several can be played as a playlist via "Play all"), or campaign file straight into a page. The embed picker lists the campaign's **linked resources** (link new library content in the Resources panel first). You can also **upload an image** right from the picker - it's embedded inline and added to your linked resources, filed under an existing category or a new one you name on the spot (e.g. *NPC art*).
+- **Import & export** (GM only) - export the whole wiki as a Markdown `.zip` (one file per page with YAML frontmatter - an Obsidian-style vault) or a JSON bundle, and import pages from Markdown, a Grimoire JSON bundle, or a **LegendKeeper** export (`.json`, `.lk`, or `.zip` - both the per-page export and the current `{version, resources}` bundle). LegendKeeper HTML and ProseMirror page bodies are converted to Markdown and the page hierarchy is preserved; LegendKeeper-only block types (e.g. secrets, embeds) are dropped, matching LegendKeeper's own export caveats. Imports are non-destructive - pages are always added, never overwritten.
 
 Existing session notes are automatically rolled into wiki pages (nested under a "Session Notes" page) the first time the new version starts; empty notes are discarded.
 
-**Resources** — link books, maps, tokens, and audio, or upload campaign files (handouts, images, etc.) the GM keeps with the campaign. Each resource has a visibility: **Public** (all players), **Private** (shared with specific players — e.g. a handout for 2 of 4), or **GM only**. Resources group under their type by default, but the GM can create custom categories (e.g. *Player Handouts*), drag items between categories and reorder them, and delete categories (keeping items uncategorized or unlinking them). Each group can be **collapsed or expanded** (remembered per campaign), and the GM can **reorder all the groups** — custom categories and the built-in Books / Maps / Tokens / Audio / Files groups together — from the category manager.
+**Resources** - link books, maps, tokens, and audio, or upload campaign files (handouts, images, etc.) the GM keeps with the campaign. Each resource has a visibility: **Public** (all players), **Private** (shared with specific players - e.g. a handout for 2 of 4), or **GM only**. Resources group under their type by default, but the GM can create custom categories (e.g. *Player Handouts*), drag items between categories and reorder them, and delete categories (keeping items uncategorized or unlinking them). Each group can be **collapsed or expanded** (remembered per campaign), and the GM can **reorder all the groups** - custom categories and the built-in Books / Maps / Tokens / Audio / Files groups together - from the category manager.
 
 Uploaded campaign files live in the data directory, separate from the library. Admins can disable these uploads app-wide or cap them by per-file and per-campaign size in **Settings → App** (admins themselves are exempt).
 
@@ -605,10 +626,10 @@ Uploaded campaign files live in the data directory, separate from the library. A
 
 GM campaigns support recurring session schedules:
 
-- **Weekly** — same day(s) every week
-- **Biweekly** — every other week (anchored to a reference date)
-- **Monthly** — nth weekday of the month (e.g. "first Friday")
-- **Custom** — explicit list of dates
+- **Weekly** - same day(s) every week
+- **Biweekly** - every other week (anchored to a reference date)
+- **Monthly** - nth weekday of the month (e.g. "first Friday")
+- **Custom** - explicit list of dates
 
 Session note stubs are auto-created the day before each scheduled session. Players can mark their availability for upcoming dates, and the GM can cancel individual dates.
 
@@ -622,20 +643,20 @@ Grimoire supports authentication via any OpenID Connect–compliant identity pro
 
 Open **Settings → Authentication** as an admin:
 
-1. Set the **Issuer URL** (e.g. `https://idp.example.com/realms/main`) and click **Autopopulate** — the server fetches the IdP's `.well-known/openid-configuration` and fills in the endpoint URLs. You can also paste the full discovery document URL directly (e.g. `https://idp.example.com/realms/main/.well-known/openid-configuration`).
+1. Set the **Issuer URL** (e.g. `https://idp.example.com/realms/main`) and click **Autopopulate** - the server fetches the IdP's `.well-known/openid-configuration` and fills in the endpoint URLs. You can also paste the full discovery document URL directly (e.g. `https://idp.example.com/realms/main/.well-known/openid-configuration`).
 2. Paste the **Client ID** and **Client Secret** issued by your IdP.
-3. Register the displayed **Redirect URI** with your IdP. The path is fixed — set `BASE_URL` so the host portion reflects your public origin:
+3. Register the displayed **Redirect URI** with your IdP. The path is fixed - set `BASE_URL` so the host portion reflects your public origin:
    ```
    https://<your.server.com>/api/auth/openid/callback
    ```
 4. Enable **OpenID Connect**.
 5. (Optional) Configure:
-   - **Token Issuer** — the exact `iss` value your IdP puts in tokens. Leave blank to auto-detect from the discovery document. Set this explicitly if auto-detection fails or if your IdP's issuer differs from the Issuer URL (e.g. Authentik application providers). Can also be set via `OIDC_TOKEN_ISSUER`.
-   - **Groups Claim** — name of the OIDC claim that contains the user's groups. When set, roles are assigned from groups named (case-insensitively) `admin`, `gm`, or `player`. Highest level wins; users without any matching group are denied access.
-   - **Advanced Permissions Claim** — name of the OIDC claim containing a permissions object for non-admin users. Supports `{viewNSFW: bool, campaignAccess: bool}`. A missing `viewNSFW` key defaults to `false`; a missing `campaignAccess` key leaves [campaign access](#per-user-campaign-access) enabled. If the entire claim is missing, access is denied.
-   - **Match Existing Users By** — link an existing local account to the OIDC subject by email or username on first login. Subsequent logins always match by stable subject claim.
-   - **Auto-launch** — automatically redirect to the IdP when visiting `/login`. Append `?autoLaunch=0` to bypass.
-   - **Auto-register** — automatically create local accounts on first OIDC login.
+ - **Token Issuer** - the exact `iss` value your IdP puts in tokens. Leave blank to auto-detect from the discovery document. Set this explicitly if auto-detection fails or if your IdP's issuer differs from the Issuer URL (e.g. Authentik application providers). Can also be set via `OIDC_TOKEN_ISSUER`.
+ - **Groups Claim** - name of the OIDC claim that contains the user's groups. When set, roles are assigned from groups named (case-insensitively) `admin`, `gm`, or `player`. Highest level wins; users without any matching group are denied access.
+ - **Advanced Permissions Claim** - name of the OIDC claim containing a permissions object for non-admin users. Supports `{viewNSFW: bool, campaignAccess: bool}`. A missing `viewNSFW` key defaults to `false`; a missing `campaignAccess` key leaves [campaign access](#per-user-campaign-access) enabled. If the entire claim is missing, access is denied.
+ - **Match Existing Users By** - link an existing local account to the OIDC subject by email or username on first login. Subsequent logins always match by stable subject claim.
+ - **Auto-launch** - automatically redirect to the IdP when visiting `/login`. Append `?autoLaunch=0` to bypass.
+ - **Auto-register** - automatically create local accounts on first OIDC login.
 
 Any field can also be pinned via an environment variable (see the table above). Pinned fields are shown read-only in the admin UI.
 
@@ -663,12 +684,12 @@ environment:
 
 ### Personal feed URLs
 
-OPDS access is per-user. Each user generates their own opaque feed URL in **Settings → Account → OPDS Feed**. The URL contains a long random token — no username or password is needed by the OPDS client.
+OPDS access is per-user. Each user generates their own opaque feed URL in **Settings → Account → OPDS Feed**. The URL contains a long random token - no username or password is needed by the OPDS client.
 
-- **Enable** — generates a unique feed URL
-- **Copy** — copies the URL to the clipboard
-- **Regenerate** — issues a new token; the old URL stops working immediately
-- **Disable** — revokes the token; the feed URL stops working immediately
+- **Enable** - generates a unique feed URL
+- **Copy** - copies the URL to the clipboard
+- **Regenerate** - issues a new token; the old URL stops working immediately
+- **Disable** - revokes the token; the feed URL stops working immediately
 
 ### Feed URL structure
 
@@ -691,11 +712,11 @@ The live API is self-documented via OpenAPI. With the server running:
 
 | URL | Description |
 |-----|-------------|
-| `http://localhost:9481/api/docs` | Swagger UI — interactive docs |
-| `http://localhost:9481/api/redoc` | ReDoc — readable reference |
+| `http://localhost:9481/api/docs` | Swagger UI - interactive docs |
+| `http://localhost:9481/api/redoc` | ReDoc - readable reference |
 | `http://localhost:9481/api/openapi.json` | Raw OpenAPI schema |
 
-For contributors, [docs/architecture.md](docs/architecture.md) is a developer-facing architecture reference — module map, request lifecycle, auth/OIDC flow, and startup migrations. For the database schema — an ER diagram and a table-by-table reference of the models and their foreign keys — see [docs/data-model.md](docs/data-model.md).
+For contributors, [docs/architecture.md](docs/architecture.md) is a developer-facing architecture reference - module map, request lifecycle, auth/OIDC flow, and startup migrations. For the database schema - an ER diagram and a table-by-table reference of the models and their foreign keys - see [docs/data-model.md](docs/data-model.md).
 
 ---
 
@@ -707,7 +728,7 @@ Common questions and troubleshooting tips are in [docs/faq.md](docs/faq.md).
 
 ## Contributing
 
-Grimoire is open source and contributions are welcome — bug reports, feature ideas, docs, and code.
+Grimoire is open source and contributions are welcome - bug reports, feature ideas, docs, and code.
 
 See [CONTRIBUTING.md](.github/CONTRIBUTING.md) for full details on reporting issues, submitting pull requests, and setting up a local development environment.
 
@@ -717,4 +738,4 @@ To report a security vulnerability privately, see [SECURITY.md](.github/SECURITY
 
 ## License
 
-GNU General Public License v3.0 — see [LICENSE](LICENSE) for details.
+GNU General Public License v3.0 - see [LICENSE](LICENSE) for details.

--- a/backend/config.py
+++ b/backend/config.py
@@ -31,8 +31,40 @@ VALKEY_URL = os.environ.get("VALKEY_URL", "")
 #   OCR_LANGUAGES — Tesseract language codes, e.g. "eng" or "eng+deu+fra".
 #                   Extra languages need their tessdata files present (bundle
 #                   them by mounting a tessdata dir and setting TESSDATA_PREFIX).
+#   OCR_CONCURRENCY — number of scanned books OCR'd in parallel by the deferred
+#                     OCR worker. Defaults to 1 (serial) to keep small self-hosted
+#                     boxes responsive; raise it on multi-core hosts with spare CPU.
+#                     Setting it to 0 disables OCR entirely (same effect as
+#                     OCR_ENABLED=false) — a runtime off switch for users hitting
+#                     repeated OCR errors or OOMs, without pulling the slim image.
 OCR_ENABLED = os.environ.get("OCR_ENABLED", "true").lower() == "true"
 OCR_LANGUAGES = os.environ.get("OCR_LANGUAGES", "eng").strip() or "eng"
+
+
+def _read_ocr_concurrency() -> int:
+    """Parallel-OCR worker count. 0 = OCR disabled; negatives clamp to 0; bad
+    values fall back to the serial default of 1."""
+    try:
+        return max(0, int(os.environ.get("OCR_CONCURRENCY", "1")))
+    except ValueError:
+        return 1
+
+
+OCR_CONCURRENCY = _read_ocr_concurrency()
+
+
+#   OCR_DPI — resolution at which scanned pages are rasterized before OCR.
+#             Rendering is the memory/CPU-heavy half of OCR; higher = more
+#             accurate but slower and more RAM per page. Default 150.
+def _read_ocr_dpi() -> float:
+    try:
+        dpi = float(os.environ.get("OCR_DPI", "150"))
+    except ValueError:
+        dpi = 150.0
+    return max(72.0, min(dpi, 600.0))
+
+
+OCR_DPI = _read_ocr_dpi()
 _PAGE_CACHE_HEADERS = {"Cache-Control": "max-age=31536000, immutable"}
 
 # Optional override for password authentication. When the env var is set,

--- a/backend/indexer.py
+++ b/backend/indexer.py
@@ -21,7 +21,7 @@ from sqlalchemy import text
 from sqlalchemy.exc import IntegrityError
 from sqlalchemy.orm import Session
 
-from . import ocr
+from . import config, ocr
 from .models import GameSystem, Book, GenericMap, MapFolder, Token, TokenFolder, Audio, AudioFolder
 
 logger = logging.getLogger("grimoire.indexer")
@@ -34,6 +34,11 @@ _DB_TIMEOUT = 30  # seconds — max time to wait for a DB operation before treat
 # that can't finish in this window is treated as unindexable rather than allowed
 # to stall the scan forever.
 _EXTRACT_TIMEOUT = 1800  # seconds (30 min)
+
+# Per-page OCR budget for the deferred-OCR worker.  OCR is checkpointed per page,
+# so the whole-book budget no longer applies to scanned PDFs — only a single
+# wedged page is abandoned after this, and the book continues to the next page.
+_OCR_PAGE_TIMEOUT = 120  # seconds
 
 # Spawn (not fork) a fresh interpreter for the extraction worker.  The app runs
 # many threads and holds a SQLite connection; forking that state into a child
@@ -303,6 +308,38 @@ _ARCHIVE_LIST_CAP = 5000
 _ARCHIVE_MEMBER_SIZE_CAP = 256 * 1024 * 1024
 
 
+def _extract_7z_member(zf, name: str) -> Optional[bytes]:
+    """Read a single member out of an open py7zr archive as bytes.
+
+    Tolerant of the py7zr 0.x/1.x API split: 1.x removed ``SevenZipFile.read()``
+    in favour of extracting through a ``BytesIOFactory``, while 0.x still has
+    ``read()``. Try the factory path first, fall back to ``read()``, so the cover
+    extraction works whichever version is installed. Returns None on any failure.
+    """
+    # py7zr 1.x: extract the chosen member into memory via BytesIOFactory.
+    try:
+        from py7zr.io import BytesIOFactory
+
+        factory = BytesIOFactory(limit=_ARCHIVE_MEMBER_SIZE_CAP)
+        zf.extract(targets=[name], factory=factory)
+        bio = factory.get(name)
+        if bio is not None:
+            bio.seek(0)
+            return bio.read()
+        return None
+    except ImportError:
+        pass
+
+    # py7zr 0.x: SevenZipFile.read() returns {name: BytesIO}.
+    zf.reset()
+    data = zf.read([name])
+    bio = data.get(name) if data else None
+    if bio is not None:
+        bio.seek(0)
+        return bio.read()
+    return None
+
+
 def _first_image_from_archive(filepath: str, arc_ext: str) -> Optional[bytes]:
     """Return the raw bytes of the first image inside a comic-book archive.
 
@@ -328,7 +365,6 @@ def _first_image_from_archive(filepath: str, arc_ext: str) -> Optional[bytes]:
                         return rf.read(name)
         elif arc_ext in (".cb7", ".7z"):
             import py7zr
-            from py7zr.io import BytesIOFactory
 
             with py7zr.SevenZipFile(filepath) as zf:
                 names = [n for n in zf.getnames()[:_ARCHIVE_LIST_CAP]]
@@ -337,15 +373,7 @@ def _first_image_from_archive(filepath: str, arc_ext: str) -> Optional[bytes]:
                     key=str.lower,
                 )
                 if targets:
-                    first = targets[0]
-                    # py7zr 1.x dropped SevenZipFile.read(); extract the single
-                    # chosen member into memory via a BytesIOFactory instead.
-                    factory = BytesIOFactory(limit=_ARCHIVE_MEMBER_SIZE_CAP)
-                    zf.extract(targets=[first], factory=factory)
-                    bio = factory.get(first)
-                    if bio is not None:
-                        bio.seek(0)
-                        return bio.read()
+                    return _extract_7z_member(zf, targets[0])
         elif arc_ext in (".cbt", ".tar", ".tar.gz", ".tgz", ".tar.bz2", ".tbz2"):
             with tarfile.open(filepath) as tf:
                 members = [m for m in tf.getmembers() if m.isfile()]
@@ -429,7 +457,9 @@ def generate_thumbnail(filepath: str, output_path: str, size: tuple = (300, 400)
     return bool(result[0])
 
 
-def extract_text_from_pdf(filepath: str, should_stop=None) -> tuple[list[dict], bool]:
+def extract_text_from_pdf(
+    filepath: str, should_stop=None, text_only: bool = False
+) -> tuple[list[dict], bool]:
     """Extract text from all pages of a PDF.
 
     Returns ``(pages, used_ocr)`` where ``pages`` is a list of
@@ -440,10 +470,14 @@ def extract_text_from_pdf(filepath: str, should_stop=None) -> tuple[list[dict], 
     text are OCR'd when OCR is available (default image); otherwise they are
     skipped, so a PDF with no extractable text yields an empty list — the
     caller then marks it ``image-only``.
+
+    When ``text_only`` is True, OCR is skipped: image-only pages are left out and
+    the book is queued for deferred OCR by the caller instead of being OCR'd
+    inline (which could stall the scan for hours on a large scanned book).
     """
     pages = []
     used_ocr = False
-    ocr_on = ocr.ocr_available()
+    ocr_on = False if text_only else ocr.ocr_available()
     try:
         doc = _fitz_open_with_timeout(filepath, should_stop=should_stop)
         for i, page in enumerate(doc):
@@ -453,7 +487,8 @@ def extract_text_from_pdf(filepath: str, should_stop=None) -> tuple[list[dict], 
             if page_text:
                 pages.append({"page": i + 1, "content": page_text})
             elif ocr_on:
-                pix = page.get_pixmap(matrix=fitz.Matrix(2, 2), alpha=False)
+                scale = config.OCR_DPI / 72.0
+                pix = page.get_pixmap(matrix=fitz.Matrix(scale, scale), alpha=False)
                 ocr_text = ocr.ocr_pixmap(pix, should_stop=should_stop)
                 if ocr_text:
                     pages.append({"page": i + 1, "content": ocr_text})
@@ -464,7 +499,9 @@ def extract_text_from_pdf(filepath: str, should_stop=None) -> tuple[list[dict], 
     return pages, used_ocr
 
 
-def extract_text_isolated(filepath: str, should_stop=None) -> tuple[list[dict], bool]:
+def extract_text_isolated(
+    filepath: str, should_stop=None, text_only: bool = False
+) -> tuple[list[dict], bool]:
     """Extract text from a PDF in a separate process, isolating native crashes.
 
     Returns ``(pages, used_ocr)`` exactly like ``extract_text_from_pdf``.  The
@@ -476,12 +513,17 @@ def extract_text_isolated(filepath: str, should_stop=None) -> tuple[list[dict], 
 
     A cooperative ``should_stop`` cancels by terminating the child and raising
     TimeoutError, matching the abort semantics of the rest of the indexer.
+
+    With ``text_only`` the child skips OCR (fast scan phase); image-only books
+    return empty ``pages`` and are queued for deferred OCR by the caller.
     """
     from . import pdf_worker
 
     fd, result_path = tempfile.mkstemp(prefix="grimoire_extract_", suffix=".pkl")
     os.close(fd)
-    proc = _MP_CONTEXT.Process(target=pdf_worker.main, args=(filepath, result_path))
+    proc = _MP_CONTEXT.Process(
+        target=pdf_worker.main, args=(filepath, result_path, text_only)
+    )
     try:
         proc.start()
         poll_interval = 0.5
@@ -521,6 +563,158 @@ def extract_text_isolated(filepath: str, should_stop=None) -> tuple[list[dict], 
             os.unlink(result_path)
         except OSError:
             pass
+
+
+def ocr_page_isolated(filepath: str, page_index: int, should_stop=None, dpi: int | None = None) -> str:
+    """OCR a single page in a spawned child, bounded by ``_OCR_PAGE_TIMEOUT``.
+
+    Returns the recognised text ("" on timeout, crash, cancel, or empty result —
+    never raises).  Isolation means a native OCR/MuPDF crash or a wedged page
+    kills only this throwaway process; the caller checkpoints the page as done
+    and moves on rather than losing the whole book or crashing the server.
+
+    ``dpi`` overrides the rasterization resolution (per-book re-OCR); None uses
+    the global ``OCR_DPI`` default.
+    """
+    from . import pdf_worker
+
+    fd, result_path = tempfile.mkstemp(prefix="grimoire_ocr_", suffix=".pkl")
+    os.close(fd)
+    proc = _MP_CONTEXT.Process(
+        target=pdf_worker.ocr_page_main,
+        args=(filepath, page_index, ocr.effective_languages(), result_path, dpi),
+    )
+    try:
+        proc.start()
+        poll_interval = 0.5
+        elapsed = 0.0
+        while proc.is_alive() and elapsed < _OCR_PAGE_TIMEOUT:
+            proc.join(poll_interval)
+            elapsed += poll_interval
+            if should_stop and should_stop():
+                proc.terminate()
+                proc.join()
+                return ""
+        if proc.is_alive():
+            logger.error(
+                f"OCR page {page_index + 1} timed out after {_OCR_PAGE_TIMEOUT}s for {filepath}"
+            )
+            proc.terminate()
+            proc.join()
+            return ""
+        if os.path.getsize(result_path) == 0:
+            logger.error(
+                f"OCR page {page_index + 1} worker crashed (exit {proc.exitcode}) for {filepath}"
+            )
+            return ""
+        with open(result_path, "rb") as fh:
+            return pickle.load(fh) or ""
+    finally:
+        if proc.is_alive():
+            proc.terminate()
+            proc.join()
+        try:
+            os.unlink(result_path)
+        except OSError:
+            pass
+
+
+def ocr_book(book: Book, session: Session, should_stop=None, on_page=None) -> str:
+    """OCR one queued book page-by-page, checkpointing progress as it goes.
+
+    Resumes from ``book.ocr_pages_done``: pages at or below that index were
+    already OCR'd and committed to the FTS index in a prior run, so a restart or
+    crash never loses work and never re-does a page.  Each recognised page is
+    inserted into ``book_search`` and ``ocr_pages_done`` is advanced and
+    committed before moving on, so the whole-book 30-min wall no longer applies —
+    a multi-hour scanned book makes steady, durable progress.
+
+    Returns one of: ``"done"`` (all pages processed, book indexed), ``"stopped"``
+    (cancelled via ``should_stop`` — resumable), or ``"error"`` (page count
+    unreadable).  ``on_page(done, total)`` is called after each page for live
+    status.
+    """
+    try:
+        page_count = _book_page_count(book.filepath)
+    except Exception as e:
+        logger.error(f"OCR: cannot open '{book.filename}' to count pages: {e}")
+        book.ocr_pending = False
+        book.index_failed = True
+        book.index_error = f"ocr open failed: {e}"[:500]
+        _commit(session, f"ocr open-failed '{book.filepath}'")
+        return "error"
+
+    start = book.ocr_pages_done or 0
+    dpi = book.ocr_dpi  # per-book override; None => global OCR_DPI default
+    logger.info(
+        f"OCR: '{book.filename}' — {page_count} page(s), resuming at page {start + 1}"
+        + (f" (dpi={dpi})" if dpi else "")
+    )
+    for i in range(start, page_count):
+        if should_stop and should_stop():
+            logger.info(f"OCR: stop requested during '{book.filename}' at page {i + 1}")
+            return "stopped"
+
+        text_out = ocr_book_page_isolated_wrapper(book.filepath, i, should_stop, dpi=dpi)
+
+        # A page cancelled mid-flight comes back empty; treat that as a stop, not a
+        # processed page, so it isn't silently skipped forever on resume. Checked
+        # here (not just at the top) because the OCR call can take up to the
+        # per-page timeout, during which a stop may have been requested.
+        if should_stop and should_stop():
+            logger.info(f"OCR: stop requested during '{book.filename}' at page {i + 1}")
+            return "stopped"
+
+        if text_out:
+            session.execute(
+                text(
+                    "INSERT INTO book_search (book_id, page_number, content) "
+                    "VALUES (:bid, :pnum, :content)"
+                ),
+                {"bid": book.id, "pnum": i + 1, "content": text_out},
+            )
+        # Advance the checkpoint whether the page yielded text, was legitimately
+        # blank, or was abandoned (crash/timeout in the isolated worker — already
+        # logged there). The page is counted as processed exactly once and never
+        # re-OCR'd on resume, so a single pathological page can't stall or loop the
+        # book forever. Committed per page so a crash right after loses at most the
+        # page in flight.
+        book.ocr_pages_done = i + 1
+        _commit(session, f"ocr page {i + 1} '{book.filepath}'")
+        if on_page:
+            on_page(i + 1, page_count)
+
+    # All pages processed: the book is now fully indexed.  ``index_error='ocr'``
+    # badges it in the UI as OCR-sourced (same convention as inline OCR).
+    book.ocr_pending = False
+    book.indexed = True
+    book.index_failed = False
+    book.index_error = "ocr"
+    _commit(session, f"ocr done '{book.filepath}'")
+    logger.info(f"OCR: completed '{book.filename}' ({page_count} pages)")
+    return "done"
+
+
+# Indirection so tests can stub the isolated call without spawning subprocesses.
+def ocr_book_page_isolated_wrapper(filepath: str, page_index: int, should_stop=None) -> str:
+    return ocr_page_isolated(filepath, page_index, should_stop=should_stop)
+
+
+def _book_page_count(filepath: str) -> int:
+    doc = _fitz_open_with_timeout(filepath)
+    try:
+        return doc.page_count
+    finally:
+        doc.close()
+
+
+def _commit(session: Session, label: str) -> None:
+    """Commit with the standard indexer timeout guard; roll back on hang."""
+    try:
+        _run_with_timeout(session.commit, _DB_TIMEOUT, label)
+    except (TimeoutError, IntegrityError) as e:
+        logger.error(f"DB hang on commit ({label}): {e}")
+        session.rollback()
 
 
 def _count_eligible_files(directory: Path, extensions: set) -> int:
@@ -1596,7 +1790,12 @@ def index_book_text(book: Book, data_path: str, session: Session, should_stop=No
 
     logger.info(f"Indexing: extracting text from '{book.filepath}'")
     try:
-        pages, used_ocr = extract_text_isolated(book.filepath, should_stop=should_stop)
+        # text_only: never OCR inline. Image-only books come back with no pages
+        # and are queued for the deferred-OCR worker below, so a large scanned
+        # book can't stall the scan for hours or hit the whole-book timeout.
+        pages, used_ocr = extract_text_isolated(
+            book.filepath, should_stop=should_stop, text_only=True
+        )
     except PdfExtractionCrashError as e:
         logger.error(f"Text extraction crashed for '{book.filename}': {e} — marking index_failed")
         book.index_error = f"extraction crashed: {e}"[:500]
@@ -1618,6 +1817,21 @@ def index_book_text(book: Book, data_path: str, session: Session, should_stop=No
         return False
 
     if not pages:
+        if ocr.ocr_available():
+            # Scanned/image-only PDF: hand it to the deferred-OCR queue instead
+            # of OCRing inline. Left not-indexed with ocr_pending set so the OCR
+            # worker (and startup recovery) picks it up; index_failed cleared so
+            # it isn't mistaken for a hard failure.
+            logger.info(f"No text layer in '{book.filename}' — queuing for deferred OCR")
+            book.ocr_pending = True
+            book.ocr_pages_done = 0
+            book.indexed = False
+            book.index_failed = False
+            book.index_error = ""
+            _commit(session, f"queue ocr '{book.filepath}'")
+            return False
+        # OCR unavailable (slim image): keep the pre-OCR behaviour — mark
+        # image-only and indexed so it isn't retried every scan.
         logger.info(f"No text extracted from '{book.filename}' — image-only PDF, marking as indexed")
         book.index_error = "image-only"
         book.indexed = True

--- a/backend/migrations/versions/0002_ocr_queue.py
+++ b/backend/migrations/versions/0002_ocr_queue.py
@@ -1,0 +1,74 @@
+"""ocr queue: ocr_pending + ocr_pages_done on books
+
+Deferred-OCR support. Image-only (scanned) PDFs are no longer OCR'd inline
+during the scan; they are queued via ``ocr_pending`` and drained by a dedicated
+background worker that checkpoints ``ocr_pages_done`` so long books resume after
+a restart instead of losing work.
+
+Revision ID: a1f4c2e9b7d0
+Revises: 96c733b7c205
+Create Date: 2026-07-13 00:00:00.000000+00:00
+
+"""
+from typing import Sequence, Union
+
+from alembic import op
+import sqlalchemy as sa
+from sqlalchemy import inspect
+
+
+# revision identifiers, used by Alembic.
+revision: str = "a1f4c2e9b7d0"
+down_revision: Union[str, None] = "96c733b7c205"
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def _books_columns() -> set:
+    bind = op.get_bind()
+    return {c["name"] for c in inspect(bind).get_columns("books")}
+
+
+def _books_indexes() -> set:
+    bind = op.get_bind()
+    return {i["name"] for i in inspect(bind).get_indexes("books")}
+
+
+def upgrade() -> None:
+    # Adding a nullable column with a constant default and creating an index are
+    # both operations SQLite performs in place, so we issue plain ALTER/CREATE
+    # statements rather than a batch_alter_table rebuild. The rebuild copies the
+    # whole table through a temporary _alembic_tmp_books table; if it is
+    # interrupted (OOM, container kill) it leaves that temp table behind and,
+    # because the migration never committed, the next startup re-runs this
+    # revision and dies with "table _alembic_tmp_books already exists". Plain
+    # ALTERs create no temp table and each is idempotent below, so a retried or
+    # partially-applied run recovers cleanly.
+    #
+    # Drop any stale temp table left by an earlier interrupted batch run of this
+    # migration (from a prior release) before proceeding.
+    op.execute("DROP TABLE IF EXISTS _alembic_tmp_books")
+
+    existing = _books_columns()
+    if "ocr_pending" not in existing:
+        op.add_column(
+            "books",
+            sa.Column("ocr_pending", sa.Boolean(), nullable=True, server_default=sa.text("0")),
+        )
+    if "ocr_pages_done" not in existing:
+        op.add_column(
+            "books",
+            sa.Column("ocr_pages_done", sa.Integer(), nullable=True, server_default=sa.text("0")),
+        )
+    if "ix_books_ocr_pending" not in _books_indexes():
+        op.create_index("ix_books_ocr_pending", "books", ["ocr_pending"], unique=False)
+
+
+def downgrade() -> None:
+    if "ix_books_ocr_pending" in _books_indexes():
+        op.drop_index("ix_books_ocr_pending", table_name="books")
+    existing = _books_columns()
+    if "ocr_pages_done" in existing:
+        op.drop_column("books", "ocr_pages_done")
+    if "ocr_pending" in existing:
+        op.drop_column("books", "ocr_pending")

--- a/backend/migrations/versions/0003_ocr_dpi.py
+++ b/backend/migrations/versions/0003_ocr_dpi.py
@@ -1,0 +1,40 @@
+"""ocr dpi: per-book OCR resolution override on books
+
+Adds a nullable ``ocr_dpi`` column so a specific scanned book can be re-OCR'd at
+a higher resolution than the global ``OCR_DPI`` default (NULL = use the default).
+
+Revision ID: b2e5d3f0c8a1
+Revises: a1f4c2e9b7d0
+Create Date: 2026-07-14 00:00:00.000000+00:00
+
+"""
+from typing import Sequence, Union
+
+from alembic import op
+import sqlalchemy as sa
+from sqlalchemy import inspect
+
+
+# revision identifiers, used by Alembic.
+revision: str = "b2e5d3f0c8a1"
+down_revision: Union[str, None] = "a1f4c2e9b7d0"
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def _books_columns() -> set:
+    return {c["name"] for c in inspect(op.get_bind()).get_columns("books")}
+
+
+def upgrade() -> None:
+    # Plain in-place ALTER (no batch_alter_table rebuild): adding a nullable
+    # column needs no table copy, so there is no _alembic_tmp_books to leave
+    # behind if interrupted. Guarded so a retried/partial run is a clean no-op.
+    op.execute("DROP TABLE IF EXISTS _alembic_tmp_books")
+    if "ocr_dpi" not in _books_columns():
+        op.add_column("books", sa.Column("ocr_dpi", sa.Integer(), nullable=True))
+
+
+def downgrade() -> None:
+    if "ocr_dpi" in _books_columns():
+        op.drop_column("books", "ocr_dpi")

--- a/backend/models/db.py
+++ b/backend/models/db.py
@@ -112,6 +112,10 @@ def _apply_legacy_migrations(conn) -> None:
         "CREATE INDEX IF NOT EXISTS ix_campaign_members_guest_code ON campaign_members(guest_code)",
         "ALTER TABLE books ADD COLUMN tags JSON DEFAULT '[]'",
         "ALTER TABLE game_systems ADD COLUMN is_system_agnostic BOOLEAN DEFAULT 0",
+        "ALTER TABLE books ADD COLUMN ocr_pending BOOLEAN DEFAULT 0",
+        "ALTER TABLE books ADD COLUMN ocr_pages_done INTEGER DEFAULT 0",
+        "CREATE INDEX IF NOT EXISTS ix_books_ocr_pending ON books(ocr_pending)",
+        "ALTER TABLE books ADD COLUMN ocr_dpi INTEGER",
     ]:
         try:
             conn.execute(text(migration))

--- a/backend/models/library.py
+++ b/backend/models/library.py
@@ -68,6 +68,20 @@ class Book(Base):
     index_error = Column(String(500), default="")
     scan_failed = Column(Boolean, default=False)
     is_missing = Column(Boolean, default=False)
+    # OCR is deferred to a separate background phase so scanned (image-only) PDFs
+    # don't block the fast text-layer indexing of the rest of the library. A book
+    # with no embedded text layer is marked ocr_pending here; a dedicated OCR
+    # worker drains the queue page-by-page, checkpointing ocr_pages_done so a long
+    # book resumes where it left off after a restart or crash instead of losing
+    # hours of work. See docs/architecture.md and backend/indexer.ocr_book_page.
+    ocr_pending = Column(Boolean, default=False, index=True)
+    ocr_pages_done = Column(Integer, default=0)
+    # Optional per-book OCR resolution override (DPI). NULL means "use the global
+    # OCR_DPI default". Set when a user re-OCRs a specific book at a higher DPI
+    # for a sharper read than the library-wide default gives; persisted so the
+    # override survives a restart mid-re-OCR. See indexer.ocr_book / the
+    # POST /api/books/{id}/reindex endpoint.
+    ocr_dpi = Column(Integer, nullable=True)
 
     created_at = Column(DateTime, default=_utcnow)
     updated_at = Column(DateTime, default=_utcnow, onupdate=_utcnow)

--- a/backend/ocr.py
+++ b/backend/ocr.py
@@ -44,11 +44,13 @@ def _probe_tesseract() -> bool:
 def ocr_available() -> bool:
     """Whether OCR can run: enabled in config AND tesseract is usable.
 
-    The tesseract probe is cached after the first call; ``OCR_ENABLED`` is read
-    live so tests can toggle it without clearing the cache.
+    The tesseract probe is cached after the first call; ``OCR_ENABLED`` and
+    ``OCR_CONCURRENCY`` are read live so tests can toggle them without clearing
+    the cache. ``OCR_CONCURRENCY == 0`` is a runtime off switch, equivalent to
+    ``OCR_ENABLED=false``.
     """
     global _available
-    if not config.OCR_ENABLED:
+    if not config.OCR_ENABLED or config.OCR_CONCURRENCY == 0:
         return False
     if _available is None:
         _available = _probe_tesseract()
@@ -65,13 +67,20 @@ def reset_availability_cache() -> None:
     _available = None
 
 
+def effective_languages() -> str:
+    """The Tesseract language string to OCR with (mirrors ``config.OCR_LANGUAGES``)."""
+    return config.OCR_LANGUAGES
+
+
 def requeue_image_only_books(session) -> int:
-    """Reset books previously marked ``image-only`` so the next scan OCRs them.
+    """Queue books previously marked ``image-only`` for deferred OCR.
 
     Called on startup: when OCR has become available (e.g. after upgrading from
-    the slim image or enabling OCR), previously-skipped image-only PDFs are
-    re-queued by clearing ``indexed``. No-op — returning 0 — when OCR is
-    unavailable, so slim installs never churn. Returns the number re-queued.
+    the slim image or enabling OCR), previously-skipped image-only PDFs are moved
+    into the deferred-OCR queue (``ocr_pending=1``) with their page checkpoint
+    reset, rather than OCR'd inline during the next scan. No-op — returning 0 —
+    when OCR is unavailable, so slim installs never churn. Returns the number
+    queued.
     """
     if not ocr_available():
         return 0
@@ -80,14 +89,15 @@ def requeue_image_only_books(session) -> int:
 
     result = session.execute(
         _sql_text(
-            "UPDATE books SET indexed = 0, index_error = '' "
-            "WHERE index_error = 'image-only' AND indexed = 1"
+            "UPDATE books SET ocr_pending = 1, ocr_pages_done = 0, indexed = 0, "
+            "index_failed = 0, index_error = '' "
+            "WHERE index_error = 'image-only'"
         )
     )
     count = result.rowcount or 0
     if count:
         session.commit()
-        logger.info(f"OCR: re-queued {count} previously image-only book(s) for indexing")
+        logger.info(f"OCR: queued {count} previously image-only book(s) for deferred OCR")
     return count
 
 

--- a/backend/pdf_worker.py
+++ b/backend/pdf_worker.py
@@ -39,16 +39,23 @@ def _ocr_settings() -> tuple[bool, str]:
         return False, languages
 
 
-def run(filepath: str) -> tuple[list[dict], bool]:
+def run(filepath: str, text_only: bool = False) -> tuple[list[dict], bool]:
     """Extract text from every page of ``filepath``.
 
     Returns ``(pages, used_ocr)`` matching ``indexer.extract_text_from_pdf``:
     pages with an embedded text layer are read directly; text-less pages are
     OCR'd when OCR is available, otherwise skipped.
+
+    When ``text_only`` is True, OCR is skipped entirely — only the embedded text
+    layer is read.  The deferred-OCR pipeline uses this for the fast scan phase:
+    image-only pages come back missing (empty ``pages``), the caller queues the
+    book for OCR, and OCR runs later page-by-page via ``ocr_page`` so a slow
+    scanned book never blocks or times out the main scan.
     """
     pages: list[dict] = []
     used_ocr = False
-    ocr_on, languages = _ocr_settings()
+    ocr_on = False if text_only else _ocr_settings()[0]
+    languages = _ocr_settings()[1] if ocr_on else "eng"
     doc = fitz.open(filepath)
     try:
         for i, page in enumerate(doc):
@@ -65,20 +72,70 @@ def run(filepath: str) -> tuple[list[dict], bool]:
     return pages, used_ocr
 
 
-def _ocr_page(page, languages: str) -> str:
+def ocr_page(filepath: str, page_index: int, languages: str, dpi: int | None = None) -> str:
+    """OCR a single 0-based page of ``filepath``, returning stripped text.
+
+    Used by the deferred-OCR worker's isolated subprocess so a native crash or
+    hang while OCRing one page can't take down the server or the whole book —
+    the parent checkpoints progress and resumes at the next page.  Returns "" on
+    any failure (page already has a text layer, render error, OCR error).
+
+    ``dpi`` overrides the resolution the page is rasterized at; None uses the
+    global ``OCR_DPI`` default. Used by the per-book re-OCR flow to re-read a
+    specific book at a sharper resolution.
+    """
+    doc = fitz.open(filepath)
+    try:
+        page = doc[page_index]
+        # A page that already has embedded text was handled in the fast phase;
+        # OCRing it again would duplicate content in the index.
+        if page.get_text().strip():
+            return ""
+        return _ocr_page(page, languages, dpi=dpi)
+    finally:
+        doc.close()
+
+
+def _ocr_scale(dpi: int | None = None) -> float:
+    """Rasterization scale for OCR (72 DPI × scale). Mirrors backend.config default.
+
+    Rendering is the CPU/memory-heavy half of OCR: a page's bitmap is
+    ``(scale·width_pt) × (scale·height_pt) × 3`` bytes in memory. The default
+    ``OCR_DPI=150`` (scale ≈ 2.08) is a good accuracy/cost balance for Tesseract;
+    lower it (e.g. 100) to cut render time and per-process memory on small hosts,
+    raise it (e.g. 300) for cleaner OCR on faint scans at higher cost.
+
+    An explicit ``dpi`` (per-book override) wins over the ``OCR_DPI`` env default.
+    """
+    if dpi is not None:
+        try:
+            value = float(dpi)
+        except (TypeError, ValueError):
+            value = 150.0
+    else:
+        try:
+            value = float(os.environ.get("OCR_DPI", "150"))
+        except ValueError:
+            value = 150.0
+    value = max(72.0, min(value, 600.0))  # clamp to a sane range
+    return value / 72.0
+
+
+def _ocr_page(page, languages: str, dpi: int | None = None) -> str:
     """Render a page to an image and OCR it, returning stripped text ("" on failure)."""
     try:
         from PIL import Image
         import pytesseract
 
-        pix = page.get_pixmap(matrix=fitz.Matrix(2, 2), alpha=False)
+        scale = _ocr_scale(dpi)
+        pix = page.get_pixmap(matrix=fitz.Matrix(scale, scale), alpha=False)
         image = Image.frombytes("RGB", [pix.width, pix.height], pix.samples)
         return pytesseract.image_to_string(image, lang=languages).strip()
     except Exception:
         return ""
 
 
-def main(filepath: str, result_path: str) -> None:
+def main(filepath: str, result_path: str, text_only: bool = False) -> None:
     """Subprocess entry point: extract and pickle ``(pages, used_ocr)`` to disk.
 
     Writing to a file rather than a pipe/queue avoids the deadlock where a child
@@ -86,6 +143,20 @@ def main(filepath: str, result_path: str) -> None:
     propagates and the process exits nonzero, which the parent treats as a
     crash — the result file is left empty so the parent can tell.
     """
-    result = run(filepath)
+    result = run(filepath, text_only=text_only)
     with open(result_path, "wb") as fh:
         pickle.dump(result, fh)
+
+
+def ocr_page_main(
+    filepath: str, page_index: int, languages: str, result_path: str, dpi: int | None = None
+) -> None:
+    """Subprocess entry point for OCRing a single page (deferred-OCR worker).
+
+    Pickles the recognised text to ``result_path``.  A crash leaves the file
+    empty, which the parent treats as a failed page and skips. ``dpi`` overrides
+    the rasterization resolution (per-book re-OCR); None uses the global default.
+    """
+    text = ocr_page(filepath, page_index, languages, dpi=dpi)
+    with open(result_path, "wb") as fh:
+        pickle.dump(text, fh)

--- a/backend/routers/books/__init__.py
+++ b/backend/routers/books/__init__.py
@@ -2,7 +2,14 @@
 from fastapi import APIRouter, Depends
 
 from ...auth import require_not_guest
-from .core import list_books, get_book, update_book, serve_book_file, serve_book_thumbnail
+from .core import (
+    list_books,
+    get_book,
+    update_book,
+    reindex_book,
+    serve_book_file,
+    serve_book_thumbnail,
+)
 from .pages import get_book_toc, serve_book_page, get_page_text, get_page_words
 from ._helpers import _invalidate_book_cache  # re-exported for library.py
 
@@ -18,6 +25,12 @@ router.add_api_route(
 )
 router.add_api_route("/{book_id}", get_book, methods=["GET"], summary="Get a book")
 router.add_api_route("/{book_id}", update_book, methods=["PATCH"], summary="Update book metadata")
+router.add_api_route(
+    "/{book_id}/reindex",
+    reindex_book,
+    methods=["POST"],
+    summary="Re-run OCR on a book (optional DPI override)",
+)
 router.add_api_route(
     "/{book_id}/file", serve_book_file, methods=["GET"], summary="Download book file"
 )

--- a/backend/routers/books/core.py
+++ b/backend/routers/books/core.py
@@ -4,16 +4,21 @@ import hashlib
 import os
 from typing import Optional
 
-from fastapi import Depends, HTTPException, Query
+from fastapi import BackgroundTasks, Depends, HTTPException, Query
 from fastapi.responses import FileResponse
+from sqlalchemy import text
 
 from ...auth import CurrentUser, get_current_user, require_gm_or_admin
 from ...config import _PAGE_CACHE_HEADERS, SessionLocal, THUMB_DIR
 from ...security import SAME_ORIGIN_FRAME_HEADERS
 
 from ...models import Book, GameSystem
-from ._helpers import _allow_explicit
+from ._helpers import _allow_explicit, _invalidate_book_cache
 from ._schemas import BookUpdate
+
+# OCR DPI bounds, mirroring backend.config._read_ocr_dpi clamping.
+_OCR_DPI_MIN = 72
+_OCR_DPI_MAX = 600
 
 
 def list_books(
@@ -89,6 +94,8 @@ def get_book(book_id: str, current_user: CurrentUser = Depends(get_current_user)
             "indexed": book.indexed,
             "index_failed": book.index_failed,
             "ocr_indexed": book.index_error == "ocr",
+            "ocr_pending": bool(book.ocr_pending),
+            "ocr_dpi": book.ocr_dpi,
             "is_missing": bool(book.is_missing),
             "mime_type": book.mime_type,
             "has_thumbnail": book.has_thumbnail,
@@ -113,6 +120,64 @@ def update_book(book_id: str, data: BookUpdate, _: CurrentUser = Depends(require
         return {"status": "ok"}
     finally:
         db.close()
+
+
+def reindex_book(
+    book_id: str,
+    background_tasks: BackgroundTasks,
+    ocr_dpi: Optional[int] = Query(
+        None,
+        ge=_OCR_DPI_MIN,
+        le=_OCR_DPI_MAX,
+        description="Optional OCR resolution override (DPI, 72–600) for this book. "
+        "Omit to use the global OCR_DPI default.",
+    ),
+    _: CurrentUser = Depends(require_gm_or_admin),
+):
+    """Re-run OCR on a single scanned book, optionally at a higher DPI.
+
+    Clears the book's existing search index and re-queues it for OCR from page 1.
+    A higher ``ocr_dpi`` re-reads a specific book more sharply than the library
+    default, without re-OCRing the whole library. Only applies to OCR-sourced
+    (image-only) PDFs; books with a real text layer have nothing to re-OCR.
+
+    The OCR itself runs in the background; poll ``GET /api/scan-status`` (phase
+    ``ocr``) for progress.
+    """
+    from ..library._helpers import trigger_ocr_queue
+
+    db = SessionLocal()
+    try:
+        book = db.query(Book).filter_by(id=book_id).first()
+        if not book:
+            raise HTTPException(404, "Book not found")
+        if book.mime_type != "application/pdf":
+            raise HTTPException(400, "Only PDF books can be OCR'd")
+        if not os.path.exists(book.filepath):
+            raise HTTPException(404, "File not found on disk")
+        # Re-OCR only makes sense for image-only books (no embedded text layer).
+        # A book indexed from its own text layer (index_error == "") would gain
+        # nothing and OCRing it would duplicate content.
+        if book.index_error not in ("ocr", "image-only"):
+            raise HTTPException(
+                400, "This book has an embedded text layer; OCR does not apply to it."
+            )
+
+        # Drop the old search rows so the re-OCR starts from a clean index.
+        db.execute(text("DELETE FROM book_search WHERE book_id = :bid"), {"bid": book.id})
+        book.ocr_dpi = ocr_dpi  # None => global default
+        book.ocr_pending = True
+        book.ocr_pages_done = 0
+        book.indexed = False
+        book.index_failed = False
+        book.index_error = ""
+        db.commit()
+        _invalidate_book_cache()
+    finally:
+        db.close()
+
+    background_tasks.add_task(trigger_ocr_queue)
+    return {"status": "reindex_queued", "ocr_dpi": ocr_dpi}
 
 
 def serve_book_file(book_id: str):

--- a/backend/routers/library/_helpers.py
+++ b/backend/routers/library/_helpers.py
@@ -2,9 +2,10 @@
 import json
 import time
 
+from ... import config
 from ...config import SessionLocal, LIBRARY_PATH, DATA_PATH, logger, _valkey
 from ...models import Book
-from ...indexer import scan_library, index_book_text
+from ...indexer import scan_library, index_book_text, ocr_book
 from ..books import _invalidate_book_cache
 
 _SCAN_KEY = "grimoire:scan_status"
@@ -28,6 +29,11 @@ _DEFAULT_STATUS: dict = {
     "updated_books": 0,
     "indexed": 0,
     "to_index": 0,
+    # Deferred-OCR queue progress (phase "ocr"). total_ocr = books queued,
+    # ocr_done = books finished, ocr_current = filename in flight.
+    "total_ocr": 0,
+    "ocr_done": 0,
+    "ocr_current": None,
 }
 
 # In-process fallback when Valkey is unavailable (single-worker or no cache)
@@ -130,6 +136,124 @@ def background_indexer():
         db.close()
         if _get_status()["phase"] == "indexing":
             _set_status({"running": False, "phase": None})
+    # Drain any books the fast phase queued for OCR (or left over from before).
+    if not is_stop_requested():
+        try:
+            run_ocr_queue()
+        finally:
+            if _get_status()["phase"] == "ocr":
+                _set_status({"running": False, "phase": None})
+
+
+def _ocr_one_book(book_id: str) -> str:
+    """Drain a single queued book on its own DB session (thread-pool unit).
+
+    Returns ocr_book's result ("done"/"stopped"/"error"). Each book gets a fresh
+    session so concurrent OCR workers don't share a Session across threads.
+    """
+    db = SessionLocal()
+    try:
+        book = db.get(Book, book_id)
+        if not book or not book.ocr_pending:
+            return "done"
+        _set_status({"ocr_current": book.filename})
+        return ocr_book(book, db, should_stop=is_stop_requested)
+    finally:
+        db.close()
+
+
+def run_ocr_queue() -> int:
+    """Drain the deferred-OCR queue (books with ocr_pending=1).
+
+    Runs after the fast scan/index phases. Processes books serially, or with up
+    to OCR_CONCURRENCY workers when configured, each checkpointing pages as it
+    goes so a restart resumes rather than restarts. Sets phase "ocr" and updates
+    ocr_done/total_ocr for the admin UI. Returns the number of books completed.
+
+    Resumable and idempotent: a stop or crash leaves ocr_pending set with a page
+    checkpoint, so the next scan (or startup recovery) continues where it left
+    off. Returns immediately when the queue is empty, or when OCR is disabled
+    (OCR_CONCURRENCY=0) so already-queued books stay pending untouched until a
+    user re-enables it.
+    """
+    concurrency = config.OCR_CONCURRENCY
+    if concurrency == 0:
+        logger.info("OCR queue: OCR disabled (OCR_CONCURRENCY=0), skipping.")
+        return 0
+
+    db = SessionLocal()
+    try:
+        pending_ids = [
+            b.id
+            for b in db.query(Book)
+            .filter_by(ocr_pending=True, mime_type="application/pdf")
+            .order_by(Book.ocr_pages_done.desc())  # finish nearly-done books first
+            .all()
+        ]
+    finally:
+        db.close()
+
+    if not pending_ids:
+        return 0
+
+    _set_status(
+        {"running": True, "phase": "ocr", "total_ocr": len(pending_ids), "ocr_done": 0}
+    )
+    logger.info(
+        f"OCR queue: {len(pending_ids)} book(s) to OCR "
+        f"(concurrency={concurrency})"
+    )
+    completed = 0
+    try:
+        if concurrency <= 1:
+            for book_id in pending_ids:
+                if is_stop_requested():
+                    logger.info("OCR queue: stop requested, halting.")
+                    break
+                if _ocr_one_book(book_id) == "done":
+                    completed += 1
+                _set_status({"ocr_done": _get_status()["ocr_done"] + 1})
+        else:
+            from concurrent.futures import ThreadPoolExecutor
+
+            with ThreadPoolExecutor(max_workers=concurrency) as pool:
+                for result in pool.map(_ocr_one_book, pending_ids):
+                    if result == "done":
+                        completed += 1
+                    _set_status({"ocr_done": _get_status()["ocr_done"] + 1})
+        logger.info(f"OCR queue: complete — {completed}/{len(pending_ids)} book(s) OCR'd")
+    finally:
+        _set_status({"ocr_current": None})
+    return completed
+
+
+def background_ocr():
+    """Startup recovery: resume any books left ocr_pending by a prior run."""
+    time.sleep(2)
+    if _get_status()["running"]:
+        return
+    try:
+        run_ocr_queue()
+    finally:
+        if _get_status()["phase"] == "ocr":
+            _set_status({"running": False, "phase": None})
+
+
+def trigger_ocr_queue():
+    """Drain the OCR queue now (on-demand, e.g. after a per-book re-OCR request).
+
+    Unlike background_ocr this has no startup delay. It no-ops if a scan/OCR run
+    is already in progress — the newly-queued book is picked up by that run (or
+    the next one), since the queue lives in the DB. Clears the running/phase flags
+    on completion when this call owns the OCR phase.
+    """
+    if _get_status()["running"]:
+        return
+    try:
+        run_ocr_queue()
+    finally:
+        if _get_status()["phase"] == "ocr":
+            _set_status({"running": False, "phase": None})
 
 
 def run_rescan_sync(scope_path: str | None = None, metadata_mode: str = "new") -> None:
@@ -226,5 +350,11 @@ def run_rescan_sync(scope_path: str | None = None, metadata_mode: str = "new") -
             logger.info(f"Index scan end: {indexed_count}/{len(to_index)} PDF(s) indexed")
         finally:
             db.close()
+
+        # --- Phase 3: deferred OCR of scanned/image-only PDFs ---
+        # Runs after the fast phases so text-layer books and other media are
+        # already searchable; scanned books grind here without blocking them.
+        if not is_stop_requested():
+            run_ocr_queue()
     finally:
         _set_status({"running": False, "phase": None})

--- a/backend/routers/systems/core.py
+++ b/backend/routers/systems/core.py
@@ -105,6 +105,7 @@ def get_system(system_id: str, current_user: CurrentUser = Depends(get_current_u
                     "index_failed": b.index_failed,
                     "index_error": b.index_error,
                     "ocr_indexed": b.index_error == "ocr",
+                    "ocr_dpi": b.ocr_dpi,
                     "has_thumbnail": b.has_thumbnail,
                     "tags": b.tags or [],
                     "is_explicit": bool(b.is_explicit),

--- a/backend/tests/test_books.py
+++ b/backend/tests/test_books.py
@@ -155,6 +155,158 @@ class TestUpdateBook:
         assert resp.status_code == 404
 
 
+class TestReindexBook:
+    """POST /api/books/{id}/reindex — per-book re-OCR with optional DPI override."""
+
+    def _make_ocr_book(self, system_id, index_error="ocr"):
+        """A real on-disk PDF book flagged as OCR-sourced, with a search row."""
+        with tempfile.NamedTemporaryFile(suffix=".pdf", delete=False) as f:
+            f.write(b"%PDF-1.4\n%stub\n")
+            fpath = f.name
+        book = make_book(
+            system_id=system_id,
+            title="Scanned Book",
+            filename="scanned.pdf",
+            filepath=fpath,
+            mime_type="application/pdf",
+            page_count=3,
+            indexed=True,
+            index_error=index_error,
+        )
+        # Seed a search row so we can assert it gets cleared.
+        from backend.config import SessionLocal
+        from sqlalchemy import text as _text
+
+        db = SessionLocal()
+        try:
+            db.execute(
+                _text(
+                    "INSERT INTO book_search (book_id, page_number, content) "
+                    "VALUES (:b, 1, 'old text')"
+                ),
+                {"b": book.id},
+            )
+            db.commit()
+        finally:
+            db.close()
+        return book, fpath
+
+    @pytest.fixture(scope="module")
+    def sys(self):
+        return make_game_system()
+
+    def _search_count(self, book_id):
+        from backend.config import SessionLocal
+        from sqlalchemy import text as _text
+
+        db = SessionLocal()
+        try:
+            return db.execute(
+                _text("SELECT COUNT(*) FROM book_search WHERE book_id = :b"),
+                {"b": book_id},
+            ).scalar()
+        finally:
+            db.close()
+
+    def _book_row(self, book_id):
+        from backend.config import SessionLocal
+        from backend.models import Book
+
+        db = SessionLocal()
+        try:
+            b = db.get(Book, book_id)
+            return {
+                "ocr_pending": b.ocr_pending,
+                "ocr_pages_done": b.ocr_pages_done,
+                "ocr_dpi": b.ocr_dpi,
+                "indexed": b.indexed,
+                "index_error": b.index_error,
+            }
+        finally:
+            db.close()
+
+    def test_requeues_and_clears_index(self, client, admin_headers, sys):
+        from unittest.mock import patch as _patch
+
+        book, fpath = self._make_ocr_book(sys.id)
+        try:
+            with _patch(
+                "backend.routers.library._helpers.trigger_ocr_queue"
+            ) as m:
+                resp = client.post(f"/api/books/{book.id}/reindex", headers=admin_headers)
+            assert resp.status_code == 200
+            assert resp.json() == {"status": "reindex_queued", "ocr_dpi": None}
+            assert m.called  # background drain was scheduled
+            assert self._search_count(book.id) == 0  # old index cleared
+            row = self._book_row(book.id)
+            assert row["ocr_pending"] is True
+            assert row["ocr_pages_done"] == 0
+            assert row["ocr_dpi"] is None
+            assert row["indexed"] is False
+            assert row["index_error"] == ""
+        finally:
+            os.unlink(fpath)
+
+    def test_dpi_override_stored(self, client, admin_headers, sys):
+        from unittest.mock import patch as _patch
+
+        book, fpath = self._make_ocr_book(sys.id)
+        try:
+            with _patch("backend.routers.library._helpers.trigger_ocr_queue"):
+                resp = client.post(
+                    f"/api/books/{book.id}/reindex?ocr_dpi=300", headers=admin_headers
+                )
+            assert resp.status_code == 200
+            assert resp.json()["ocr_dpi"] == 300
+            assert self._book_row(book.id)["ocr_dpi"] == 300
+        finally:
+            os.unlink(fpath)
+
+    def test_dpi_out_of_range_rejected(self, client, admin_headers, sys):
+        from unittest.mock import patch as _patch
+
+        book, fpath = self._make_ocr_book(sys.id)
+        try:
+            with _patch("backend.routers.library._helpers.trigger_ocr_queue"):
+                too_high = client.post(
+                    f"/api/books/{book.id}/reindex?ocr_dpi=9000", headers=admin_headers
+                )
+                too_low = client.post(
+                    f"/api/books/{book.id}/reindex?ocr_dpi=10", headers=admin_headers
+                )
+            assert too_high.status_code == 422
+            assert too_low.status_code == 422
+        finally:
+            os.unlink(fpath)
+
+    def test_text_layer_book_rejected(self, client, admin_headers, sys):
+        # A natively-indexed book (index_error == "") has no OCR to redo.
+        book, fpath = self._make_ocr_book(sys.id, index_error="")
+        try:
+            resp = client.post(f"/api/books/{book.id}/reindex", headers=admin_headers)
+            assert resp.status_code == 400
+        finally:
+            os.unlink(fpath)
+
+    def test_player_cannot_reindex(self, client, player_headers, sys):
+        book, fpath = self._make_ocr_book(sys.id)
+        try:
+            resp = client.post(f"/api/books/{book.id}/reindex", headers=player_headers)
+            assert resp.status_code == 403
+        finally:
+            os.unlink(fpath)
+
+    def test_nonexistent_book(self, client, admin_headers):
+        resp = client.post("/api/books/ghost/reindex", headers=admin_headers)
+        assert resp.status_code == 404
+
+    def test_missing_file_rejected(self, client, admin_headers, sys):
+        book, fpath = self._make_ocr_book(sys.id)
+        os.unlink(fpath)  # remove the file before the call
+        resp = client.post(f"/api/books/{book.id}/reindex", headers=admin_headers)
+        assert resp.status_code == 404
+
+
 class TestImageBookPage:
     IMAGE_TYPES = [
         ("png", "image/png", b"\x89PNG\r\n\x1a\n" + b"\x00" * 8),

--- a/backend/tests/test_db_migrations.py
+++ b/backend/tests/test_db_migrations.py
@@ -359,3 +359,71 @@ class TestAlembicCutover:
             if t != "alembic_version"
         }
         assert remaining == set()
+
+
+class TestOcrQueueMigration:
+    """Revision a1f4c2e9b7d0 (ocr_pending/ocr_pages_done) must be recoverable.
+
+    An earlier version of this migration used batch_alter_table, which rebuilds
+    the books table through a temporary _alembic_tmp_books table. When a deploy
+    was interrupted mid-rebuild, that temp table was left behind and every
+    restart crashed with "table _alembic_tmp_books already exists" (the
+    migration never committed, so it re-ran forever). These tests pin the
+    recovery behaviour.
+    """
+
+    def _stuck_at_down_revision(self, path):
+        """Build a real DB, then roll it back to the state just before the OCR
+        migration: at the down_revision, without the OCR columns."""
+        init_db(path)
+        engine = create_engine(f"sqlite:///{path}")
+        with engine.begin() as conn:
+            conn.execute(
+                text("UPDATE alembic_version SET version_num='96c733b7c205'")
+            )
+            conn.execute(text("DROP INDEX IF EXISTS ix_books_ocr_pending"))
+            conn.execute(text("ALTER TABLE books DROP COLUMN ocr_pages_done"))
+            conn.execute(text("ALTER TABLE books DROP COLUMN ocr_pending"))
+        engine.dispose()
+
+    def test_recovers_from_leftover_temp_table(self):
+        """A stale _alembic_tmp_books (from an interrupted batch run) must not
+        block the migration; the columns and index still land at head."""
+        path = os.path.join(tempfile.mkdtemp(), "stuck.db")
+        self._stuck_at_down_revision(path)
+
+        engine = create_engine(f"sqlite:///{path}")
+        with engine.begin() as conn:
+            conn.execute(text("CREATE TABLE _alembic_tmp_books (id VARCHAR(36))"))
+        engine.dispose()
+
+        # This previously crashed with "table _alembic_tmp_books already exists".
+        init_db(path)
+
+        engine = create_engine(f"sqlite:///{path}")
+        insp = inspect(engine)
+        cols = {c["name"] for c in insp.get_columns("books")}
+        idx = {i["name"] for i in insp.get_indexes("books")}
+        tables = set(insp.get_table_names())
+        assert {"ocr_pending", "ocr_pages_done"} <= cols
+        assert "ix_books_ocr_pending" in idx
+        assert "_alembic_tmp_books" not in tables
+        assert _stamped_revision(path) == _alembic_head(path)
+
+    def test_upgrade_is_reentrant_after_partial_apply(self):
+        """If the columns already exist but the version wasn't stamped (a partial
+        apply), re-running must not raise on duplicate columns/index."""
+        path = os.path.join(tempfile.mkdtemp(), "partial.db")
+        init_db(path)  # fully applies, columns present
+        engine = create_engine(f"sqlite:///{path}")
+        with engine.begin() as conn:
+            # Simulate the version not having been committed while the columns
+            # from a prior run are already there.
+            conn.execute(
+                text("UPDATE alembic_version SET version_num='96c733b7c205'")
+            )
+        engine.dispose()
+
+        init_db(path)  # must be a clean no-op, not "duplicate column" error
+
+        assert _stamped_revision(path) == _alembic_head(path)

--- a/backend/tests/test_indexer_resilience.py
+++ b/backend/tests/test_indexer_resilience.py
@@ -24,12 +24,12 @@ from backend.models import Book, GenericMap, Token
 
 # Top-level (picklable) worker stand-ins for the spawned extraction process.
 # Defined at module scope so the "spawn" start method can import them by name.
-def _worker_crash(filepath: str, result_path: str) -> None:
+def _worker_crash(filepath: str, result_path: str, text_only: bool = False) -> None:
     """Simulate a native crash / OOM-kill: die without writing a result."""
     os._exit(1)
 
 
-def _worker_ok(filepath: str, result_path: str) -> None:
+def _worker_ok(filepath: str, result_path: str, text_only: bool = False) -> None:
     """Simulate a clean extraction: write a small result payload."""
     import pickle
 
@@ -142,8 +142,8 @@ class TestIndexBookTextIndexFailed:
 
         assert result is False
 
-    def test_image_only_pdf_marked_indexed(self):
-        """When extract_text_from_pdf returns empty, image-only PDF is marked indexed=True with index_error='image-only'."""
+    def test_image_only_pdf_marked_indexed_without_ocr(self):
+        """With OCR unavailable, an empty extraction marks the book image-only/indexed."""
         uid = str(uuid.uuid4())[:8]
         db = SessionLocal()
         try:
@@ -160,7 +160,8 @@ class TestIndexBookTextIndexFailed:
             db.commit()
             db.refresh(book)
 
-            with patch("backend.indexer.extract_text_isolated", return_value=([], False)):
+            with patch("backend.indexer.extract_text_isolated", return_value=([], False)), \
+                 patch("backend.indexer.ocr.ocr_available", return_value=False):
                 result = index_book_text(book, "/tmp", db)
 
             db.refresh(book)
@@ -168,6 +169,40 @@ class TestIndexBookTextIndexFailed:
             assert book.indexed is True
             assert book.index_failed is False
             assert book.index_error == "image-only"
+            assert book.ocr_pending is False
+        finally:
+            db.close()
+
+    def test_image_only_pdf_queued_for_ocr_when_available(self):
+        """With OCR available, an empty extraction defers the book to the OCR queue."""
+        uid = str(uuid.uuid4())[:8]
+        db = SessionLocal()
+        try:
+            book = Book(
+                title=f"TestBook-{uid}",
+                filename=f"book-{uid}.pdf",
+                filepath=f"/tmp/nonexistent-{uid}.pdf",
+                relative_path=f"book-{uid}.pdf",
+                mime_type="application/pdf",
+                indexed=False,
+                index_failed=False,
+            )
+            db.add(book)
+            db.commit()
+            db.refresh(book)
+
+            with patch("backend.indexer.extract_text_isolated", return_value=([], False)), \
+                 patch("backend.indexer.ocr.ocr_available", return_value=True):
+                result = index_book_text(book, "/tmp", db)
+
+            db.refresh(book)
+            # Not indexed yet — the deferred OCR worker will finish it.
+            assert result is False
+            assert book.indexed is False
+            assert book.index_failed is False
+            assert book.ocr_pending is True
+            assert book.ocr_pages_done == 0
+            assert book.index_error == ""
         finally:
             db.close()
 

--- a/backend/tests/test_library_helpers.py
+++ b/backend/tests/test_library_helpers.py
@@ -21,6 +21,84 @@ class TestScanStatusState:
         for key in ("total_audio", "scanned_audio", "new_audio"):
             assert key in _helpers._DEFAULT_STATUS
 
+    def test_default_status_includes_ocr_fields(self):
+        for key in ("total_ocr", "ocr_done", "ocr_current"):
+            assert key in _helpers._DEFAULT_STATUS
+
+
+class TestOcrConcurrency:
+    def test_pool_used_when_concurrency_gt_1(self):
+        """OCR_CONCURRENCY>1 drains the queue via a ThreadPoolExecutor."""
+        import uuid as _uuid
+
+        from backend import config
+        from backend.config import SessionLocal
+        from backend.models import Book
+
+        _helpers.clear_stop()
+        _helpers._set_status({**_helpers._DEFAULT_STATUS})
+        # Clear any pending books left by other tests so we count only ours.
+        db = SessionLocal()
+        db.query(Book).filter_by(ocr_pending=True).update({"ocr_pending": False})
+        db.commit()
+        db.close()
+
+        ids = []
+        for _ in range(2):
+            uid = str(_uuid.uuid4())[:8]
+            db = SessionLocal()
+            b = Book(
+                title=f"S-{uid}", filename=f"s-{uid}.pdf", filepath=f"/tmp/s-{uid}.pdf",
+                relative_path=f"s-{uid}.pdf", mime_type="application/pdf",
+                ocr_pending=True,
+            )
+            db.add(b)
+            db.commit()
+            ids.append(b.id)
+            db.close()
+
+        with patch.object(config, "OCR_CONCURRENCY", 2), \
+             patch.object(_helpers, "_ocr_one_book", return_value="done") as m:
+            completed = _helpers.run_ocr_queue()
+
+        assert completed == 2
+        assert m.call_count == 2
+        assert set(m.call_args_list[i].args[0] for i in range(2)) == set(ids)
+
+    def test_concurrency_zero_disables_and_leaves_queue_pending(self):
+        """OCR_CONCURRENCY=0 skips the drain and leaves queued books untouched."""
+        import uuid as _uuid
+
+        from backend import config
+        from backend.config import SessionLocal
+        from backend.models import Book
+
+        _helpers.clear_stop()
+        _helpers._set_status({**_helpers._DEFAULT_STATUS})
+        db = SessionLocal()
+        uid = str(_uuid.uuid4())[:8]
+        b = Book(
+            title=f"Z-{uid}", filename=f"z-{uid}.pdf", filepath=f"/tmp/z-{uid}.pdf",
+            relative_path=f"z-{uid}.pdf", mime_type="application/pdf",
+            ocr_pending=True,
+        )
+        db.add(b)
+        db.commit()
+        bid = b.id
+        db.close()
+
+        with patch.object(config, "OCR_CONCURRENCY", 0), \
+             patch.object(_helpers, "_ocr_one_book") as m:
+            completed = _helpers.run_ocr_queue()
+
+        assert completed == 0
+        m.assert_not_called()
+        db = SessionLocal()
+        try:
+            assert db.get(Book, bid).ocr_pending is True  # left queued, not lost
+        finally:
+            db.close()
+
 
 class TestStopSignal:
     def test_request_and_clear_stop(self):

--- a/backend/tests/test_ocr.py
+++ b/backend/tests/test_ocr.py
@@ -46,7 +46,8 @@ class TestAvailability:
     def test_available_when_pytesseract_present(self):
         ocr.reset_availability_cache()
         with patch.dict(sys.modules, {"pytesseract": _fake_pytesseract()}):
-            with patch.object(config, "OCR_ENABLED", True):
+            with patch.object(config, "OCR_ENABLED", True), \
+                 patch.object(config, "OCR_CONCURRENCY", 1):
                 assert ocr.ocr_available() is True
 
     def test_disabled_by_config_even_when_present(self):
@@ -54,6 +55,14 @@ class TestAvailability:
         ocr.reset_availability_cache()
         with patch.dict(sys.modules, {"pytesseract": _fake_pytesseract()}):
             with patch.object(config, "OCR_ENABLED", False):
+                assert ocr.ocr_available() is False
+
+    def test_disabled_when_concurrency_zero(self):
+        """OCR_CONCURRENCY=0 is a runtime off switch, same as OCR_ENABLED=false."""
+        ocr.reset_availability_cache()
+        with patch.dict(sys.modules, {"pytesseract": _fake_pytesseract()}):
+            with patch.object(config, "OCR_ENABLED", True), \
+                 patch.object(config, "OCR_CONCURRENCY", 0):
                 assert ocr.ocr_available() is False
 
 
@@ -217,6 +226,9 @@ class TestRequeue:
             refreshed = db.query(Book).filter_by(id=book_id).first()
             assert refreshed.indexed is False
             assert refreshed.index_error == ""
+            # Now moved into the deferred-OCR queue rather than re-indexed inline.
+            assert refreshed.ocr_pending is True
+            assert refreshed.ocr_pages_done == 0
         finally:
             db.close()
 
@@ -247,3 +259,51 @@ class TestRequeue:
             assert refreshed.index_error == "image-only"
         finally:
             db.close()
+
+
+class TestEffectiveLanguages:
+    def test_mirrors_config(self):
+        with patch.object(config, "OCR_LANGUAGES", "eng+deu"):
+            assert ocr.effective_languages() == "eng+deu"
+
+
+class TestOcrConcurrencyConfig:
+    def test_defaults_to_one(self, monkeypatch):
+        monkeypatch.delenv("OCR_CONCURRENCY", raising=False)
+        assert config._read_ocr_concurrency() == 1
+
+    def test_reads_env(self, monkeypatch):
+        monkeypatch.setenv("OCR_CONCURRENCY", "4")
+        assert config._read_ocr_concurrency() == 4
+
+    def test_invalid_falls_back_to_one(self, monkeypatch):
+        monkeypatch.setenv("OCR_CONCURRENCY", "not-a-number")
+        assert config._read_ocr_concurrency() == 1
+
+    def test_zero_means_disabled(self, monkeypatch):
+        monkeypatch.setenv("OCR_CONCURRENCY", "0")
+        assert config._read_ocr_concurrency() == 0
+
+    def test_negative_clamps_to_zero(self, monkeypatch):
+        monkeypatch.setenv("OCR_CONCURRENCY", "-5")
+        assert config._read_ocr_concurrency() == 0
+
+
+class TestOcrDpiConfig:
+    def test_defaults_to_150(self, monkeypatch):
+        monkeypatch.delenv("OCR_DPI", raising=False)
+        assert config._read_ocr_dpi() == 150.0
+
+    def test_reads_env(self, monkeypatch):
+        monkeypatch.setenv("OCR_DPI", "300")
+        assert config._read_ocr_dpi() == 300.0
+
+    def test_clamps_range(self, monkeypatch):
+        monkeypatch.setenv("OCR_DPI", "5000")
+        assert config._read_ocr_dpi() == 600.0
+        monkeypatch.setenv("OCR_DPI", "10")
+        assert config._read_ocr_dpi() == 72.0
+
+    def test_invalid_falls_back(self, monkeypatch):
+        monkeypatch.setenv("OCR_DPI", "nope")
+        assert config._read_ocr_dpi() == 150.0

--- a/backend/tests/test_ocr_queue.py
+++ b/backend/tests/test_ocr_queue.py
@@ -1,0 +1,324 @@
+"""Tests for the deferred-OCR queue: page-checkpointed OCR of scanned PDFs.
+
+Scanned (image-only) PDFs are no longer OCR'd inline during the scan; they are
+queued (``ocr_pending``) and drained by a background worker that OCRs one page
+at a time and checkpoints ``ocr_pages_done`` so a long book resumes rather than
+restarts. These tests exercise the indexer's ``ocr_book`` / ``ocr_page_isolated``
+and the helper's ``run_ocr_queue`` drain loop, stubbing the actual per-page OCR
+subprocess so no tesseract binary is required.
+"""
+import uuid
+from unittest.mock import patch
+
+from sqlalchemy import text
+
+from backend import indexer
+from backend.config import SessionLocal
+from backend.models import Book
+from backend.routers.library import _helpers
+
+
+def _clear_pending() -> None:
+    """Reset any lingering ocr_pending books so a drain test sees only its own.
+
+    The test DB is a shared session-scoped file with no per-test teardown, so
+    ocr_pending rows from other tests would otherwise be swept into run_ocr_queue.
+    """
+    db = SessionLocal()
+    try:
+        db.query(Book).filter_by(ocr_pending=True).update({"ocr_pending": False})
+        db.commit()
+    finally:
+        db.close()
+
+
+def _queued_book(pages_done: int = 0, page_count: int = 3) -> str:
+    """Create an ocr_pending book and return its id. page_count is faked below."""
+    uid = str(uuid.uuid4())[:8]
+    db = SessionLocal()
+    book = Book(
+        title=f"Scan-{uid}",
+        filename=f"scan-{uid}.pdf",
+        filepath=f"/tmp/scan-{uid}.pdf",
+        relative_path=f"scan-{uid}.pdf",
+        mime_type="application/pdf",
+        indexed=False,
+        index_failed=False,
+        ocr_pending=True,
+        ocr_pages_done=pages_done,
+    )
+    db.add(book)
+    db.commit()
+    bid = book.id
+    db.close()
+    return bid
+
+
+def _search_pages(book_id: str) -> list[int]:
+    db = SessionLocal()
+    try:
+        rows = db.execute(
+            text("SELECT page_number FROM book_search WHERE book_id = :b ORDER BY page_number"),
+            {"b": book_id},
+        ).fetchall()
+        return [r[0] for r in rows]
+    finally:
+        db.close()
+
+
+class TestOcrBook:
+    def test_ocrs_all_pages_and_marks_indexed(self):
+        bid = _queued_book(page_count=3)
+        db = SessionLocal()
+        try:
+            book = db.get(Book, bid)
+            with patch.object(indexer, "_book_page_count", return_value=3), \
+                 patch.object(
+                     indexer, "ocr_book_page_isolated_wrapper",
+                     side_effect=lambda fp, i, should_stop=None, dpi=None: f"text-{i + 1}",
+                 ):
+                result = indexer.ocr_book(book, db)
+            assert result == "done"
+            db.refresh(book)
+            assert book.indexed is True
+            assert book.ocr_pending is False
+            assert book.index_error == "ocr"
+            assert book.ocr_pages_done == 3
+        finally:
+            db.close()
+        assert _search_pages(bid) == [1, 2, 3]
+
+    def test_resumes_from_checkpoint(self):
+        """A book with ocr_pages_done=2 only OCRs the remaining pages."""
+        bid = _queued_book(pages_done=2, page_count=3)
+        seen = []
+        db = SessionLocal()
+        try:
+            book = db.get(Book, bid)
+
+            def _ocr(fp, i, should_stop=None, dpi=None):
+                seen.append(i)
+                return f"text-{i + 1}"
+
+            with patch.object(indexer, "_book_page_count", return_value=3), \
+                 patch.object(indexer, "ocr_book_page_isolated_wrapper", side_effect=_ocr):
+                result = indexer.ocr_book(book, db)
+            assert result == "done"
+        finally:
+            db.close()
+        # Only page index 2 (page 3) was OCR'd; pages 1-2 were already done.
+        assert seen == [2]
+        assert _search_pages(bid) == [3]
+
+    def test_empty_page_still_advances_checkpoint(self):
+        """A page that OCRs to nothing is skipped in the index but still checkpointed."""
+        bid = _queued_book(page_count=2)
+        db = SessionLocal()
+        try:
+            book = db.get(Book, bid)
+            with patch.object(indexer, "_book_page_count", return_value=2), \
+                 patch.object(
+                     indexer, "ocr_book_page_isolated_wrapper",
+                     side_effect=lambda fp, i, should_stop=None, dpi=None: "" if i == 0 else "text",
+                 ):
+                indexer.ocr_book(book, db)
+            db.refresh(book)
+            assert book.ocr_pages_done == 2
+        finally:
+            db.close()
+        assert _search_pages(bid) == [2]  # only the non-empty page indexed
+
+    def test_stop_is_resumable(self):
+        """A stop mid-book leaves ocr_pending set and the checkpoint advanced."""
+        bid = _queued_book(page_count=5)
+        db = SessionLocal()
+        try:
+            book = db.get(Book, bid)
+
+            # Stop once page index 2 (the 3rd page) is reached, so pages 1-2 are
+            # committed and the book resumes at page 3 later. Keyed on the book's
+            # checkpoint rather than a call counter so it's robust to how many
+            # times ocr_book polls should_stop per iteration.
+            def _stop():
+                return book.ocr_pages_done >= 2
+
+            with patch.object(indexer, "_book_page_count", return_value=5), \
+                 patch.object(
+                     indexer, "ocr_book_page_isolated_wrapper",
+                     side_effect=lambda fp, i, should_stop=None, dpi=None: f"t{i}",
+                 ):
+                result = indexer.ocr_book(book, db, should_stop=_stop)
+            assert result == "stopped"
+            db.refresh(book)
+            assert book.ocr_pending is True
+            assert book.indexed is False
+            assert book.ocr_pages_done == 2  # two pages committed before stop
+        finally:
+            db.close()
+
+    def test_cancelled_page_not_skipped_on_resume(self):
+        """A page cancelled mid-flight (empty return + stop) isn't marked done."""
+        bid = _queued_book(page_count=3)
+        db = SessionLocal()
+        try:
+            book = db.get(Book, bid)
+
+            # should_stop is False at the top of the loop (so page 1 is attempted)
+            # but flips True during the OCR call, so it's True on the after-page
+            # check. The empty return is a cancellation, not a blank page: the
+            # checkpoint must NOT advance.
+            state = {"stopping": False}
+
+            def _ocr(fp, i, should_stop=None, dpi=None):
+                state["stopping"] = True  # cancel arrives while OCRing page 1
+                return ""
+
+            with patch.object(indexer, "_book_page_count", return_value=3), \
+                 patch.object(indexer, "ocr_book_page_isolated_wrapper", side_effect=_ocr):
+                result = indexer.ocr_book(book, db, should_stop=lambda: state["stopping"])
+            assert result == "stopped"
+            db.refresh(book)
+            assert book.ocr_pages_done == 0  # page 1 not burned
+            assert book.ocr_pending is True
+        finally:
+            db.close()
+
+    def test_unreadable_book_marked_failed(self):
+        bid = _queued_book()
+        db = SessionLocal()
+        try:
+            book = db.get(Book, bid)
+            with patch.object(indexer, "_book_page_count", side_effect=RuntimeError("bad")):
+                result = indexer.ocr_book(book, db)
+            assert result == "error"
+            db.refresh(book)
+            assert book.ocr_pending is False
+            assert book.index_failed is True
+            assert "ocr open failed" in book.index_error
+        finally:
+            db.close()
+
+    def test_per_book_dpi_is_threaded_to_worker(self):
+        """ocr_book passes book.ocr_dpi through to each per-page OCR call."""
+        bid = _queued_book(page_count=2)
+        db = SessionLocal()
+        try:
+            book = db.get(Book, bid)
+            book.ocr_dpi = 400
+            db.commit()
+            seen_dpi = []
+
+            def _ocr(fp, i, should_stop=None, dpi=None):
+                seen_dpi.append(dpi)
+                return "t"
+
+            with patch.object(indexer, "_book_page_count", return_value=2), \
+                 patch.object(indexer, "ocr_book_page_isolated_wrapper", side_effect=_ocr):
+                indexer.ocr_book(book, db)
+            assert seen_dpi == [400, 400]
+        finally:
+            db.close()
+
+    def test_default_dpi_is_none(self):
+        """A book with no override passes dpi=None (global default used downstream)."""
+        bid = _queued_book(page_count=1)
+        db = SessionLocal()
+        try:
+            book = db.get(Book, bid)
+            seen = []
+            with patch.object(indexer, "_book_page_count", return_value=1), \
+                 patch.object(
+                     indexer, "ocr_book_page_isolated_wrapper",
+                     side_effect=lambda fp, i, should_stop=None, dpi=None: seen.append(dpi) or "t",
+                 ):
+                indexer.ocr_book(book, db)
+            assert seen == [None]
+        finally:
+            db.close()
+
+
+class TestOcrPageIsolated:
+    def test_returns_worker_text(self):
+        with patch.object(indexer._MP_CONTEXT, "Process") as MockProc, \
+             patch("backend.indexer.pickle.load", return_value="hello"), \
+             patch("backend.indexer.os.path.getsize", return_value=10), \
+             patch("builtins.open"):
+            proc = MockProc.return_value
+            proc.is_alive.return_value = False
+            proc.exitcode = 0
+            out = indexer.ocr_page_isolated("/tmp/x.pdf", 0)
+        assert out == "hello"
+
+    def test_crash_returns_empty(self):
+        with patch.object(indexer._MP_CONTEXT, "Process") as MockProc, \
+             patch("backend.indexer.os.path.getsize", return_value=0):
+            proc = MockProc.return_value
+            proc.is_alive.return_value = False
+            proc.exitcode = 1
+            out = indexer.ocr_page_isolated("/tmp/x.pdf", 0)
+        assert out == ""
+
+    def test_stop_terminates_and_returns_empty(self):
+        with patch.object(indexer._MP_CONTEXT, "Process") as MockProc:
+            proc = MockProc.return_value
+            proc.is_alive.return_value = True  # never exits on its own
+            out = indexer.ocr_page_isolated("/tmp/x.pdf", 0, should_stop=lambda: True)
+        assert out == ""
+        proc.terminate.assert_called()
+
+    def test_dpi_passed_to_worker_process(self):
+        """The dpi arg is forwarded as the last Process arg to ocr_page_main."""
+        with patch.object(indexer._MP_CONTEXT, "Process") as MockProc, \
+             patch("backend.indexer.pickle.load", return_value="x"), \
+             patch("backend.indexer.os.path.getsize", return_value=10), \
+             patch("builtins.open"):
+            proc = MockProc.return_value
+            proc.is_alive.return_value = False
+            proc.exitcode = 0
+            indexer.ocr_page_isolated("/tmp/x.pdf", 2, dpi=350)
+        # args = (filepath, page_index, languages, result_path, dpi)
+        args = MockProc.call_args.kwargs["args"]
+        assert args[1] == 2  # page_index
+        assert args[-1] == 350  # dpi
+
+
+class TestRunOcrQueue:
+    def test_drains_pending_books(self):
+        _helpers.clear_stop()
+        _helpers._set_status({**_helpers._DEFAULT_STATUS})
+        _clear_pending()
+        bid = _queued_book(page_count=2)
+
+        with patch.object(indexer, "_book_page_count", return_value=2), \
+             patch.object(
+                 indexer, "ocr_book_page_isolated_wrapper",
+                 side_effect=lambda fp, i, should_stop=None, dpi=None: "t",
+             ):
+            completed = _helpers.run_ocr_queue()
+
+        assert completed == 1
+        db = SessionLocal()
+        try:
+            book = db.get(Book, bid)
+            assert book.indexed is True
+            assert book.ocr_pending is False
+        finally:
+            db.close()
+
+    def test_empty_queue_is_noop(self):
+        _helpers.clear_stop()
+        _clear_pending()
+        assert _helpers.run_ocr_queue() == 0
+
+    def test_stop_halts_before_processing(self):
+        _helpers._set_status({**_helpers._DEFAULT_STATUS})
+        _clear_pending()
+        _queued_book(page_count=2)
+        _helpers.request_stop()
+        try:
+            with patch.object(indexer, "ocr_book_page_isolated_wrapper") as m:
+                completed = _helpers.run_ocr_queue()
+            assert completed == 0
+            m.assert_not_called()
+        finally:
+            _helpers.clear_stop()

--- a/backend/tests/test_pdf_worker.py
+++ b/backend/tests/test_pdf_worker.py
@@ -136,6 +136,159 @@ def test_main_writes_pickled_result(tmp_path):
     assert used_ocr is False
 
 
+def test_run_text_only_skips_ocr(tmp_path):
+    """text_only=True never OCRs: an image-only page yields no pages."""
+    pdf = tmp_path / "scan.pdf"
+    _make_image_only_pdf(pdf)
+
+    called = {"ocr": False}
+
+    def _spy(*a, **k):
+        called["ocr"] = True
+        return "should not run"
+
+    with patch.object(pdf_worker, "_ocr_settings", return_value=(True, "eng")):
+        with patch.object(pdf_worker, "_ocr_page", side_effect=_spy):
+            pages, used_ocr = pdf_worker.run(str(pdf), text_only=True)
+
+    assert pages == []
+    assert used_ocr is False
+    assert called["ocr"] is False
+
+
+def test_run_text_only_keeps_text_layer(tmp_path):
+    """text_only still reads embedded text; it only skips OCR of image pages."""
+    pdf = tmp_path / "mixed.pdf"
+    _make_text_pdf(pdf, ["Real text here"])
+
+    pages, used_ocr = pdf_worker.run(str(pdf), text_only=True)
+    assert pages == [{"page": 1, "content": "Real text here"}]
+    assert used_ocr is False
+
+
+def test_ocr_page_single(tmp_path):
+    """ocr_page OCRs one image-only page and returns its text."""
+    pdf = tmp_path / "scan.pdf"
+    _make_image_only_pdf(pdf)
+
+    with patch.object(pdf_worker, "_ocr_page", return_value="page text"):
+        out = pdf_worker.ocr_page(str(pdf), 0, "eng")
+    assert out == "page text"
+
+
+def test_ocr_page_skips_text_layer_pages(tmp_path):
+    """ocr_page returns "" for a page that already has a text layer (no dup)."""
+    pdf = tmp_path / "text.pdf"
+    _make_text_pdf(pdf, ["Already has text"])
+
+    with patch.object(pdf_worker, "_ocr_page", return_value="unexpected") as m:
+        out = pdf_worker.ocr_page(str(pdf), 0, "eng")
+    assert out == ""
+    assert not m.called
+
+
+def test_ocr_scale_default(monkeypatch):
+    monkeypatch.delenv("OCR_DPI", raising=False)
+    assert pdf_worker._ocr_scale() == 150.0 / 72.0
+
+
+def test_ocr_scale_reads_env(monkeypatch):
+    monkeypatch.setenv("OCR_DPI", "300")
+    assert pdf_worker._ocr_scale() == 300.0 / 72.0
+
+
+def test_ocr_scale_clamps_and_handles_bad_value(monkeypatch):
+    monkeypatch.setenv("OCR_DPI", "5000")
+    assert pdf_worker._ocr_scale() == 600.0 / 72.0  # clamped high
+    monkeypatch.setenv("OCR_DPI", "10")
+    assert pdf_worker._ocr_scale() == 72.0 / 72.0  # clamped low
+    monkeypatch.setenv("OCR_DPI", "bogus")
+    assert pdf_worker._ocr_scale() == 150.0 / 72.0  # fallback
+
+
+def test_ocr_page_uses_configured_dpi(tmp_path, monkeypatch):
+    """_ocr_page renders at the OCR_DPI-derived scale."""
+    pdf = tmp_path / "scan.pdf"
+    _make_image_only_pdf(pdf)
+    doc = fitz.open(str(pdf))
+    page = doc[0]
+
+    monkeypatch.setenv("OCR_DPI", "72")  # scale 1.0 → smaller pixmap
+    fake_tess = MagicMock()
+    fake_tess.image_to_string.return_value = "x"
+    captured = {}
+    real_get_pixmap = page.get_pixmap
+
+    def spy(*a, **k):
+        captured["matrix"] = k.get("matrix")
+        return real_get_pixmap(*a, **k)
+
+    page.get_pixmap = spy
+    with patch.dict(sys.modules, {"pytesseract": fake_tess}):
+        pdf_worker._ocr_page(page, "eng")
+    doc.close()
+    # 72 DPI → scale 1.0 identity matrix
+    assert captured["matrix"] == fitz.Matrix(1.0, 1.0)
+
+
+def test_ocr_scale_explicit_dpi_overrides_env(monkeypatch):
+    monkeypatch.setenv("OCR_DPI", "150")
+    # Explicit per-book DPI wins over the env default.
+    assert pdf_worker._ocr_scale(300) == 300.0 / 72.0
+    # None falls back to the env value.
+    assert pdf_worker._ocr_scale(None) == 150.0 / 72.0
+
+
+def test_ocr_scale_explicit_dpi_clamped(monkeypatch):
+    assert pdf_worker._ocr_scale(9000) == 600.0 / 72.0
+    assert pdf_worker._ocr_scale(1) == 72.0 / 72.0
+
+
+def test_ocr_page_threads_explicit_dpi(tmp_path):
+    """_ocr_page renders at the scale derived from an explicit DPI override."""
+    pdf = tmp_path / "scan.pdf"
+    _make_image_only_pdf(pdf)
+    doc = fitz.open(str(pdf))
+    page = doc[0]
+    real_get_pixmap = page.get_pixmap
+    captured = {}
+
+    def spy(*a, **k):
+        captured["matrix"] = k.get("matrix")
+        return real_get_pixmap(*a, **k)
+
+    page.get_pixmap = spy
+    fake_tess = MagicMock()
+    fake_tess.image_to_string.return_value = "x"
+    with patch.dict(sys.modules, {"pytesseract": fake_tess}):
+        pdf_worker._ocr_page(page, "eng", dpi=288)  # 288/72 = 4.0
+    doc.close()
+    assert captured["matrix"] == fitz.Matrix(4.0, 4.0)
+
+
+def test_ocr_page_main_passes_dpi(tmp_path):
+    """ocr_page_main forwards its dpi argument to ocr_page."""
+    pdf = tmp_path / "scan.pdf"
+    _make_image_only_pdf(pdf)
+    result_path = tmp_path / "out.pkl"
+    with patch.object(pdf_worker, "ocr_page", return_value="ok") as m:
+        pdf_worker.ocr_page_main(str(pdf), 0, "eng", str(result_path), dpi=250)
+    assert m.call_args.kwargs.get("dpi") == 250
+
+
+def test_ocr_page_main_writes_pickled_text(tmp_path):
+    """ocr_page_main pickles the recognised text to result_path."""
+    pdf = tmp_path / "scan.pdf"
+    _make_image_only_pdf(pdf)
+    result_path = tmp_path / "out.pkl"
+
+    with patch.object(pdf_worker, "_ocr_page", return_value="recognised"):
+        pdf_worker.ocr_page_main(str(pdf), 0, "eng", str(result_path))
+
+    with open(result_path, "rb") as fh:
+        assert pickle.load(fh) == "recognised"
+
+
 def test_worker_imports_no_heavy_backend_modules():
     """Importing pdf_worker must not pull in backend.config (DB/Valkey/Alembic).
 

--- a/docs/api.md
+++ b/docs/api.md
@@ -8,8 +8,8 @@ The live API is self-documented via OpenAPI. With the server running:
 
 | URL | Description |
 |-----|-------------|
-| `http://localhost:9481/api/docs` | **Swagger UI** — interactive, try-it-out docs |
-| `http://localhost:9481/api/redoc` | **ReDoc** — clean, readable reference |
+| `http://localhost:9481/api/docs` | **Swagger UI** - interactive, try-it-out docs |
+| `http://localhost:9481/api/redoc` | **ReDoc** - clean, readable reference |
 | `http://localhost:9481/api/openapi.json` | Raw OpenAPI schema |
 ---
 
@@ -31,7 +31,7 @@ Tokens are returned by `/api/auth/login` and expire after **30 days**.
 
 ### Rate limiting
 
-The credential-checking endpoints — `/api/auth/login`, `/api/auth/setup`, `/api/auth/guest-login`, and `/api/stats` — are rate-limited per client IP (default `10/minute`, configurable via `AUTH_RATE_LIMIT`). Exceeding the limit returns `429 Too Many Requests` with `{"error": "Rate limit exceeded: ..."}`. Keying honors `X-Forwarded-For` behind a reverse proxy. See [Security hardening](../README.md#security-hardening).
+The credential-checking endpoints - `/api/auth/login`, `/api/auth/setup`, `/api/auth/guest-login`, and `/api/stats` - are rate-limited per client IP (default `10/minute`, configurable via `AUTH_RATE_LIMIT`). Exceeding the limit returns `429 Too Many Requests` with `{"error": "Rate limit exceeded: ..."}`. Keying honors `X-Forwarded-For` behind a reverse proxy. See [Security hardening](../README.md#security-hardening).
 
 ### Roles
 
@@ -49,20 +49,20 @@ The credential-checking endpoints — `/api/auth/login`, `/api/auth/setup`, `/ap
 
 | Endpoint | Method | Auth | Description |
 |----------|--------|------|-------------|
-| `/api/health` | GET | — | Unauthenticated readiness probe used by the container `HEALTHCHECK`. Checks the database (always) and Valkey (only when configured). Returns `200` with `{"status": "ok", "checks": {...}}` when all dependencies are reachable, or `503` with `{"status": "unhealthy", ...}` otherwise. |
+| `/api/health` | GET | - | Unauthenticated readiness probe used by the container `HEALTHCHECK`. Checks the database (always) and Valkey (only when configured). Returns `200` with `{"status": "ok", "checks": {...}}` when all dependencies are reachable, or `503` with `{"status": "unhealthy", ...}` otherwise. |
 
 ### Auth
 
 | Endpoint | Method | Auth | Description |
 |----------|--------|------|-------------|
-| `/api/auth/status` | GET | — | Returns `{"initialized": bool}` — used by the frontend to decide whether to show first-run setup |
-| `/api/auth/config` | GET | — | Public auth configuration for the login screen: `{password_auth_enabled, guest_access_enabled, custom_login_message_enabled, custom_login_message, oidc_enabled, oidc_button_text, oidc_auto_launch}`. The custom message is only returned when its toggle is on. OIDC fields are only true/non-empty when the IdP is fully configured. |
-| `/api/auth/setup` | POST | — | First-run admin account creation. Body: `{username, password}`. Returns `{token, user}`. Fails with 400 if any users exist. |
-| `/api/auth/login` | POST | — | Authenticate. Body: `{username, password}`. Returns `{token, user}` (`user` includes `display_name`). Returns 403 if password authentication is disabled. |
-| `/api/auth/guest-login` | POST | — | Exchange a campaign guest invite code for a JWT. Body: `{code}`. Returns `{token, user, campaign_id}` — `user.display_name` is the GM-set guest nickname. Returns 403 if guest access is disabled, 401 for an unknown/expired code. |
+| `/api/auth/status` | GET | - | Returns `{"initialized": bool}` - used by the frontend to decide whether to show first-run setup |
+| `/api/auth/config` | GET | - | Public auth configuration for the login screen: `{password_auth_enabled, guest_access_enabled, custom_login_message_enabled, custom_login_message, oidc_enabled, oidc_button_text, oidc_auto_launch}`. The custom message is only returned when its toggle is on. OIDC fields are only true/non-empty when the IdP is fully configured. |
+| `/api/auth/setup` | POST | - | First-run admin account creation. Body: `{username, password}`. Returns `{token, user}`. Fails with 400 if any users exist. |
+| `/api/auth/login` | POST | - | Authenticate. Body: `{username, password}`. Returns `{token, user}` (`user` includes `display_name`). Returns 403 if password authentication is disabled. |
+| `/api/auth/guest-login` | POST | - | Exchange a campaign guest invite code for a JWT. Body: `{code}`. Returns `{token, user, campaign_id}` - `user.display_name` is the GM-set guest nickname. Returns 403 if guest access is disabled, 401 for an unknown/expired code. |
 | `/api/auth/me` | GET | any | Current user: `{id, username, display_name, email, role, allow_explicit, campaign_access, oidc_linked}` |
-| `/api/auth/openid/login` | GET | — | Start an OIDC login. Redirects to the IdP. Optional `?return_to=/path` to redirect after callback. Returns 503 if OIDC isn't configured. |
-| `/api/auth/openid/callback` | GET | — | OIDC callback. Validates the code, finds/creates the local user, and redirects to the frontend with `#oidc_token=<jwt>`. |
+| `/api/auth/openid/login` | GET | - | Start an OIDC login. Redirects to the IdP. Optional `?return_to=/path` to redirect after callback. Returns 503 if OIDC isn't configured. |
+| `/api/auth/openid/callback` | GET | - | OIDC callback. Validates the code, finds/creates the local user, and redirects to the frontend with `#oidc_token=<jwt>`. |
 | `/api/auth/openid/discover` | POST | admin | Server-side discovery fetch. Body: `{issuer_url}`. Returns the relevant endpoints from `.well-known/openid-configuration`. |
 
 ### Users
@@ -85,7 +85,7 @@ The credential-checking endpoints — `/api/auth/login`, `/api/auth/setup`, `/ap
 |----------|--------|------|-------------|
 | `/api/stats` | GET | JWT **or** `X-API-Key` header | Counts, page totals, library size |
 | `/api/about` | GET | any (JWT) | Build info for the About dialog: `{version, commit_hash, python_version}`. Deliberately **not** exposed on `/api/stats`, so these details aren't readable via the `X-API-Key` fallback. |
-| `/api/scan-status` | GET | admin | Current scan state |
+| `/api/scan-status` | GET | admin | Current scan state. `phase` is `scanning` (file walk), `indexing` (text-layer extraction), or `ocr` (deferred OCR of scanned/image-only PDFs). During the `ocr` phase, `total_ocr`/`ocr_done`/`ocr_current` report the OCR queue's progress. |
 | `/api/rescan` | POST | admin | Trigger a background rescan and reindex (optionally scoped, with a metadata-refresh mode) |
 | `/api/cancel-scan` | POST | admin | Request a graceful stop of the running scan or indexing job |
 
@@ -108,7 +108,7 @@ the safe way to surface library counts on an external dashboard. Generate a key
 as an admin under **Settings → App Settings → Stats API Key** (regenerate or
 revoke it there at any time).
 
-**Homepage Custom API widget** — add this to your Homepage `services.yaml`
+**Homepage Custom API widget** - add this to your Homepage `services.yaml`
 ([Custom API widget docs](https://gethomepage.dev/widgets/services/customapi/)):
 
 ```yaml
@@ -122,16 +122,16 @@ revoke it there at any time).
       headers:
         X-API-Key: your-key-here
       mappings:
-        - field: books
+ - field: books
           label: Books
           format: number
-        - field: maps
+ - field: maps
           label: Maps
           format: number
-        - field: tokens
+ - field: tokens
           label: Tokens
           format: number
-        - field: total_size_mb
+ - field: total_size_mb
           label: Size
           format: float
           scale: 0.001
@@ -139,7 +139,7 @@ revoke it there at any time).
 ```
 
 Homepage shows up to four fields per row; pick the counts you care about from the
-available fields below. Use a `refreshInterval` of 60s or higher — `/api/stats`
+available fields below. Use a `refreshInterval` of 60s or higher - `/api/stats`
 is rate limited.
 
 | Field | Meaning | Suggested `format` |
@@ -151,7 +151,7 @@ is rate limited.
 | `audio` | Total audio tracks | `number` |
 | `indexed_books` | Books with a searchable full-text index | `number` |
 | `total_pages` | Sum of all book page counts | `number` |
-| `total_size_mb` | Total library size in MB | `float` — add `scale: 0.001` + `suffix: " GB"` to show GB |
+| `total_size_mb` | Total library size in MB | `float` - add `scale: 0.001` + `suffix: " GB"` to show GB |
 
 **Scan-status response:**
 ```json
@@ -197,7 +197,7 @@ Returns `{"status": "scan_started"}`, or `{"status": "already_running"}` if a sc
 ```json
 {"status": "stop_requested"}
 ```
-Returns `{"status": "not_running"}` if no scan is in progress. Cancellation is cooperative — the running scan checks for the stop signal after each file and exits at the next safe checkpoint. Poll `/api/scan-status` until `running` is `false` to confirm it has stopped.
+Returns `{"status": "not_running"}` if no scan is in progress. Cancellation is cooperative - the running scan checks for the stop signal after each file and exits at the next safe checkpoint. Poll `/api/scan-status` until `running` is `false` to confirm it has stopped.
 
 ### Game Systems
 
@@ -218,6 +218,7 @@ Returns `{"status": "not_running"}` if no scan is in progress. Cancellation is c
 | `/api/books` | GET | any | Paginated book list. Query: `system_id`, `category`, `limit` (max 500, default 100), `offset` |
 | `/api/books/:id` | GET | any | Book detail with game system |
 | `/api/books/:id` | PATCH | gm/admin | Update: `title`, `category`, `description`, `authors`, `publisher`, `publisher_url`, `year`, `is_explicit` |
+| `/api/books/:id/reindex` | POST | gm/admin | Re-run OCR on a scanned book. Optional query `ocr_dpi` (72–600) re-reads this book at a higher resolution than the global `OCR_DPI`; omit for the default. Clears the book's search index and re-queues it (OCR runs in the background — poll `/api/scan-status`). 400 if the book has an embedded text layer (nothing to OCR). Returns `{status: "reindex_queued", ocr_dpi}`. |
 | `/api/books/:id/file` | GET | any | Download/stream the file |
 | `/api/books/:id/thumbnail` | GET | any | WebP cover thumbnail |
 | `/api/books/:id/toc` | GET | any | PDF table of contents as `{title, page, level, children}[]` |
@@ -279,7 +280,7 @@ Item types: `book`, `map`, `token`, `audio`, `system`
 
 ### Bookmarks
 
-Bookmarks are per-user — users cannot see or modify each other's bookmarks.
+Bookmarks are per-user - users cannot see or modify each other's bookmarks.
 
 | Endpoint | Method | Auth | Description |
 |----------|--------|------|-------------|
@@ -317,8 +318,8 @@ Bookmarks are per-user — users cannot see or modify each other's bookmarks.
 | Endpoint | Method | Auth | Description |
 |----------|--------|------|-------------|
 | `/api/campaigns` | GET | any | List own + invited campaigns (admins see only their own here). Each item includes `has_banner`, `next_session` (next scheduled date or null), and `last_accessed_at`. |
-| `/api/campaigns` | POST | any (gm/admin for `is_gm_campaign: true`) | Create campaign. Body: `{name, description?, is_gm_campaign?, gm_title?, system_id?, system_name?, parent_campaign_id?, resources?}`. `description` accepts markdown. `system_name` is free text for a system not in the library (ignored when `system_id` is set). `resources` is an explicit list of `{resource_type, resource_id, visibility?, shared_user_ids?}` to link — omit it (or send `[]`) to link nothing. No resources are auto-added. Returns 403 if the user's `campaign_access` is disabled. |
-| `/api/campaigns/:id` | GET | owner or member | Campaign detail with members and resources. Includes `has_banner` and `locked` (`true` when the owner's `campaign_access` is disabled — the campaign is then read-only for everyone, owner-management endpoints return 403, members keep read access) plus `owner_has_campaign_access`. Each member includes `id`, `has_art`, `has_sheet`, `character_sheet_filename`, and `campaign_access` (false → flagged as a disabled user). Opening this endpoint records `last_accessed_at` (drives recently-accessed sorting on the campaigns list). |
+| `/api/campaigns` | POST | any (gm/admin for `is_gm_campaign: true`) | Create campaign. Body: `{name, description?, is_gm_campaign?, gm_title?, system_id?, system_name?, parent_campaign_id?, resources?}`. `description` accepts markdown. `system_name` is free text for a system not in the library (ignored when `system_id` is set). `resources` is an explicit list of `{resource_type, resource_id, visibility?, shared_user_ids?}` to link - omit it (or send `[]`) to link nothing. No resources are auto-added. Returns 403 if the user's `campaign_access` is disabled. |
+| `/api/campaigns/:id` | GET | owner or member | Campaign detail with members and resources. Includes `has_banner` and `locked` (`true` when the owner's `campaign_access` is disabled - the campaign is then read-only for everyone, owner-management endpoints return 403, members keep read access) plus `owner_has_campaign_access`. Each member includes `id`, `has_art`, `has_sheet`, `character_sheet_filename`, and `campaign_access` (false → flagged as a disabled user). Opening this endpoint records `last_accessed_at` (drives recently-accessed sorting on the campaigns list). |
 | `/api/campaigns/:id` | PATCH | owner | Update `name`, `description` (markdown), `gm_title`, `system_id`, `system_name`, `parent_campaign_id`. Setting `system_id` clears `system_name` and vice-versa (`system_name: ""` clears it). |
 | `/api/campaigns/:id` | DELETE | owner | Delete campaign and all related data. Admins delete via the database directly. |
 | `/api/campaigns/admin/by-user/:user_id` | GET | admin | Read-only minimal list of a user's campaigns (`id`, `name`, `description`, `is_gm_campaign`, `system_id`, `system_name`) for the user-management page |
@@ -347,7 +348,7 @@ Guests are code-only accounts (role `guest`) scoped to a single GM campaign. All
 | `/api/campaigns/:id/guests/:member_id/share-template` | GET | owner | Returns share content: `{code, link, message, mailto_url, discord_message}`. `link` is a `/guest?code=…` deep link built from `BASE_URL`. |
 | `/api/campaigns/:id/guests/:member_id` | DELETE | owner | Remove a guest; also deletes the backing guest account and its contributions. |
 
-Guests authenticate via [`/api/auth/guest-login`](#auth) and may write only their own character name, art, sheet, session notes, and availability — everything else is read-only. The shared library, maps, tokens, and search return 403 for guests.
+Guests authenticate via [`/api/auth/guest-login`](#auth) and may write only their own character name, art, sheet, session notes, and availability - everything else is read-only. The shared library, maps, tokens, and search return 403 for guests.
 
 #### Banner, character art & sheets
 
@@ -385,7 +386,7 @@ The GET (serving) endpoints for banners, art, sheets, and campaign files (`/file
 | `/api/campaigns/:id/images` | POST | owner | Upload an image (multipart `file`, image types only) to embed in a wiki note; links it as a `file` resource with `is_image: true`. Optional multipart fields: `category_id` (file it under an existing resource category) or `new_category_name` (create a category and file it there). |
 | `/api/campaigns/:id/files/:file_id` | GET | per visibility | Download a campaign file (honours the linking resource's visibility); for an image this also serves it inline/as its thumbnail |
 
-Resource types: `book`, `map`, `token`, `audio`, `file` (a GM-uploaded file stored under `DATA_PATH/campaign_uploads/files/`, separate from the library). Listed/serialized resources include `is_image` (true for `file` resources that hold an image upload — those render inline with a thumbnail instead of as a download card).
+Resource types: `book`, `map`, `token`, `audio`, `file` (a GM-uploaded file stored under `DATA_PATH/campaign_uploads/files/`, separate from the library). Listed/serialized resources include `is_image` (true for `file` resources that hold an image upload - those render inline with a thumbnail instead of as a download card).
 
 Resource **visibility** is one of: `public` (every accepted member), `private` (the owner plus the users in `shared_user_ids`), or `gm` (owner only). The character-sheet upload endpoints also accept a URL alternative via the member PATCH: `PATCH /api/campaigns/:id/members/:user_id` with `{character_sheet_url}` (`""` clears it; setting a URL clears any uploaded sheet, and uploading a sheet clears the URL).
 
@@ -393,9 +394,9 @@ App-wide admin settings gate campaign file uploads (admins are exempt): `campaig
 
 #### Categories
 
-GM-defined groupings for linked **resources**, scoped per campaign. Resources carry an optional `category_id` (null = grouped under their built-in type group: Books / Maps / Tokens / Files), set via the resource PATCH endpoint (`category_id`), using `""` to clear it. Wiki pages no longer use categories — they nest under parent pages instead (see Wiki). `kind` `note` is retired: `POST` with `kind: "note"` returns 400, and legacy note categories are converted to parent pages on startup.
+GM-defined groupings for linked **resources**, scoped per campaign. Resources carry an optional `category_id` (null = grouped under their built-in type group: Books / Maps / Tokens / Files), set via the resource PATCH endpoint (`category_id`), using `""` to clear it. Wiki pages no longer use categories - they nest under parent pages instead (see Wiki). `kind` `note` is retired: `POST` with `kind: "note"` returns 400, and legacy note categories are converted to parent pages on startup.
 
-The resource panel's **group display order** (custom categories interleaved with the built-in type groups) is stored per campaign as `resource_group_order` (returned by the campaign GET): an ordered list of group keys — `type:book`, `type:map`, `type:token`, `type:file`, and `cat:<category_id>`. Groups absent from the list fall to the end in their default order; an empty list means the default order (categories then type groups).
+The resource panel's **group display order** (custom categories interleaved with the built-in type groups) is stored per campaign as `resource_group_order` (returned by the campaign GET): an ordered list of group keys - `type:book`, `type:map`, `type:token`, `type:file`, and `cat:<category_id>`. Groups absent from the list fall to the end in their default order; an empty list means the default order (categories then type groups).
 
 | Endpoint | Method | Auth | Description |
 |----------|--------|------|-------------|
@@ -414,7 +415,7 @@ Pages nest: each page has an optional `parent_id` (null = top level), forming a 
 
 Each page has a **visibility**: `gm` (owner only), `group` (all accepted members), or `members` (owner plus the users in `shared_user_ids`). The owner may create/edit/delete any page; a member may create `group` pages and edit/delete pages they authored, but cannot set `gm`/`members` visibility.
 
-Within a page body, text wrapped in `||double pipes||` is a **GM-only secret** — finer-grained than page visibility, it hides a span inside an otherwise shared page. Those spans (markers and enclosed text, which may span multiple lines) are stripped server-side from the `body` returned to anyone other than the campaign owner, and from `search` snippets/matches for non-owners. The owner always receives the raw `||...||`. Personal (non-GM) campaigns are never stripped, since only the owner can view them.
+Within a page body, text wrapped in `||double pipes||` is a **GM-only secret** - finer-grained than page visibility, it hides a span inside an otherwise shared page. Those spans (markers and enclosed text, which may span multiple lines) are stripped server-side from the `body` returned to anyone other than the campaign owner, and from `search` snippets/matches for non-owners. The owner always receives the raw `||...||`. Personal (non-GM) campaigns are never stripped, since only the owner can view them.
 
 | Endpoint | Method | Auth | Description |
 |----------|--------|------|-------------|
@@ -423,8 +424,8 @@ Within a page body, text wrapped in `||double pipes||` is a **GM-only secret** �
 | `/api/campaigns/:id/wiki/search` | GET | member or owner | Search visible pages by title/body. Query: `q` |
 | `/api/campaigns/:id/wiki/titles` | GET | member or owner | `{title, slug}` list for `[[link]]` autocomplete |
 | `/api/campaigns/:id/wiki/reorder` | PUT | owner | Drag-and-drop order. Body: `{ordered_ids}` |
-| `/api/campaigns/:id/wiki/export` | GET | owner | Export all pages. Query: `format` = `md` (a `.zip` of one Markdown file per page, with YAML frontmatter incl. `parent` slug — Obsidian-friendly) or `json` (a Grimoire JSON bundle: `{grimoire_wiki_version, campaign, pages[]}`, each page carrying its `parent` slug). Returns a file download |
-| `/api/campaigns/:id/wiki/import` | POST | owner | Import pages from a multipart `file`. Accepts a single `.md`/`.markdown`/`.txt`, a Grimoire `.json` bundle, a LegendKeeper export (`.json`/`.lk` — a per-page export or a current `{version, resources[]}` bundle with ProseMirror bodies), or a `.zip` (Markdown vault, Grimoire bundle, or LegendKeeper directory export). LegendKeeper HTML and ProseMirror bodies are converted to Markdown (lossy for LegendKeeper-only blocks, which are dropped); page nesting (`parent`/`parentId`) is preserved. Import is non-destructive: every record becomes a new page (slugs de-duplicated), existing pages are never overwritten, and internal links are remapped. Returns `{imported, format, pages[]}` |
+| `/api/campaigns/:id/wiki/export` | GET | owner | Export all pages. Query: `format` = `md` (a `.zip` of one Markdown file per page, with YAML frontmatter incl. `parent` slug - Obsidian-friendly) or `json` (a Grimoire JSON bundle: `{grimoire_wiki_version, campaign, pages[]}`, each page carrying its `parent` slug). Returns a file download |
+| `/api/campaigns/:id/wiki/import` | POST | owner | Import pages from a multipart `file`. Accepts a single `.md`/`.markdown`/`.txt`, a Grimoire `.json` bundle, a LegendKeeper export (`.json`/`.lk` - a per-page export or a current `{version, resources[]}` bundle with ProseMirror bodies), or a `.zip` (Markdown vault, Grimoire bundle, or LegendKeeper directory export). LegendKeeper HTML and ProseMirror bodies are converted to Markdown (lossy for LegendKeeper-only blocks, which are dropped); page nesting (`parent`/`parentId`) is preserved. Import is non-destructive: every record becomes a new page (slugs de-duplicated), existing pages are never overwritten, and internal links are remapped. Returns `{imported, format, pages[]}` |
 | `/api/campaigns/:id/wiki/:page_id` | GET | per visibility | Page detail incl. `body`, `backlinks`, `shared_user_ids`, `icon`, `can_edit` |
 | `/api/campaigns/:id/wiki/:page_id` | PATCH | owner or page author | Update fields (each optional; `icon: ""` clears it) |
 | `/api/campaigns/:id/wiki/:page_id` | DELETE | owner or page author | Delete the page and its link rows |
@@ -466,7 +467,7 @@ Superseded by the wiki. On startup, any non-empty legacy session notes are rolle
 | Field | Description |
 |-------|-------------|
 | `frequency` | `weekly`, `biweekly`, `monthly`, or `custom` |
-| `days` | Weekday indices — `0` = Monday … `6` = Sunday |
+| `days` | Weekday indices - `0` = Monday … `6` = Sunday |
 | `time_utc` | Session time in UTC (`HH:MM`) |
 | `biweekly_reference` | Anchor date for biweekly cadence (`YYYY-MM-DD`) |
 | `monthly_week` | Week of month: `1`–`4`, or `-1` for last |
@@ -522,10 +523,10 @@ Availability statuses: `available`, `tentative`, `unavailable`
 | `oidc_authorization_endpoint` | string | Discovered or manual authorization endpoint URL. |
 | `oidc_token_endpoint` | string | Discovered or manual token endpoint URL. |
 | `oidc_userinfo_endpoint` | string | Discovered or manual userinfo endpoint URL. |
-| `oidc_jwks_uri` | string | Discovered or manual JWKS URL — required to validate the ID token signature. |
+| `oidc_jwks_uri` | string | Discovered or manual JWKS URL - required to validate the ID token signature. |
 | `oidc_end_session_endpoint` | string | Optional RP-initiated logout endpoint. |
 | `oidc_client_id` | string | Client ID issued by the IdP. |
-| `oidc_client_secret` | string | **Write-only.** Setting a non-empty string saves it. Empty string is a no-op (so form re-submits don't clobber). The literal `"__CLEAR__"` wipes the stored secret. GET responses never return the value — instead, `oidc_client_secret_set: bool` and `oidc_client_secret_length: int` are returned. |
+| `oidc_client_secret` | string | **Write-only.** Setting a non-empty string saves it. Empty string is a no-op (so form re-submits don't clobber). The literal `"__CLEAR__"` wipes the stored secret. GET responses never return the value - instead, `oidc_client_secret_set: bool` and `oidc_client_secret_length: int` are returned. |
 | `oidc_signing_alg` | string | One of `RS256`/`RS384`/`RS512`/`ES256`/`ES384`/`ES512`/`PS256`/`PS384`/`PS512`/`HS256`. Default `RS256`. |
 | `oidc_button_text` | string | Label for the SSO button on the login page. |
 | `oidc_groups_claim` | string | Optional. Name of the claim containing group memberships. When set, roles are assigned from groups named (case-insensitively) `admin`, `gm`, or `player`; users without a matching group are denied. |
@@ -552,10 +553,10 @@ GET responses also include a sibling `<key>_env_locked: bool` for each individua
 
 | Parameter | Default | Description |
 |-----------|---------|-------------|
-| `level` | `info` | Minimum log level: `debug`, `info`, `warning`, `error`, `critical`. Follows standard hierarchy — `debug` returns all levels, `info` returns info and above, etc. |
+| `level` | `info` | Minimum log level: `debug`, `info`, `warning`, `error`, `critical`. Follows standard hierarchy - `debug` returns all levels, `info` returns info and above, etc. |
 | `limit` | `200` | Max entries to return (1–20000) |
 | `offset` | `0` | Skip this many of the most-recent matching entries (historical pagination, ignored when `after_seq` is set) |
-| `after_seq` | — | Return only entries with `seq` greater than this value. Use the `max_seq` from the previous response as a cursor for live polling. Exact even when hundreds of entries arrive between polls. |
+| `after_seq` | - | Return only entries with `seq` greater than this value. Use the `max_seq` from the previous response as a cursor for live polling. Exact even when hundreds of entries arrive between polls. |
 
 **Response:**
 ```json
@@ -602,12 +603,12 @@ All errors follow FastAPI's standard format:
 
 | Status | Meaning |
 |--------|---------|
-| `400` | Bad request — validation failed or business rule violated |
-| `401` | Not authenticated — missing or invalid token |
-| `403` | Forbidden — insufficient role or not a campaign member |
+| `400` | Bad request - validation failed or business rule violated |
+| `401` | Not authenticated - missing or invalid token |
+| `403` | Forbidden - insufficient role or not a campaign member |
 | `404` | Resource not found |
-| `409` | Conflict — duplicate (e.g. duplicate username, resource already linked) |
-| `422` | Unprocessable entity — request body failed schema validation |
+| `409` | Conflict - duplicate (e.g. duplicate username, resource already linked) |
+| `422` | Unprocessable entity - request body failed schema validation |
 
 ---
 
@@ -639,8 +640,8 @@ Game system records are created automatically from the folder names under `books
 
 When a book is first indexed, the scanner looks for an OPF metadata file alongside the PDF. Two locations are checked in order:
 
-1. `<bookname>.opf` — same directory, same stem as the PDF.
-2. `metadata.opf` — same directory (Calibre's per-book-folder format).
+1. `<bookname>.opf` - same directory, same stem as the PDF.
+2. `metadata.opf` - same directory (Calibre's per-book-folder format).
 
 Fields read: `dc:title`, `dc:creator` (role=aut → authors), `dc:publisher`, `dc:date` (year), `dc:description` (HTML stripped), `dc:subject` (→ tags). Cover images referenced in the OPF `<guide>` are excluded from the book list automatically.
 

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -5,16 +5,16 @@ flows end-to-end, how authentication and OIDC work, and how schema changes are a
 startup. It complements the high-level overview in [`CLAUDE.md`](../CLAUDE.md) and the
 schema reference in [`docs/data-model.md`](data-model.md).
 
-All `file_path` references point at the current code — if you change a module's shape,
+All `file_path` references point at the current code - if you change a module's shape,
 update the matching section here.
 
 ## Stack
 
-- **Frontend** — React 18 + Vite 6 SPA, React Router v6, React Context (no Redux/Zustand),
+- **Frontend** - React 18 + Vite 6 SPA, React Router v6, React Context (no Redux/Zustand),
   i18next (EN/DE/FR), Vitest + React Testing Library.
-- **Backend** — FastAPI (async) + SQLAlchemy 2.0, SQLite with FTS5 full-text search,
+- **Backend** - FastAPI (async) + SQLAlchemy 2.0, SQLite with FTS5 full-text search,
   PyMuPDF (`fitz`) for PDF→WebP rendering, PyJWT auth.
-- **Optional** — Valkey/Redis for in-memory page-image caching (falls back to disk).
+- **Optional** - Valkey/Redis for in-memory page-image caching (falls back to disk).
 
 The FastAPI backend serves both the REST API under `/api/*` and the static React build
 (`frontend/dist/`) via a catch-all route. In development, Vite proxies `/api` to the
@@ -31,9 +31,9 @@ backend on port 9481.
 | [`backend/models/`](../backend/models/) | ORM models split by domain (`library.py`, `media.py`, `users.py`, `campaigns.py`, `settings.py`); `db.py` holds `init_db`, runtime migrations, and FTS5 setup. See [`docs/data-model.md`](data-model.md). |
 | [`backend/auth.py`](../backend/auth.py) | JWT creation/validation, password hashing (`bcrypt_sha256`), the `get_current_user` dependency, and the role-guard dependencies (`require_admin`, `require_gm_or_admin`, `require_not_guest`). |
 | [`backend/indexer.py`](../backend/indexer.py) | Library scanning, PDF FTS5 indexing, thumbnail generation, and OPF/metadata parsing. PDF text extraction runs in an isolated subprocess (see below). |
-| [`backend/pdf_worker.py`](../backend/pdf_worker.py) | Standalone entry point for the spawned PDF text-extraction process. Imports only `fitz`/OCR libs — never `backend.config` — so a throwaway extraction child does not open the DB or run migrations. |
+| [`backend/pdf_worker.py`](../backend/pdf_worker.py) | Standalone entry point for the spawned PDF text-extraction process. Imports only `fitz`/OCR libs - never `backend.config` - so a throwaway extraction child does not open the DB or run migrations. |
 | [`backend/routers/`](../backend/routers/) | One package per feature area (see the router shape below). |
-| [`backend/scheduler.py`](../backend/scheduler.py), [`backend/session_creator.py`](../backend/session_creator.py) | Campaign session scheduling — apply recurrence on startup and auto-create upcoming sessions. |
+| [`backend/scheduler.py`](../backend/scheduler.py), [`backend/session_creator.py`](../backend/session_creator.py) | Campaign session scheduling - apply recurrence on startup and auto-create upcoming sessions. |
 | [`backend/seed_users.py`](../backend/seed_users.py) | First-run / env-driven user pre-seeding. |
 
 #### Router package shape
@@ -42,23 +42,23 @@ Every package under `backend/routers/` follows the same layout (larger packages 
 modules like [`books/pages.py`](../backend/routers/books/pages.py) or
 `campaigns/sessions.py`):
 
-- `__init__.py` — builds the `APIRouter` and registers routes via `add_api_route(...)`.
+- `__init__.py` - builds the `APIRouter` and registers routes via `add_api_route(...)`.
   Auth-adjacent packages expose **two** routers: a `public_router` (mounted directly on the
   app, no auth) and a `router` (mounted under the authenticated `/api` parent). See
   [`routers/auth/__init__.py`](../backend/routers/auth/__init__.py).
-- `core.py` — the endpoint handler functions (plain functions, no decorators).
-- `_schemas.py` — Pydantic request/response models (when needed).
-- `_helpers.py` — shared internal helpers (when needed).
+- `core.py` - the endpoint handler functions (plain functions, no decorators).
+- `_schemas.py` - Pydantic request/response models (when needed).
+- `_helpers.py` - shared internal helpers (when needed).
 
 ### Frontend
 
 | Path | Responsibility |
 | --- | --- |
 | [`frontend/src/App.jsx`](../frontend/src/App.jsx) | Router setup, protected routes, and the context-provider tree. |
-| [`frontend/src/api.js`](../frontend/src/api.js) | Centralized `fetch` wrapper — attaches the JWT, handles errors, exposes the `mediaUrl(...)` helper for `?token=` image/download URLs, and the per-feature API namespaces (`campaigns`, `auth`, `settings`, …). |
+| [`frontend/src/api.js`](../frontend/src/api.js) | Centralized `fetch` wrapper - attaches the JWT, handles errors, exposes the `mediaUrl(...)` helper for `?token=` image/download URLs, and the per-feature API namespaces (`campaigns`, `auth`, `settings`, …). |
 | [`frontend/src/context/`](../frontend/src/context/) | `AuthContext` (token + current user), `UISettingsContext`, `FavoritesContext`. |
-| [`frontend/src/views/`](../frontend/src/views/) | Page-level components — one per route. |
-| [`frontend/src/components/`](../frontend/src/components/) | Shared UI components (one component per file — enforced by ESLint). |
+| [`frontend/src/views/`](../frontend/src/views/) | Page-level components - one per route. |
+| [`frontend/src/components/`](../frontend/src/components/) | Shared UI components (one component per file - enforced by ESLint). |
 | [`frontend/src/hooks/`](../frontend/src/hooks/), [`frontend/src/utils.js`](../frontend/src/utils.js) | Reusable hooks and helpers. |
 
 ## Request lifecycle
@@ -88,18 +88,18 @@ sequenceDiagram
 
 Key points:
 
-- **Frontend** — [`api.js`](../frontend/src/api.js) reads the JWT from `localStorage`
+- **Frontend** - [`api.js`](../frontend/src/api.js) reads the JWT from `localStorage`
   (`grimoire_token`) and sends it as an `Authorization: Bearer` header. On any `401` it
   dispatches a `grimoire:unauthorized` window event; `AuthContext` listens and clears the
   stored token, bouncing the user to login.
-- **Auth boundary** — the authenticated API is a single parent router built with
+- **Auth boundary** - the authenticated API is a single parent router built with
   `APIRouter(prefix="/api", dependencies=[Depends(get_current_user)])` in
   [`main.py`](../backend/main.py#L203). Every sub-router mounted under it inherits the JWT
   requirement. Truly public endpoints (`/api/auth/status|setup|login`, OIDC, health, some
   library routes) are registered as separate `public_router`s mounted directly on the app.
-- **Handler → DB** — handlers open a session via `SessionLocal()` (or the `get_db`
+- **Handler → DB** - handlers open a session via `SessionLocal()` (or the `get_db`
   dependency) and return dicts/Pydantic models that FastAPI serializes to JSON.
-- **Static assets** — the Vite build's hashed assets are mounted at `/assets` via
+- **Static assets** - the Vite build's hashed assets are mounted at `/assets` via
   `StaticFiles`. Any other non-`/api` path falls through to `serve_frontend`, which returns
   the requested file if it exists (with a path-traversal guard) or `index.html` with
   `Cache-Control: no-store` so the SPA can client-route.
@@ -127,10 +127,10 @@ under `DATA_PATH/thumbnails/`.
 ### JWT and roles
 
 - Tokens are HS256 JWTs signed with `SECRET_KEY`, carrying `sub` (user id), `username`,
-  `role`, and a 30-day `exp` — see `create_token` / `decode_token` in
+  `role`, and a 30-day `exp` - see `create_token` / `decode_token` in
   [`auth.py`](../backend/auth.py).
 - **Roles**: `admin` (full access incl. user management), `gm` (edit metadata, rescan,
-  manage content), `player` (read-only), plus `guest` — a campaign-scoped, code-only
+  manage content), `player` (read-only), plus `guest` - a campaign-scoped, code-only
   account with no library access.
 - `get_current_user` accepts the token from either the `Authorization: Bearer` header **or**
   a `?token=` query param, so browser-embedded images and downloads authenticate without a
@@ -142,7 +142,7 @@ under `DATA_PATH/thumbnails/`.
 `POST /api/auth/login` verifies a username/password (bcrypt) and returns a JWT.
 `POST /api/auth/guest-login` exchanges a 10-char campaign invite code for a guest-scoped
 JWT (only when guest access is enabled). First-run `POST /api/auth/setup` creates the
-initial admin. All three are public routes — see
+initial admin. All three are public routes - see
 [`routers/auth/__init__.py`](../backend/routers/auth/__init__.py).
 
 ### OIDC (authorization code + PKCE)
@@ -176,19 +176,19 @@ sequenceDiagram
 
 Notes:
 
-- **PKCE + nonce** — `oidc_login` generates a `state`, `nonce`, and PKCE verifier/challenge,
+- **PKCE + nonce** - `oidc_login` generates a `state`, `nonce`, and PKCE verifier/challenge,
   stashes the per-flow secrets in the state store keyed by `state`, and redirects to the
   IdP's authorization endpoint (endpoints are read from config or auto-discovered from the
   issuer's `.well-known/openid-configuration`).
-- **State store** — `_StateStore` in
+- **State store** - `_StateStore` in
   [`routers/oidc/_helpers.py`](../backend/routers/oidc/_helpers.py) is an in-process dict
   with a 10-minute TTL. This is sufficient for a single replica; a multi-replica deployment
   would need a shared store (tracked for the Valkey-backed state/JWKS work).
-- **Callback** — `oidc_callback` validates `state`, exchanges the code for tokens, validates
+- **Callback** - `oidc_callback` validates `state`, exchanges the code for tokens, validates
   the `id_token` against the IdP's JWKS (checking issuer/audience/nonce), optionally merges
   `/userinfo` claims (some IdPs only expose groups there), resolves or auto-registers the
   user, then mints a Grimoire JWT.
-- **Token handoff** — the JWT is returned in the redirect **URL fragment**
+- **Token handoff** - the JWT is returned in the redirect **URL fragment**
   (`#oidc_token=...`) rather than a query param, so it isn't logged by intermediate proxies.
   The frontend reads it from the fragment and stores it like any other token.
 
@@ -197,35 +197,68 @@ Notes:
 The `lifespan` async context manager in [`main.py`](../backend/main.py#L87) runs once per
 process on startup:
 
-1. **Single-worker guard** — acquire a non-blocking `flock` on `DATA_PATH/.scan.lock`. Only
+1. **Single-worker guard** - acquire a non-blocking `flock` on `DATA_PATH/.scan.lock`. Only
    the winning worker runs the startup library scan; others skip it. The scan runs on a
    background daemon thread so it doesn't block the app coming up.
-2. **User seeding** — `seed_users(...)` applies env-driven / first-run accounts.
-3. **Wiki migrations** — `wiki_migration` and `wiki_category_migration` roll legacy session
+2. **User seeding** - `seed_users(...)` applies env-driven / first-run accounts.
+3. **Wiki migrations** - `wiki_migration` and `wiki_category_migration` roll legacy session
    notes and flat note-categories into the current nested-page model.
-4. **Scheduler** — apply campaign session recurrence and start the session creator (skipped
+4. **Scheduler** - apply campaign session recurrence and start the session creator (skipped
    under pytest).
 
 ### Crash-isolated PDF indexing
 
-PDF text extraction can crash the interpreter natively — a malformed object that
-segfaults MuPDF, or an out-of-memory kill on a low-RAM host — which no
+PDF text extraction can crash the interpreter natively - a malformed object that
+segfaults MuPDF, or an out-of-memory kill on a low-RAM host - which no
 `try/except` can catch. Left unguarded this is catastrophic: the killed worker is
 respawned by the server, the respawn re-runs the startup scan, hits the same file,
 and crashes again in an endless loop (see issue #204). Two layers prevent this:
 
-1. **Process isolation** — `index_book_text` runs extraction via
+1. **Process isolation** - `index_book_text` runs extraction via
    `extract_text_isolated`, which spawns [`pdf_worker.py`](../backend/pdf_worker.py)
    in a separate process (`spawn`, not `fork`, to avoid inheriting threads and the
    SQLite connection). The child writes its result to a temp file; if it dies
-   without producing one — signal death, OOM-kill, or exceeding the extraction
-   timeout — the parent raises `PdfExtractionCrashError`, marks the book
+   without producing one - signal death, OOM-kill, or exceeding the extraction
+   timeout - the parent raises `PdfExtractionCrashError`, marks the book
    `index_failed`, and moves on. The server never goes down.
-2. **Crash-loop guard** — before extraction, `index_book_text` commits
+2. **Crash-loop guard** - before extraction, `index_book_text` commits
    `index_failed=True` up front (cleared on success). So even in the worst case
    where a crash somehow escaped isolation and took the whole worker down, the book
    is already flagged and is skipped on the next scan instead of re-looping. This
    mirrors the `scan_failed` guard used for the thumbnail/page-count phase.
+
+### Deferred, checkpointed OCR
+
+Scanned (image-only) PDFs have no embedded text layer and must be OCR'd to be
+searchable. OCR is slow - a large scanned book can take tens of minutes to hours - so it runs in a **separate phase behind its own queue** rather than inline
+during the scan, where one slow book would stall the whole library (see issue
+about OCR timeouts on large scanned books).
+
+1. **Fast phase** - `index_book_text` extracts only the embedded text layer
+   (`extract_text_isolated(..., text_only=True)`). Text-layer books and all other
+   media index in seconds and are immediately searchable. A book that comes back
+   with no text is marked `ocr_pending=1` (not `image-only`) and left unindexed.
+   When OCR is unavailable (slim image / `OCR_ENABLED=false`) the pre-OCR
+   behaviour is kept: the book is marked `image-only` and `indexed`.
+2. **OCR phase** - after the fast phases, `run_ocr_queue` (in
+   [`routers/library/_helpers.py`](../backend/routers/library/_helpers.py)) drains
+   the `ocr_pending` books. Each book is OCR'd **one page at a time** by
+   `indexer.ocr_book`, which spawns [`pdf_worker.py`](../backend/pdf_worker.py)'s
+   `ocr_page_main` per page (isolated, per-page-timeout bounded), inserts the
+   recognised page into `book_search`, and advances `ocr_pages_done` before moving
+   on. Because progress is committed per page, a restart, crash, or cancel resumes
+   the book at `ocr_pages_done` rather than re-OCRing it - a multi-hour book makes
+   durable progress and never hits a whole-book wall. `OCR_CONCURRENCY` (default 1)
+   drains several books in parallel via a thread pool, each on its own session.
+   The queue lives in the DB (source of truth, survives restarts); live progress
+   (`total_ocr`/`ocr_done`/`ocr_current`, phase `ocr`) mirrors into the scan-status
+   dict/Valkey for the admin UI.
+3. **Per-book re-OCR** - `POST /api/books/{id}/reindex` (gm/admin) clears a single
+   book's search rows, resets its OCR checkpoint, and re-queues it, optionally with
+   an `ocr_dpi` override persisted on `books.ocr_dpi` (NULL = global `OCR_DPI`).
+   `ocr_book` threads that DPI through `ocr_page_isolated` → `pdf_worker.ocr_page`
+   to the pixmap render, so a specific faint scan can be re-read at higher
+   resolution without re-OCRing the whole library.
 
 ### Schema migrations
 
@@ -239,10 +272,10 @@ Schema changes are managed by **Alembic** (revisions in
   `alembic_version`.
 - **Existing pre-Alembic database** (real tables, but no `alembic_version`) → the legacy
   imperative `ALTER TABLE`/`CREATE INDEX` replay runs one final time to bring the schema
-  exactly to the baseline, then the DB is `stamp`ed at head — the baseline migration is
+  exactly to the baseline, then the DB is `stamp`ed at head - the baseline migration is
   **not** re-run (which would try to recreate existing tables). This keeps upgrades from
   any prior version transparent, with no manual action.
-- **Concurrency** — `init_db` runs once per worker process; a blocking file lock
+- **Concurrency** - `init_db` runs once per worker process; a blocking file lock
   (`<db>.migrate.lock`) serializes the migration so, with multiple uvicorn workers, the
   first migrates and the rest wait and then find the DB already at head.
 - After migrations, idempotent data fixups run on every startup (tag normalization,
@@ -262,6 +295,6 @@ alembic downgrade -1                                        # verify it reverses
 ```
 
 `env.py` targets `Base.metadata`, so autogenerate diffs the models against the DB. The
-`sqlalchemy.url` isn't in `alembic.ini` — it resolves from the app config (or an
+`sqlalchemy.url` isn't in `alembic.ini` - it resolves from the app config (or an
 `-x url=sqlite:///...` override). Keep the schema-of-record in
 [`docs/data-model.md`](data-model.md) in sync when you add a revision.

--- a/docs/data-model.md
+++ b/docs/data-model.md
@@ -1,6 +1,6 @@
 # Data Model Reference
 
-A map of Grimoire's database schema — the tables, their foreign-key relationships, and
+A map of Grimoire's database schema - the tables, their foreign-key relationships, and
 the notable constraints. The schema is defined by the SQLAlchemy models in
 [`backend/models/`](../backend/models/) (`library.py`, `media.py`, `users.py`,
 `campaigns.py`, `settings.py`); this document is a companion reference, so **keep it in
@@ -13,7 +13,7 @@ The backend runs on SQLite. All primary keys are 36-char UUID strings (`_uuid()`
 
 The diagram groups tables by their model file. Solid lines are foreign keys; the crow's-foot
 end marks the "many" side. Media tables (`generic_maps`, `tokens`, `audio`) and the
-`*_folders` tag tables have no foreign keys — they are linked to campaigns only indirectly,
+`*_folders` tag tables have no foreign keys - they are linked to campaigns only indirectly,
 through `campaign_resources` (a polymorphic `resource_type` + `resource_id`, not a real FK),
 so they are omitted from the relationship graph for clarity.
 
@@ -102,15 +102,15 @@ links from `campaign_resources`/`favorites`, which are *not* declared foreign ke
 
 ## Table reference
 
-### Library — [`backend/models/library.py`](../backend/models/library.py)
+### Library - [`backend/models/library.py`](../backend/models/library.py)
 
 | Table | Purpose | Key columns / constraints |
 | --- | --- | --- |
 | `game_systems` | A TTRPG system (D&D 5e, PbtA, …). | `name`, `slug` unique. `is_system_agnostic` flags cross-system content. |
-| `books` | One PDF/document in the library. | `filepath` unique. `game_system_id` FK. Index `ix_books_indexer_queue` on `(indexed, mime_type)` drives the indexer. `indexed`/`index_failed`/`is_missing` track scan state. `index_error` holds the failure message, or the sentinel `image-only` (no text layer, not OCR'd) / `ocr` (indexed via OCR). |
+| `books` | One PDF/document in the library. | `filepath` unique. `game_system_id` FK. Index `ix_books_indexer_queue` on `(indexed, mime_type)` drives the indexer. `indexed`/`index_failed`/`is_missing` track scan state. `index_error` holds the failure message, or the sentinel `image-only` (no text layer, OCR unavailable) / `ocr` (indexed via OCR). `ocr_pending` (indexed `ix_books_ocr_pending`) flags a scanned PDF queued for deferred OCR; `ocr_pages_done` is the per-page OCR checkpoint so a long book resumes rather than restarts after an interruption. `ocr_dpi` is an optional per-book OCR resolution override (NULL = global `OCR_DPI`), set when a book is re-OCR'd at a higher DPI via `POST /api/books/{id}/reindex`. |
 | `book_folders` | Tags auto-applied to a book subcategory folder path. | `path` unique. |
 
-### Media — [`backend/models/media.py`](../backend/models/media.py)
+### Media - [`backend/models/media.py`](../backend/models/media.py)
 
 None of these tables carry foreign keys; they are linked to campaigns polymorphically via
 `campaign_resources`.
@@ -122,7 +122,7 @@ None of these tables carry foreign keys; they are linked to campaigns polymorphi
 | `audio` | An audio track. | `filepath` unique. Embedded metadata (`title`, `artist`, `duration`, …) populated by the indexer. |
 | `map_folders`, `token_folders`, `audio_folders` | Tags auto-applied to a media folder path. | `path` unique. |
 
-### Users — [`backend/models/users.py`](../backend/models/users.py)
+### Users - [`backend/models/users.py`](../backend/models/users.py)
 
 | Table | Purpose | Key columns / constraints |
 | --- | --- | --- |
@@ -130,7 +130,7 @@ None of these tables carry foreign keys; they are linked to campaigns polymorphi
 | `bookmarks` | Per-user page/text bookmark in a book. | FKs `user_id`, `book_id`. Index `ix_bookmarks_user_book` on `(user_id, book_id)`. |
 | `favorites` | Per-user favorite across books/maps/tokens. | FK `user_id`. Polymorphic `(item_type, item_id)`. **Unique** `(user_id, item_type, item_id)`. |
 
-### Campaigns — [`backend/models/campaigns.py`](../backend/models/campaigns.py)
+### Campaigns - [`backend/models/campaigns.py`](../backend/models/campaigns.py)
 
 | Table | Purpose | Key columns / constraints |
 | --- | --- | --- |
@@ -149,7 +149,7 @@ None of these tables carry foreign keys; they are linked to campaigns polymorphi
 | `wiki_page_shares` | A user a `members` wiki page is shared with. | FKs `page_id`, `user_id`. **Unique** `(page_id, user_id)`. |
 | `wiki_page_links` | Resolved `[[wiki link]]` for backlinks. | FKs `campaign_id`, `source_page_id`, `target_page_id`. **Unique** `(source_page_id, target_page_id)`. Rebuilt on every page save. |
 
-### Settings — [`backend/models/settings.py`](../backend/models/settings.py)
+### Settings - [`backend/models/settings.py`](../backend/models/settings.py)
 
 | Table | Purpose | Key columns / constraints |
 | --- | --- | --- |

--- a/docs/docker-install.md
+++ b/docs/docker-install.md
@@ -1,18 +1,18 @@
 # Getting Started with Docker
 
-This guide is for people who have never used Docker before. It will walk you through installing Docker and running Grimoire on your computer — no technical background required.
+This guide is for people who have never used Docker before. It will walk you through installing Docker and running Grimoire on your computer - no technical background required.
 
-> **Note:** This guide sets up Grimoire for **local access only** — meaning you can use it from your own computer (and other devices on your home network). Making it accessible to friends outside your network requires additional steps such as port forwarding, a VPN, or a reverse proxy, which are outside the scope of this guide.
+> **Note:** This guide sets up Grimoire for **local access only** - meaning you can use it from your own computer (and other devices on your home network). Making it accessible to friends outside your network requires additional steps such as port forwarding, a VPN, or a reverse proxy, which are outside the scope of this guide.
 
 ---
 
 ## What is Docker?
 
-Docker is a tool that lets you run applications in a self-contained package called a **container**. You don't need to install Python, configure databases, or set up servers — Docker handles all of that for you. Installing Docker is the only technical step required to run Grimoire.
+Docker is a tool that lets you run applications in a self-contained package called a **container**. You don't need to install Python, configure databases, or set up servers - Docker handles all of that for you. Installing Docker is the only technical step required to run Grimoire.
 
 ---
 
-## Step 1 — Install Docker
+## Step 1 - Install Docker
 
 Follow the instructions for your operating system below.
 
@@ -29,11 +29,11 @@ Follow the instructions for your operating system below.
 ### macOS
 
 1. Go to [https://www.docker.com/products/docker-desktop/](https://www.docker.com/products/docker-desktop/) and click **Download for Mac**.
-   - If your Mac has an **Apple Silicon chip** (M1, M2, M3, or M4), choose **Mac with Apple Silicon**.
-   - If your Mac has an **Intel chip**, choose **Mac with Intel Chip**.
-   - Not sure? Click the Apple menu () → **About This Mac**. Look for "Apple M" (Apple Silicon) or "Intel" in the chip/processor line.
+ - If your Mac has an **Apple Silicon chip** (M1, M2, M3, or M4), choose **Mac with Apple Silicon**.
+ - If your Mac has an **Intel chip**, choose **Mac with Intel Chip**.
+ - Not sure? Click the Apple menu () → **About This Mac**. Look for "Apple M" (Apple Silicon) or "Intel" in the chip/processor line.
 2. Open the downloaded `.dmg` file and drag Docker to your Applications folder.
-3. Open Docker from your Applications folder. You will be asked to allow the installation of a helper component — enter your password when prompted.
+3. Open Docker from your Applications folder. You will be asked to allow the installation of a helper component - enter your password when prompted.
 4. Docker is ready when you see the whale icon in your menu bar.
 
 ### Linux
@@ -55,12 +55,12 @@ The exact steps vary by distribution. The official Docker documentation covers a
 
 ---
 
-## Step 2 — Create Your Folders
+## Step 2 - Create Your Folders
 
 Create two folders somewhere on your computer:
 
-- One for your **library** (PDFs, maps, tokens) — for example `Documents/grimoire/library`
-- One for **app data** (database, thumbnails, search index) — for example `Documents/grimoire/data`
+- One for your **library** (PDFs, maps, tokens) - for example `Documents/grimoire/library`
+- One for **app data** (database, thumbnails, search index) - for example `Documents/grimoire/data`
 
 Inside `library`, create three subfolders:
 
@@ -86,11 +86,11 @@ See the main [README](../README.md#library-structure) for the full folder layout
 
 ---
 
-## Step 3 — Create the Compose File
+## Step 3 - Create the Compose File
 
 Create a new file called `docker-compose.yml` in your Grimoire folder (e.g. `Documents/grimoire/docker-compose.yml`) and paste in the contents below.
 
-Then update the two lines marked with `YOUR` to point to the folders you created in Step 2. Path format differs by OS — see the examples beneath the file.
+Then update the two lines marked with `YOUR` to point to the folders you created in Step 2. Path format differs by OS - see the examples beneath the file.
 
 ```yaml
 services:
@@ -99,25 +99,25 @@ services:
     container_name: grimoire
     restart: unless-stopped
     ports:
-      - "9481:9481"
+ - "9481:9481"
     environment:
-      - LIBRARY_PATH=/library
-      - DATA_PATH=/data
-      - WORKERS=2
-      - SECRET_KEY=replace-this-with-a-long-random-string
-      - VALKEY_URL=redis://valkey:6379/0
+ - LIBRARY_PATH=/library
+ - DATA_PATH=/data
+ - WORKERS=2
+ - SECRET_KEY=replace-this-with-a-long-random-string
+ - VALKEY_URL=redis://valkey:6379/0
     volumes:
-      - /YOUR/LIBRARY/FOLDER:/library:ro
-      - /YOUR/GRIMOIRE/DATA/FOLDER:/data
+ - /YOUR/LIBRARY/FOLDER:/library:ro
+ - /YOUR/GRIMOIRE/DATA/FOLDER:/data
     depends_on:
-      - valkey
+ - valkey
 
   valkey:
     image: valkey/valkey:8-alpine
     container_name: grimoire-valkey
     restart: unless-stopped
     volumes:
-      - valkey-data:/data
+ - valkey-data:/data
 
 volumes:
   valkey-data:
@@ -125,7 +125,7 @@ volumes:
 
 ### Volume path format by OS
 
-Volume paths are written as `your-folder-path:/library:ro` — the part before the `:` is the path on your computer.
+Volume paths are written as `your-folder-path:/library:ro` - the part before the `:` is the path on your computer.
 
 **Windows**
 
@@ -133,37 +133,37 @@ Use forward slashes and include the drive letter:
 
 ```yaml
 volumes:
-  - C:/Users/YourName/Documents/grimoire/library:/library:ro
-  - C:/Users/YourName/Documents/grimoire/data:/data
+ - C:/Users/YourName/Documents/grimoire/library:/library:ro
+ - C:/Users/YourName/Documents/grimoire/data:/data
 ```
 
 **macOS**
 
 ```yaml
 volumes:
-  - /Users/YourName/Documents/grimoire/library:/library:ro
-  - /Users/YourName/Documents/grimoire/data:/data
+ - /Users/YourName/Documents/grimoire/library:/library:ro
+ - /Users/YourName/Documents/grimoire/data:/data
 ```
 
 You can also use `~` as a shorthand for your home folder:
 
 ```yaml
 volumes:
-  - ~/Documents/grimoire/library:/library:ro
-  - ~/Documents/grimoire/data:/data
+ - ~/Documents/grimoire/library:/library:ro
+ - ~/Documents/grimoire/data:/data
 ```
 
 **Linux**
 
 ```yaml
 volumes:
-  - /home/yourname/grimoire/library:/library:ro
-  - /home/yourname/grimoire/data:/data
+ - /home/yourname/grimoire/library:/library:ro
+ - /home/yourname/grimoire/data:/data
 ```
 
 ### Secret key
 
-Also replace the `SECRET_KEY` value with any long, random string — think of it as an internal password for the app. You can mash your keyboard or use a password generator:
+Also replace the `SECRET_KEY` value with any long, random string - think of it as an internal password for the app. You can mash your keyboard or use a password generator:
 
 ```yaml
 - SECRET_KEY=zx7k2mQpR9nLwT4vBcYeHs3JuAoDfGiN
@@ -173,7 +173,7 @@ Save the file when you are done.
 
 ---
 
-## Step 4 — Run Grimoire
+## Step 4 - Run Grimoire
 
 ### Windows
 
@@ -213,7 +213,7 @@ Save the file when you are done.
 
 ---
 
-## Step 5 — Open Grimoire
+## Step 5 - Open Grimoire
 
 Once the command finishes, open your web browser and go to:
 
@@ -221,7 +221,7 @@ Once the command finishes, open your web browser and go to:
 http://localhost:9481
 ```
 
-The first time you visit, you will be prompted to create an admin account. Pick a username and password — this is your login for the app.
+The first time you visit, you will be prompted to create an admin account. Pick a username and password - this is your login for the app.
 
 Grimoire will start indexing your library in the background. For large collections this can take several minutes. You can already browse the app while it works.
 
@@ -263,13 +263,13 @@ Your library and all your data (bookmarks, metadata, accounts) are stored in a s
 **The page won't load at `localhost:9481`**
 - Make sure Docker Desktop is running (check for the whale icon in your taskbar/menu bar).
 - Run `docker compose up -d` again from your Grimoire folder and wait a few seconds before refreshing.
-- Check whether the container reports itself healthy with `docker ps` — the `STATUS` column shows `(healthy)` once Grimoire is serving. If it stays `(unhealthy)`, run `docker compose logs grimoire` to see why.
+- Check whether the container reports itself healthy with `docker ps` - the `STATUS` column shows `(healthy)` once Grimoire is serving. If it stays `(unhealthy)`, run `docker compose logs grimoire` to see why.
 
 **I see an error about the port being in use**
 - Something else on your computer is using port 9481. In `docker-compose.yml`, change `"9481:9481"` to `"9482:9481"` (or any other unused port) and then access the app at `http://localhost:9482`.
 
 **My PDFs are not showing up**
-- Double-check the library path in `docker-compose.yml` — make sure it points to the right folder and uses the correct path format for your OS.
+- Double-check the library path in `docker-compose.yml` - make sure it points to the right folder and uses the correct path format for your OS.
 - After adding new files, use the **Rescan** button in the Grimoire sidebar to pick them up.
 
 **Windows: Docker says WSL 2 is not installed**

--- a/docs/dockerhub.md
+++ b/docs/dockerhub.md
@@ -1,7 +1,7 @@
 <div align="center">
   <img src="frontend/static/android-chrome-192x192.png" alt="Grimoire" width="144">
 
-  # Grimoire — Self-Hosted TTRPG Library Manager
+  # Grimoire - Self-Hosted TTRPG Library Manager
 
   [![Discord](https://img.shields.io/badge/discord-join-5865F2?logo=discord&logoColor=white)](https://discord.gg/9Sd4CGZC63)
   [![CI](https://github.com/hunter-read/grimoire/actions/workflows/ci.yml/badge.svg)](https://github.com/hunter-read/grimoire/actions/workflows/ci.yml)
@@ -31,9 +31,9 @@ pin. Given a release `v1.4.2`, the same image is pushed as `1.4.2`, `1.4`, and
 | Tag       | Example (for release `v1.4.2`) | Updates when you re-pull                                                                 |
 | --------- | ------------------------------ | ---------------------------------------------------------------------------------------- |
 | `latest`  | `latest`                       | Always the most recent stable release. **Recommended for most deployments.**             |
-| `X`       | `1`                            | **Major** version — the newest release in the `1.x.x` line. Follows new features and patches, but never a breaking `2.0.0`. |
-| `X.Y`     | `1.4`                          | **Minor** version — the newest patch in the `1.4.x` line. Gets bug-fix patches only, not the new features introduced by `1.5`. |
-| `X.Y.Z`   | `1.4.2`                        | **Patch** version — an exact, immutable release. Never changes. Use to fully pin a deployment. |
+| `X`       | `1`                            | **Major** version - the newest release in the `1.x.x` line. Follows new features and patches, but never a breaking `2.0.0`. |
+| `X.Y`     | `1.4`                          | **Minor** version - the newest patch in the `1.4.x` line. Gets bug-fix patches only, not the new features introduced by `1.5`. |
+| `X.Y.Z`   | `1.4.2`                        | **Patch** version - an exact, immutable release. Never changes. Use to fully pin a deployment. |
 | `edge`    | `edge`                         | Latest commit on the default branch. Bleeding-edge; may be unstable. Not a release.       |
 
 The version parts follow semantic versioning: the **major** (`X`) bumps for
@@ -63,7 +63,7 @@ of `latest`):
 docker pull hunterreadca/grimoire:slim
 ```
 
-There is no `edge-slim` tag — `edge` is only published as the full (OCR) image.
+There is no `edge-slim` tag - `edge` is only published as the full (OCR) image.
 
 ### Supported Architectures
 
@@ -78,10 +78,10 @@ Docker automatically pulls the correct image for your platform.
 
 ```bash
 docker run -d \
-  --name grimoire \
-  -p 9481:9481 \
-  -v /path/to/library:/library \
-  -v /path/to/data:/data \
+ --name grimoire \
+ -p 9481:9481 \
+ -v /path/to/library:/library \
+ -v /path/to/data:/data \
   hunterreadca/grimoire:latest
 ```
 

--- a/docs/faq.md
+++ b/docs/faq.md
@@ -41,12 +41,12 @@ Grimoire expects a specific folder structure inside your library volume mount. T
 
 If your PDFs live directly under the mounted folder (e.g. `RPGs/<GameSystem>/...` without a `books/` subfolder), the scanner will find nothing.
 
-**Fix** — mount your library folder as `/app/library/books` instead of `/app/library`:
+**Fix** - mount your library folder as `/app/library/books` instead of `/app/library`:
 
 ```yaml
 volumes:
-  - /path/to/your/rpgs:/app/library/books:ro
-  - ./grimoire/data:/app/data
+ - /path/to/your/rpgs:/app/library/books:ro
+ - ./grimoire/data:/app/data
 ```
 
 This lets you keep your existing file structure on the host without adding an extra `books/` folder. After updating the compose file, restart the stack and trigger a rescan from the admin panel.
@@ -77,7 +77,7 @@ Assign your users to the appropriate groups.
 Go to **Customization → Property Mappings** and create two **Scope Mappings**.
 
 **Name: `Grimoire Groups`**
-**Scope: `groups`** — maps Authentik groups to Grimoire roles:
+**Scope: `groups`** - maps Authentik groups to Grimoire roles:
 
 ```python
 groups = [group.name for group in user.ak_groups.all()]
@@ -94,7 +94,7 @@ return {"groups": grimoire_groups}
 ```
 
 **Name: `Grimoire Permissions`**
-**Scope: `permissions`** — controls explicit content access:
+**Scope: `permissions`** - controls explicit content access:
 
 ```python
 groups = [group.name for group in user.ak_groups.all()]

--- a/docs/file-management.md
+++ b/docs/file-management.md
@@ -1,6 +1,6 @@
 # Adding Files to Your Library
 
-Grimoire is a **read-only viewer** — it never modifies the files in your library folder. This keeps your source files safe and lets you use whatever file manager you prefer to add, organize, and remove content.
+Grimoire is a **read-only viewer** - it never modifies the files in your library folder. This keeps your source files safe and lets you use whatever file manager you prefer to add, organize, and remove content.
 
 Two tools integrate especially well with Grimoire:
 
@@ -15,7 +15,7 @@ Both run as Docker containers sharing the same library volume as Grimoire. After
 
 ## Filebrowser Quantum
 
-[Filebrowser Quantum](https://github.com/gtsteffaniak/filebrowser) is a lightweight, browser-based file manager. Use it to upload PDFs, create folders, rename or move files, and delete content — all from a web UI with no software to install on your local machine.
+[Filebrowser Quantum](https://github.com/gtsteffaniak/filebrowser) is a lightweight, browser-based file manager. Use it to upload PDFs, create folders, rename or move files, and delete content - all from a web UI with no software to install on your local machine.
 
 ### How it works with Grimoire
 
@@ -33,7 +33,7 @@ docker compose up -d
 
 See [`docs/docker/docker-compose.filebrowser.yml`](./docker/docker-compose.filebrowser.yml) for the full file with inline comments.
 
-Access Filebrowser at `http://localhost:8080`. Default credentials are `admin` / `admin` — change these immediately in the settings.
+Access Filebrowser at `http://localhost:8080`. Default credentials are `admin` / `admin` - change these immediately in the settings.
 
 ### Recommended folder layout
 
@@ -56,7 +56,7 @@ See [Library Structure](../README.md#library-structure) for the full folder conv
 
 ## Calibre
 
-[Calibre](https://calibre-ebook.com/) is a full-featured ebook management application. Its [Content Server](https://manual.calibre-ebook.com/server.html) exposes a web UI for browsing and uploading books. Beyond uploads, Calibre's main value here is its metadata editing — it can write `.opf` sidecar files that Grimoire reads automatically on the next scan to populate titles, authors, publishers, descriptions, and tags.
+[Calibre](https://calibre-ebook.com/) is a full-featured ebook management application. Its [Content Server](https://manual.calibre-ebook.com/server.html) exposes a web UI for browsing and uploading books. Beyond uploads, Calibre's main value here is its metadata editing - it can write `.opf` sidecar files that Grimoire reads automatically on the next scan to populate titles, authors, publishers, descriptions, and tags.
 
 ### How it works with Grimoire
 
@@ -119,6 +119,6 @@ Point Calibre-Web at `/library/books` as its library path on first setup.
 Regardless of which tool you use, trigger a rescan in Grimoire to index new content:
 
 1. Click **Rescan** in the sidebar, or go to **Settings → Maintenance → Rescan Library**.
-2. Wait for the scan to complete — new books, maps, and tokens will appear.
+2. Wait for the scan to complete - new books, maps, and tokens will appear.
 
 To automate this, configure a scheduled rescan in **Settings → Maintenance → Scheduled Rescan**.

--- a/docs/pipelines.md
+++ b/docs/pipelines.md
@@ -25,14 +25,14 @@ Runs on every push to `main`/`dev` and on all pull requests. Validates the chang
 publishing anything. Two jobs run in parallel:
 
 **Frontend (`frontend/`):**
-- `npm run format:check` — Prettier formatting
-- `npm run lint` — ESLint (errors fail CI)
-- `npm run test:coverage` — Vitest with coverage
-- `npm run build` — production build (catches broken imports / JSX errors)
+- `npm run format:check` - Prettier formatting
+- `npm run lint` - ESLint (errors fail CI)
+- `npm run test:coverage` - Vitest with coverage
+- `npm run build` - production build (catches broken imports / JSX errors)
 
 **Backend:**
-- `ruff check backend/` — lint
-- `python -c "import backend.main"` — import smoke check
+- `ruff check backend/` - lint
+- `python -c "import backend.main"` - import smoke check
 - `pytest` with coverage
 
 **Per-changed-file coverage gate (PRs only):** on pull requests, each job additionally runs
@@ -46,7 +46,7 @@ On **push to `main` only**, each job extracts its total line-coverage % (fronten
 `coverage/coverage-summary.json`, backend from coverage.py's `coverage.json`) and publishes it
 to a [Shields.io endpoint](https://shields.io/badges/endpoint-badge) badge stored in a GitHub
 Gist via [`schneegans/dynamic-badges-action`](https://github.com/schneegans/dynamic-badges-action).
-No third-party service ingests the code — the badge JSON lives in a gist you own. The badges
+No third-party service ingests the code - the badge JSON lives in a gist you own. The badges
 render in the [README](../README.md) badge row.
 
 **One-time setup** (already done for this repo; documented for forks):
@@ -65,7 +65,7 @@ render in the [README](../README.md) badge row.
 ### Note: the `dev → main` PR runs once, not twice
 
 A direct push to `dev` while the `dev → main` pull request is open would normally make CI run
-twice for the same commit — once for the `push` event and once for the `pull_request` event.
+twice for the same commit - once for the `push` event and once for the `pull_request` event.
 To avoid that (and the duplicate downstream **Edge** build it caused), both CI jobs are
 guarded to skip the `pull_request` run when the PR's head branch is `dev`:
 
@@ -100,13 +100,13 @@ runs when:
 - the CI run's triggering event was `push`.
 
 **What it produces:**
-- `hunterreadca/grimoire:edge` — multi-arch (`linux/amd64`, `linux/arm64/v8`), built from the
+- `hunterreadca/grimoire:edge` - multi-arch (`linux/amd64`, `linux/arm64/v8`), built from the
   Dockerfile's `ocr` target (bundles Tesseract OCR).
 
 Built with `APP_VERSION=edge` and the triggering commit SHA. Uses the GitHub Actions build
 cache (`type=gha`) to keep rebuilds fast.
 
-> **Edge is unstable.** It tracks `dev` and can change or break at any time — use it only for
+> **Edge is unstable.** It tracks `dev` and can change or break at any time - use it only for
 > testing upcoming changes, not for a production deployment.
 
 ---
@@ -124,20 +124,20 @@ git tag v1.5.0        # must match vX.Y.Z
 git push origin v1.5.0
 ```
 
-Pushing the tag is the entire trigger — there are no manual workflow inputs.
+Pushing the tag is the entire trigger - there are no manual workflow inputs.
 
 ### What it does
 
 The tag `v1.5.0` is parsed into `version=1.5.0`, `minor=1.5`, and `major=1`, then the workflow
 builds and pushes **two** multi-arch image variants (`linux/amd64`, `linux/arm64/v8`):
 
-**OCR (default) — Dockerfile `ocr` target, bundles Tesseract:**
+**OCR (default) - Dockerfile `ocr` target, bundles Tesseract:**
 - `hunterreadca/grimoire:latest`
 - `hunterreadca/grimoire:1`
 - `hunterreadca/grimoire:1.5`
 - `hunterreadca/grimoire:1.5.0`
 
-**Slim — Dockerfile `slim` target, no OCR engine, smaller image:**
+**Slim - Dockerfile `slim` target, no OCR engine, smaller image:**
 - `hunterreadca/grimoire:slim`
 - `hunterreadca/grimoire:1-slim`
 - `hunterreadca/grimoire:1.5-slim`
@@ -161,9 +161,9 @@ docker pull hunterreadca/grimoire:1.5.0-slim   # slim variant
 
 Grimoire follows [Semantic Versioning](https://semver.org/):
 
-- **PATCH** (`x.y.Z`) — bug fixes, dependency bumps, small tweaks
-- **MINOR** (`x.Y.0`) — new features, backwards-compatible
-- **MAJOR** (`X.0.0`) — breaking changes (config format, API, data migration required)
+- **PATCH** (`x.y.Z`) - bug fixes, dependency bumps, small tweaks
+- **MINOR** (`x.Y.0`) - new features, backwards-compatible
+- **MAJOR** (`X.0.0`) - breaking changes (config format, API, data migration required)
 
 The rolling `major` (`:1`) and `minor` (`:1.5`) tags let deployments pin to a compatibility
 level and still pick up patch updates. Because schema migrations run automatically on startup

--- a/docs/running-from-source.md
+++ b/docs/running-from-source.md
@@ -2,8 +2,8 @@
 
 Grimoire ships as a Docker image and that's the recommended way to run it (see the
 [README Quick Start](../README.md#quick-start)). If you'd rather build the image yourself
-or run the app directly on the host — for development, or on a platform where Docker isn't
-an option — this guide covers both.
+or run the app directly on the host - for development, or on a platform where Docker isn't
+an option - this guide covers both.
 
 For contributor setup (local dev environment, tests, coding standards) see
 [CONTRIBUTING.md](../.github/CONTRIBUTING.md).
@@ -66,7 +66,7 @@ uvicorn backend.main:app --host 0.0.0.0 --port 9481
 
 Open `http://localhost:9481`. On first launch you'll be prompted to create an admin account.
 
-Persistent data and upgrades work the same as under Docker — see
+Persistent data and upgrades work the same as under Docker - see
 [Persistent data](../README.md#persistent-data) and [Upgrading](../README.md#upgrading).
 
 ### Optional: Valkey/Redis page cache

--- a/frontend/src/components/ReocrButton.jsx
+++ b/frontend/src/components/ReocrButton.jsx
@@ -1,0 +1,168 @@
+import { useState, useRef, useEffect, useCallback } from 'react'
+import { createPortal } from 'react-dom'
+import { useTranslation } from 'react-i18next'
+import { LuScanText } from 'react-icons/lu'
+import api from '../api'
+
+const POPOVER_WIDTH = 220
+
+/**
+ * Per-book re-OCR action. Shown only for scanned/OCR'd books (an embedded-text
+ * book has nothing to re-read). Clicking opens a small popover to optionally set
+ * a DPI, then POSTs to /books/:id/reindex — the server clears the book's search
+ * index and re-queues it for OCR in the background.
+ *
+ * The popover is portalled to document.body at fixed coordinates so it isn't
+ * clipped by the book row's `overflow: hidden` (used for the progress bar).
+ *
+ * Props:
+ *   book     – the book object (needs id and ocr_dpi)
+ *   onQueued – optional callback fired after a successful queue
+ */
+export default function ReocrButton({ book, onQueued }) {
+  const { t } = useTranslation()
+  const [open, setOpen] = useState(false)
+  const [coords, setCoords] = useState({ top: 0, left: 0 })
+  const [dpi, setDpi] = useState(book.ocr_dpi ? String(book.ocr_dpi) : '')
+  const [state, setState] = useState('idle') // idle | working | queued | error
+  const triggerRef = useRef(null)
+  const popoverRef = useRef(null)
+
+  // Right-align the popover under the trigger, clamped to the viewport.
+  const place = useCallback(() => {
+    const el = triggerRef.current
+    if (!el) return
+    const r = el.getBoundingClientRect()
+    const margin = 8
+    let left = r.right - POPOVER_WIDTH
+    left = Math.max(margin, Math.min(left, window.innerWidth - margin - POPOVER_WIDTH))
+    setCoords({ top: r.bottom + 4, left })
+  }, [])
+
+  useEffect(() => {
+    if (!open) return
+    place()
+    const onDoc = (e) => {
+      if (triggerRef.current?.contains(e.target) || popoverRef.current?.contains(e.target)) return
+      setOpen(false)
+    }
+    const onReposition = () => place()
+    document.addEventListener('mousedown', onDoc)
+    window.addEventListener('resize', onReposition)
+    window.addEventListener('scroll', onReposition, true)
+    return () => {
+      document.removeEventListener('mousedown', onDoc)
+      window.removeEventListener('resize', onReposition)
+      window.removeEventListener('scroll', onReposition, true)
+    }
+  }, [open, place])
+
+  const submit = (e) => {
+    e.stopPropagation()
+    setState('working')
+    const value = dpi.trim() ? parseInt(dpi, 10) : null
+    const qs = value ? `?ocr_dpi=${value}` : ''
+    api
+      .post(`/books/${book.id}/reindex${qs}`)
+      .then(() => {
+        setState('queued')
+        onQueued?.()
+        setTimeout(() => setOpen(false), 1200)
+      })
+      .catch(() => setState('error'))
+  }
+
+  const label = t('reocr.button')
+
+  return (
+    <>
+      <button
+        ref={triggerRef}
+        onClick={(e) => {
+          e.stopPropagation()
+          setOpen((o) => !o)
+          setState('idle')
+        }}
+        aria-label={label}
+        aria-haspopup="dialog"
+        aria-expanded={open}
+        title={label}
+        style={{
+          background: 'none',
+          border: 'none',
+          cursor: 'pointer',
+          display: 'flex',
+          padding: '6px',
+          color: open ? 'var(--gold)' : 'var(--text-muted)',
+        }}
+      >
+        <LuScanText size={16} aria-hidden="true" />
+      </button>
+
+      {open &&
+        createPortal(
+          <div
+            ref={popoverRef}
+            onClick={(e) => e.stopPropagation()}
+            style={{
+              position: 'fixed',
+              top: coords.top,
+              left: coords.left,
+              zIndex: 2000,
+              width: POPOVER_WIDTH,
+              padding: 12,
+              borderRadius: 8,
+              background: 'var(--bg-panel)',
+              border: '1px solid var(--border)',
+              boxShadow: '0 6px 20px rgba(0,0,0,0.35)',
+            }}
+          >
+            <div style={{ fontSize: 12, color: 'var(--text-dim)', marginBottom: 6 }}>
+              {t('reocr.title')}
+            </div>
+            <div style={{ display: 'flex', gap: 6, alignItems: 'center' }}>
+              <input
+                type="number"
+                min="72"
+                max="600"
+                step="10"
+                value={dpi}
+                onChange={(e) => setDpi(e.target.value)}
+                placeholder={t('reocr.dpiPlaceholder')}
+                aria-label={t('reocr.dpiLabel')}
+                style={{ width: 90, fontSize: 13 }}
+              />
+              <button
+                onClick={submit}
+                disabled={state === 'working' || state === 'queued'}
+                style={{
+                  flex: 1,
+                  padding: '5px 8px',
+                  borderRadius: 5,
+                  background: 'var(--gold-dim)',
+                  border: 'none',
+                  color: 'var(--bg-deep)',
+                  fontSize: 12,
+                  fontWeight: 600,
+                  cursor: state === 'working' || state === 'queued' ? 'default' : 'pointer',
+                }}
+              >
+                {state === 'working'
+                  ? t('reocr.working')
+                  : state === 'queued'
+                    ? `✓ ${t('reocr.queued')}`
+                    : t('reocr.run')}
+              </button>
+            </div>
+            {state === 'error' && (
+              <div style={{ fontSize: 11, color: '#e07070', marginTop: 6 }}>{t('reocr.error')}</div>
+            )}
+            <div style={{ fontSize: 11, color: 'var(--text-muted)', marginTop: 6 }}>
+              {t('reocr.hint')}
+            </div>
+          </div>,
+          document.body
+        )}
+    </>
+  )
+}

--- a/frontend/src/components/ReocrButton.test.jsx
+++ b/frontend/src/components/ReocrButton.test.jsx
@@ -1,0 +1,71 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { render, screen, fireEvent, waitFor } from '@testing-library/react'
+import ReocrButton from './ReocrButton'
+
+vi.mock('react-i18next', () => ({
+  useTranslation: () => ({ t: (k) => k }),
+}))
+
+const mockPost = vi.fn(() => Promise.resolve({}))
+vi.mock('../api', () => ({
+  default: {
+    post: (...args) => mockPost(...args),
+  },
+}))
+
+function renderBtn(book = {}) {
+  return render(<ReocrButton book={{ id: 'b1', ...book }} />)
+}
+
+describe('ReocrButton', () => {
+  beforeEach(() => {
+    mockPost.mockClear()
+    mockPost.mockResolvedValue({})
+  })
+
+  it('opens a DPI popover on click', () => {
+    renderBtn()
+    expect(screen.queryByText('reocr.run')).not.toBeInTheDocument()
+    fireEvent.click(screen.getByLabelText('reocr.button'))
+    expect(screen.getByText('reocr.run')).toBeInTheDocument()
+  })
+
+  it('portals the popover to document.body so it escapes the row clip', () => {
+    const { container } = renderBtn()
+    fireEvent.click(screen.getByLabelText('reocr.button'))
+    // The popover renders outside the component's own DOM subtree (into body).
+    expect(container.querySelector('input[type="number"]')).toBeNull()
+    const popover = screen.getByLabelText('reocr.dpiLabel')
+    expect(popover.closest('div[style*="position: fixed"]')).not.toBeNull()
+  })
+
+  it('posts with no DPI when the field is left blank', async () => {
+    renderBtn({ id: 'b2' })
+    fireEvent.click(screen.getByLabelText('reocr.button'))
+    fireEvent.click(screen.getByText('reocr.run'))
+    await waitFor(() => expect(mockPost).toHaveBeenCalledWith('/books/b2/reindex'))
+    expect(screen.getByText(/reocr.queued/)).toBeInTheDocument()
+  })
+
+  it('posts the entered DPI as a query param', async () => {
+    renderBtn({ id: 'b3' })
+    fireEvent.click(screen.getByLabelText('reocr.button'))
+    fireEvent.change(screen.getByLabelText('reocr.dpiLabel'), { target: { value: '300' } })
+    fireEvent.click(screen.getByText('reocr.run'))
+    await waitFor(() => expect(mockPost).toHaveBeenCalledWith('/books/b3/reindex?ocr_dpi=300'))
+  })
+
+  it('seeds the DPI field from an existing per-book override', () => {
+    renderBtn({ id: 'b4', ocr_dpi: 250 })
+    fireEvent.click(screen.getByLabelText('reocr.button'))
+    expect(screen.getByLabelText('reocr.dpiLabel')).toHaveValue(250)
+  })
+
+  it('shows an error when the request fails', async () => {
+    mockPost.mockRejectedValueOnce(new Error('boom'))
+    renderBtn({ id: 'b5' })
+    fireEvent.click(screen.getByLabelText('reocr.button'))
+    fireEvent.click(screen.getByText('reocr.run'))
+    await waitFor(() => expect(screen.getByText('reocr.error')).toBeInTheDocument())
+  })
+})

--- a/frontend/src/components/RescanButton.jsx
+++ b/frontend/src/components/RescanButton.jsx
@@ -47,10 +47,15 @@ export default function RescanButton({ scope = null, compact = true, label }) {
         style={{
           display: 'inline-flex',
           alignItems: 'center',
+          justifyContent: 'center',
           gap: compact ? 0 : 6,
           padding: compact ? '2px 7px' : '6px 12px',
           borderRadius: compact ? 5 : 6,
           fontSize: compact ? 12 : 14,
+          // Match the sibling Download button's content height (18px line box)
+          // so an icon-only compact button isn't shorter than a text button.
+          lineHeight: compact ? '18px' : undefined,
+          minHeight: compact ? 18 : undefined,
           flexShrink: 0,
           color: running ? 'var(--gold)' : 'var(--text-muted)',
           border: '1px solid var(--border)',

--- a/frontend/src/components/media/MediaFolderGroup.jsx
+++ b/frontend/src/components/media/MediaFolderGroup.jsx
@@ -317,6 +317,25 @@ export default function MediaFolderGroup({
                             onSave={(newTags) => onSaveFolderTags(folderPath, newTags)}
                             onCancel={() => onSetEditingFolder(null)}
                           />
+                          {isAudio && (
+                            <button
+                              onClick={(e) => {
+                                e.stopPropagation()
+                                const tracks = subItems
+                                  .filter((i) => !i.is_missing)
+                                  .map((i) => ({
+                                    id: i.id,
+                                    title: i.title || i.filename,
+                                    artwork: i.has_artwork,
+                                  }))
+                                playQueue(tracks)
+                              }}
+                              style={zipBtnStyle}
+                              title={t('audio.playFolder', { folder: subPath })}
+                            >
+                              <LuPlay size={11} /> {t('audio.player.play')}
+                            </button>
+                          )}
                           <button
                             onClick={(e) => {
                               e.stopPropagation()

--- a/frontend/src/components/media/MediaFolderGroup.test.jsx
+++ b/frontend/src/components/media/MediaFolderGroup.test.jsx
@@ -245,4 +245,24 @@ describe('MediaFolderGroup — audio', () => {
     const queued = playQueue.mock.calls[0][0].map((t) => t.id)
     expect(queued).toEqual(['a1', 'a2'])
   })
+
+  it('shows a per-subfolder Play button that queues only that subfolder', async () => {
+    render(
+      <MediaFolderGroup
+        config={MEDIA_CONFIGS.audio}
+        folder="Ambient"
+        subfolders={{
+          '': [{ id: 'a1', filename: 't1.mp3', is_missing: false }],
+          battle: [
+            { id: 'a2', filename: 't2.mp3', is_missing: false },
+            { id: 'a3', filename: 'gone.mp3', is_missing: true },
+          ],
+        }}
+        {...baseProps()}
+      />
+    )
+    await userEvent.click(screen.getByTitle(/play battle/i))
+    // Only the subfolder's non-missing tracks are queued.
+    expect(playQueue).toHaveBeenLastCalledWith([expect.objectContaining({ id: 'a2' })])
+  })
 })

--- a/frontend/src/components/settings/RescanSection.jsx
+++ b/frontend/src/components/settings/RescanSection.jsx
@@ -25,12 +25,16 @@ export default function RescanSection() {
     scanned_maps,
     total_tokens,
     scanned_tokens,
+    total_ocr,
+    ocr_done,
+    ocr_current,
   } = status
 
   const totalScan = total_books + total_maps + total_tokens
   const scannedScan = scanned_books + scanned_maps + scanned_tokens
   const scanPct = totalScan > 0 ? Math.round((scannedScan / totalScan) * 100) : null
   const indexPct = to_index > 0 ? Math.round((indexed / to_index) * 100) : 0
+  const ocrPct = total_ocr > 0 ? Math.round((ocr_done / total_ocr) * 100) : 0
 
   const phaseLabel =
     phase === 'scanning'
@@ -39,7 +43,9 @@ export default function RescanSection() {
         : t('maintenance.rescan.scanning')
       : phase === 'indexing'
         ? t('maintenance.rescan.indexing', { indexed, total: to_index })
-        : t('maintenance.rescan.scanning')
+        : phase === 'ocr'
+          ? t('maintenance.rescan.ocr', { done: ocr_done, total: total_ocr })
+          : t('maintenance.rescan.scanning')
 
   return (
     <div style={{ marginBottom: 40 }}>
@@ -186,6 +192,47 @@ export default function RescanSection() {
           <div style={{ marginTop: 5, fontSize: 12, color: 'var(--text-muted)' }}>
             {t('maintenance.rescan.indexProgress', { pct: indexPct, indexed, total: to_index })}
           </div>
+        </div>
+      )}
+
+      {/* Progress bar — deferred OCR phase */}
+      {running && phase === 'ocr' && total_ocr > 0 && (
+        <div style={{ marginTop: 12, maxWidth: 360 }}>
+          <div
+            style={{ height: 4, borderRadius: 2, background: 'var(--border)', overflow: 'hidden' }}
+          >
+            <div
+              style={{
+                height: '100%',
+                borderRadius: 2,
+                background: 'var(--gold)',
+                width: `${ocrPct}%`,
+                transition: 'width 0.4s ease',
+              }}
+            />
+          </div>
+          <div style={{ marginTop: 5, fontSize: 12, color: 'var(--text-muted)' }}>
+            {t('maintenance.rescan.ocrProgress', {
+              pct: ocrPct,
+              done: ocr_done,
+              total: total_ocr,
+            })}
+          </div>
+          {ocr_current && (
+            <div
+              style={{
+                marginTop: 3,
+                fontSize: 12,
+                color: 'var(--text-muted)',
+                overflow: 'hidden',
+                textOverflow: 'ellipsis',
+                whiteSpace: 'nowrap',
+              }}
+              title={ocr_current}
+            >
+              {t('maintenance.rescan.ocrCurrent', { name: ocr_current })}
+            </div>
+          )}
         </div>
       )}
 

--- a/frontend/src/components/system/BookFolderGroup.jsx
+++ b/frontend/src/components/system/BookFolderGroup.jsx
@@ -181,6 +181,7 @@ const zipBtnStyle = {
   padding: '2px 7px',
   borderRadius: 5,
   fontSize: 12,
+  lineHeight: '18px',
   flexShrink: 0,
   color: 'var(--text-muted)',
   border: '1px solid var(--border)',

--- a/frontend/src/components/system/BookRow.jsx
+++ b/frontend/src/components/system/BookRow.jsx
@@ -15,6 +15,7 @@ import { useFavorites } from '../../context/FavoritesContext'
 import { getBookPrefs } from '../../hooks/useBookPrefs'
 import FavoriteButton from '../FavoriteButton'
 import DownloadButton from '../DownloadButton'
+import ReocrButton from '../ReocrButton'
 
 /**
  * A single book entry. Renders as a list row by default; pass `card` or
@@ -42,6 +43,10 @@ export default function BookRow({
   const lastPage = getBookPrefs(book.id).page || 0
   const progress = book.page_count > 0 && lastPage > 1 ? Math.min(lastPage / book.page_count, 1) : 0
   const fav = isFavorite('book', book.id)
+  // Re-OCR is offered only for scanned/OCR'd books and only to editors (onEdit
+  // is passed only for gm/admin). A book with an embedded text layer has nothing
+  // to re-OCR.
+  const isOcrBook = book.index_error === 'ocr' || book.index_error === 'image-only'
 
   const handleClick = (e) => {
     if (bulkMode) {
@@ -110,6 +115,7 @@ export default function BookRow({
           pointerEvents: visible ? 'auto' : 'none',
         }}
       >
+        {onEdit && isOcrBook && <ReocrButton book={book} />}
         <a
           href={mediaUrl(`/books/${book.id}/file`)}
           download

--- a/frontend/src/locales/de-DE.json
+++ b/frontend/src/locales/de-DE.json
@@ -100,7 +100,11 @@
     "haveInviteCode": "Einladungscode vorhanden?",
     "inviteCode": "Einladungscode",
     "enterAsGuest": "Als Gast eintreten",
-    "guestInvalidCode": "Ungültiger oder abgelaufener Einladungscode."
+    "guestInvalidCode": "Ungültiger oder abgelaufener Einladungscode.",
+    "show": "Anzeigen",
+    "hide": "Verbergen",
+    "showPassword": "Passwort anzeigen",
+    "hidePassword": "Passwort verbergen"
   },
   "setup": {
     "title": "Ersteinrichtung",
@@ -575,6 +579,9 @@
       "scanning": "Scannen…",
       "scanningPercent": "Scannen… {{pct}}%",
       "indexing": "PDFs indizieren… {{indexed}} / {{total}}",
+      "ocr": "OCR… {{done}} / {{total}}",
+      "ocrProgress": "{{pct}}% — {{done}} von {{total}} gescannten Büchern per OCR erfasst",
+      "ocrCurrent": "Aktuell: {{name}}",
       "stop": "Stoppen",
       "stopping": "Wird gestoppt…",
       "complete": "Scan abgeschlossen",
@@ -1061,6 +1068,17 @@
     "failed": "Speichern fehlgeschlagen.",
     "resetProgress": "Lesefortschritt zurücksetzen",
     "progressReset": "Fortschritt zurückgesetzt"
+  },
+  "reocr": {
+    "button": "OCR wiederholen",
+    "title": "OCR mit höherer DPI wiederholen",
+    "dpiPlaceholder": "z. B. 300",
+    "dpiLabel": "OCR-Auflösung (DPI)",
+    "run": "Starten",
+    "working": "Läuft…",
+    "queued": "Eingereiht",
+    "error": "Re-OCR konnte nicht eingereiht werden",
+    "hint": "Liest dieses gescannte Buch neu ein. DPI leer lassen für den Standard oder erhöhen (z. B. 300) für ein schärferes Ergebnis. Läuft im Hintergrund."
   },
   "bookRow": {
     "missingFile": "Fehlend",

--- a/frontend/src/locales/en-CA.json
+++ b/frontend/src/locales/en-CA.json
@@ -100,7 +100,11 @@
     "haveInviteCode": "Have an invite code?",
     "inviteCode": "Invite Code",
     "enterAsGuest": "Enter as Guest",
-    "guestInvalidCode": "Invalid or expired invite code."
+    "guestInvalidCode": "Invalid or expired invite code.",
+    "show": "Show",
+    "hide": "Hide",
+    "showPassword": "Show password",
+    "hidePassword": "Hide password"
   },
   "setup": {
     "title": "First-Time Setup",
@@ -575,6 +579,9 @@
       "scanning": "Scanning…",
       "scanningPercent": "Scanning… {{pct}}%",
       "indexing": "Indexing PDFs… {{indexed}} / {{total}}",
+      "ocr": "OCR… {{done}} / {{total}}",
+      "ocrProgress": "{{pct}}% — {{done}} of {{total}} scanned books OCR'd",
+      "ocrCurrent": "Current: {{name}}",
       "stop": "Stop",
       "stopping": "Stopping…",
       "complete": "Scan complete",
@@ -1061,6 +1068,17 @@
     "failed": "Failed to save.",
     "resetProgress": "Reset reading progress",
     "progressReset": "Progress reset"
+  },
+  "reocr": {
+    "button": "Re-OCR",
+    "title": "Re-run OCR at a higher DPI",
+    "dpiPlaceholder": "e.g. 300",
+    "dpiLabel": "OCR resolution (DPI)",
+    "run": "Run",
+    "working": "Working…",
+    "queued": "Queued",
+    "error": "Failed to queue re-OCR",
+    "hint": "Re-reads this scanned book. Leave DPI blank for the default, or raise it (e.g. 300) for a sharper read. Runs in the background."
   },
   "bookRow": {
     "missingFile": "Missing",

--- a/frontend/src/locales/en-US.json
+++ b/frontend/src/locales/en-US.json
@@ -100,7 +100,11 @@
     "haveInviteCode": "Have an invite code?",
     "inviteCode": "Invite Code",
     "enterAsGuest": "Enter as Guest",
-    "guestInvalidCode": "Invalid or expired invite code."
+    "guestInvalidCode": "Invalid or expired invite code.",
+    "show": "Show",
+    "hide": "Hide",
+    "showPassword": "Show password",
+    "hidePassword": "Hide password"
   },
   "setup": {
     "title": "First-Time Setup",
@@ -575,6 +579,9 @@
       "scanning": "Scanning…",
       "scanningPercent": "Scanning… {{pct}}%",
       "indexing": "Indexing PDFs… {{indexed}} / {{total}}",
+      "ocr": "OCR… {{done}} / {{total}}",
+      "ocrProgress": "{{pct}}% — {{done}} of {{total}} scanned books OCR'd",
+      "ocrCurrent": "Current: {{name}}",
       "stop": "Stop",
       "stopping": "Stopping…",
       "complete": "Scan complete",
@@ -1061,6 +1068,17 @@
     "failed": "Failed to save.",
     "resetProgress": "Reset reading progress",
     "progressReset": "Progress reset"
+  },
+  "reocr": {
+    "button": "Re-OCR",
+    "title": "Re-run OCR at a higher DPI",
+    "dpiPlaceholder": "e.g. 300",
+    "dpiLabel": "OCR resolution (DPI)",
+    "run": "Run",
+    "working": "Working…",
+    "queued": "Queued",
+    "error": "Failed to queue re-OCR",
+    "hint": "Re-reads this scanned book. Leave DPI blank for the default, or raise it (e.g. 300) for a sharper read. Runs in the background."
   },
   "bookRow": {
     "missingFile": "Missing",

--- a/frontend/src/locales/es-ES.json
+++ b/frontend/src/locales/es-ES.json
@@ -100,7 +100,11 @@
     "haveInviteCode": "¿Tienes un código de invitación?",
     "inviteCode": "Código de invitación",
     "enterAsGuest": "Entrar como invitado",
-    "guestInvalidCode": "Código de invitación no válido o caducado."
+    "guestInvalidCode": "Código de invitación no válido o caducado.",
+    "show": "Mostrar",
+    "hide": "Ocultar",
+    "showPassword": "Mostrar contraseña",
+    "hidePassword": "Ocultar contraseña"
   },
   "setup": {
     "title": "Configuración inicial",
@@ -575,6 +579,9 @@
       "scanning": "Escaneando…",
       "scanningPercent": "Escaneando… {{pct}}%",
       "indexing": "Indexando PDF… {{indexed}} / {{total}}",
+      "ocr": "OCR… {{done}} / {{total}}",
+      "ocrProgress": "{{pct}}% — {{done}} de {{total}} libros escaneados procesados con OCR",
+      "ocrCurrent": "Actual: {{name}}",
       "stop": "Detener",
       "stopping": "Deteniendo…",
       "complete": "Escaneo completado",
@@ -1061,6 +1068,17 @@
     "failed": "Error al guardar.",
     "resetProgress": "Restablecer progreso de lectura",
     "progressReset": "Progreso restablecido"
+  },
+  "reocr": {
+    "button": "Repetir OCR",
+    "title": "Repetir OCR con mayor DPI",
+    "dpiPlaceholder": "p. ej. 300",
+    "dpiLabel": "Resolución de OCR (DPI)",
+    "run": "Ejecutar",
+    "working": "Procesando…",
+    "queued": "En cola",
+    "error": "No se pudo poner en cola el OCR",
+    "hint": "Vuelve a leer este libro escaneado. Deja el DPI en blanco para el valor predeterminado o súbelo (p. ej. 300) para una lectura más nítida. Se ejecuta en segundo plano."
   },
   "bookRow": {
     "missingFile": "Ausente",

--- a/frontend/src/locales/es-MX.json
+++ b/frontend/src/locales/es-MX.json
@@ -100,7 +100,11 @@
     "haveInviteCode": "¿Tienes un código de invitación?",
     "inviteCode": "Código de invitación",
     "enterAsGuest": "Entrar como invitado",
-    "guestInvalidCode": "Código de invitación no válido o caducado."
+    "guestInvalidCode": "Código de invitación no válido o caducado.",
+    "show": "Mostrar",
+    "hide": "Ocultar",
+    "showPassword": "Mostrar contraseña",
+    "hidePassword": "Ocultar contraseña"
   },
   "setup": {
     "title": "Configuración inicial",
@@ -575,6 +579,9 @@
       "scanning": "Escaneando…",
       "scanningPercent": "Escaneando… {{pct}}%",
       "indexing": "Indexando PDF… {{indexed}} / {{total}}",
+      "ocr": "OCR… {{done}} / {{total}}",
+      "ocrProgress": "{{pct}}% — {{done}} de {{total}} libros escaneados procesados con OCR",
+      "ocrCurrent": "Actual: {{name}}",
       "stop": "Detener",
       "stopping": "Deteniendo…",
       "complete": "Escaneo completado",
@@ -1061,6 +1068,17 @@
     "failed": "Error al guardar.",
     "resetProgress": "Restablecer progreso de lectura",
     "progressReset": "Progreso restablecido"
+  },
+  "reocr": {
+    "button": "Repetir OCR",
+    "title": "Repetir OCR con mayor DPI",
+    "dpiPlaceholder": "p. ej. 300",
+    "dpiLabel": "Resolución de OCR (DPI)",
+    "run": "Ejecutar",
+    "working": "Procesando…",
+    "queued": "En cola",
+    "error": "No se pudo poner en cola el OCR",
+    "hint": "Vuelve a leer este libro escaneado. Deja el DPI en blanco para el valor predeterminado o súbelo (p. ej. 300) para una lectura más nítida. Se ejecuta en segundo plano."
   },
   "bookRow": {
     "missingFile": "Ausente",

--- a/frontend/src/locales/fr-CA.json
+++ b/frontend/src/locales/fr-CA.json
@@ -100,7 +100,11 @@
     "haveInviteCode": "Vous avez un code d'invitation ?",
     "inviteCode": "Code d'invitation",
     "enterAsGuest": "Entrer en tant qu'invité",
-    "guestInvalidCode": "Code d'invitation invalide ou expiré."
+    "guestInvalidCode": "Code d'invitation invalide ou expiré.",
+    "show": "Afficher",
+    "hide": "Masquer",
+    "showPassword": "Afficher le mot de passe",
+    "hidePassword": "Masquer le mot de passe"
   },
   "setup": {
     "title": "Configuration initiale",
@@ -575,6 +579,9 @@
       "scanning": "Analyse…",
       "scanningPercent": "Analyse… {{pct}} %",
       "indexing": "Indexation des PDF… {{indexed}} / {{total}}",
+      "ocr": "OCR… {{done}} / {{total}}",
+      "ocrProgress": "{{pct}} % — {{done}} sur {{total}} livres numérisés traités par OCR",
+      "ocrCurrent": "En cours : {{name}}",
       "stop": "Arrêter",
       "stopping": "Arrêt…",
       "complete": "Analyse terminée",
@@ -1061,6 +1068,17 @@
     "failed": "Échec de l'enregistrement.",
     "resetProgress": "Réinitialiser la progression de lecture",
     "progressReset": "Progression réinitialisée"
+  },
+  "reocr": {
+    "button": "Relancer l'OCR",
+    "title": "Relancer l'OCR à une résolution plus élevée",
+    "dpiPlaceholder": "p. ex. 300",
+    "dpiLabel": "Résolution OCR (DPI)",
+    "run": "Lancer",
+    "working": "En cours…",
+    "queued": "En file",
+    "error": "Échec de la mise en file de l'OCR",
+    "hint": "Relit ce livre numérisé. Laissez le DPI vide pour la valeur par défaut, ou augmentez-le (p. ex. 300) pour une lecture plus nette. S'exécute en arrière-plan."
   },
   "bookRow": {
     "missingFile": "Manquant",

--- a/frontend/src/locales/fr-FR.json
+++ b/frontend/src/locales/fr-FR.json
@@ -100,7 +100,11 @@
     "haveInviteCode": "Vous avez un code d'invitation ?",
     "inviteCode": "Code d'invitation",
     "enterAsGuest": "Entrer en tant qu'invité",
-    "guestInvalidCode": "Code d'invitation invalide ou expiré."
+    "guestInvalidCode": "Code d'invitation invalide ou expiré.",
+    "show": "Afficher",
+    "hide": "Masquer",
+    "showPassword": "Afficher le mot de passe",
+    "hidePassword": "Masquer le mot de passe"
   },
   "setup": {
     "title": "Configuration initiale",
@@ -575,6 +579,9 @@
       "scanning": "Analyse…",
       "scanningPercent": "Analyse… {{pct}} %",
       "indexing": "Indexation des PDF… {{indexed}} / {{total}}",
+      "ocr": "OCR… {{done}} / {{total}}",
+      "ocrProgress": "{{pct}} % — {{done}} sur {{total}} livres numérisés traités par OCR",
+      "ocrCurrent": "En cours : {{name}}",
       "stop": "Arrêter",
       "stopping": "Arrêt…",
       "complete": "Analyse terminée",
@@ -1061,6 +1068,17 @@
     "failed": "Échec de l'enregistrement.",
     "resetProgress": "Réinitialiser la progression de lecture",
     "progressReset": "Progression réinitialisée"
+  },
+  "reocr": {
+    "button": "Relancer l'OCR",
+    "title": "Relancer l'OCR à une résolution plus élevée",
+    "dpiPlaceholder": "p. ex. 300",
+    "dpiLabel": "Résolution OCR (DPI)",
+    "run": "Lancer",
+    "working": "En cours…",
+    "queued": "En file",
+    "error": "Échec de la mise en file de l'OCR",
+    "hint": "Relit ce livre numérisé. Laissez le DPI vide pour la valeur par défaut, ou augmentez-le (p. ex. 300) pour une lecture plus nette. S'exécute en arrière-plan."
   },
   "bookRow": {
     "missingFile": "Manquant",

--- a/frontend/src/locales/nl-NL.json
+++ b/frontend/src/locales/nl-NL.json
@@ -100,7 +100,11 @@
     "haveInviteCode": "Heb je een uitnodigingscode?",
     "inviteCode": "Uitnodigingscode",
     "enterAsGuest": "Als gast aanmelden",
-    "guestInvalidCode": "Ongeldige of verlopen uitnodigingscode."
+    "guestInvalidCode": "Ongeldige of verlopen uitnodigingscode.",
+    "show": "Tonen",
+    "hide": "Verbergen",
+    "showPassword": "Wachtwoord tonen",
+    "hidePassword": "Wachtwoord verbergen"
   },
   "setup": {
     "title": "Eerste configuratie",
@@ -575,6 +579,9 @@
       "scanning": "Scannen…",
       "scanningPercent": "Scannen… {{pct}}%",
       "indexing": "Pdf's indexeren… {{indexed}} / {{total}}",
+      "ocr": "OCR… {{done}} / {{total}}",
+      "ocrProgress": "{{pct}}% — {{done}} van {{total}} gescande boeken via OCR verwerkt",
+      "ocrCurrent": "Huidig: {{name}}",
       "stop": "Stoppen",
       "stopping": "Stoppen…",
       "complete": "Scan voltooid",
@@ -1061,6 +1068,17 @@
     "failed": "Opslaan mislukt.",
     "resetProgress": "Leesvoortgang opnieuw instellen",
     "progressReset": "Voortgang opnieuw ingesteld"
+  },
+  "reocr": {
+    "button": "OCR opnieuw",
+    "title": "OCR opnieuw met hogere DPI",
+    "dpiPlaceholder": "bijv. 300",
+    "dpiLabel": "OCR-resolutie (DPI)",
+    "run": "Uitvoeren",
+    "working": "Bezig…",
+    "queued": "In wachtrij",
+    "error": "OCR in wachtrij zetten mislukt",
+    "hint": "Leest dit gescande boek opnieuw in. Laat DPI leeg voor de standaard, of verhoog het (bijv. 300) voor een scherpere lezing. Draait op de achtergrond."
   },
   "bookRow": {
     "missingFile": "Ontbreekt",

--- a/frontend/src/locales/pt-BR.json
+++ b/frontend/src/locales/pt-BR.json
@@ -100,7 +100,11 @@
     "haveInviteCode": "Tem um código de convite?",
     "inviteCode": "Código de convite",
     "enterAsGuest": "Entrar como convidado",
-    "guestInvalidCode": "Código de convite inválido ou expirado."
+    "guestInvalidCode": "Código de convite inválido ou expirado.",
+    "show": "Mostrar",
+    "hide": "Ocultar",
+    "showPassword": "Mostrar senha",
+    "hidePassword": "Ocultar senha"
   },
   "setup": {
     "title": "Configuração inicial",
@@ -575,6 +579,9 @@
       "scanning": "Escaneando…",
       "scanningPercent": "Escaneando… {{pct}}%",
       "indexing": "Indexando PDFs… {{indexed}} / {{total}}",
+      "ocr": "OCR… {{done}} / {{total}}",
+      "ocrProgress": "{{pct}}% — {{done}} de {{total}} livros digitalizados processados por OCR",
+      "ocrCurrent": "Atual: {{name}}",
       "stop": "Parar",
       "stopping": "Parando…",
       "complete": "Escaneamento concluído",
@@ -1061,6 +1068,17 @@
     "failed": "Falha ao salvar.",
     "resetProgress": "Redefinir progresso de leitura",
     "progressReset": "Progresso redefinido"
+  },
+  "reocr": {
+    "button": "Refazer OCR",
+    "title": "Refazer OCR com DPI maior",
+    "dpiPlaceholder": "ex.: 300",
+    "dpiLabel": "Resolução do OCR (DPI)",
+    "run": "Executar",
+    "working": "Processando…",
+    "queued": "Na fila",
+    "error": "Falha ao enfileirar o OCR",
+    "hint": "Relê este livro digitalizado. Deixe o DPI em branco para o padrão ou aumente-o (ex.: 300) para uma leitura mais nítida. É executado em segundo plano."
   },
   "bookRow": {
     "missingFile": "Ausente",

--- a/frontend/src/locales/pt-PT.json
+++ b/frontend/src/locales/pt-PT.json
@@ -100,7 +100,11 @@
     "haveInviteCode": "Tem um código de convite?",
     "inviteCode": "Código de convite",
     "enterAsGuest": "Entrar como convidado",
-    "guestInvalidCode": "Código de convite inválido ou expirado."
+    "guestInvalidCode": "Código de convite inválido ou expirado.",
+    "show": "Mostrar",
+    "hide": "Ocultar",
+    "showPassword": "Mostrar palavra-passe",
+    "hidePassword": "Ocultar palavra-passe"
   },
   "setup": {
     "title": "Configuração inicial",
@@ -575,6 +579,9 @@
       "scanning": "A analisar…",
       "scanningPercent": "A analisar… {{pct}}%",
       "indexing": "A indexar PDFs… {{indexed}} / {{total}}",
+      "ocr": "OCR… {{done}} / {{total}}",
+      "ocrProgress": "{{pct}}% — {{done}} de {{total}} livros digitalizados processados por OCR",
+      "ocrCurrent": "Atual: {{name}}",
       "stop": "Parar",
       "stopping": "A parar…",
       "complete": "Análise concluída",
@@ -1061,6 +1068,17 @@
     "failed": "Falha ao guardar.",
     "resetProgress": "Repor progresso de leitura",
     "progressReset": "Progresso reposto"
+  },
+  "reocr": {
+    "button": "Refazer OCR",
+    "title": "Refazer OCR com DPI maior",
+    "dpiPlaceholder": "ex.: 300",
+    "dpiLabel": "Resolução do OCR (DPI)",
+    "run": "Executar",
+    "working": "A processar…",
+    "queued": "Na fila",
+    "error": "Falha ao colocar o OCR na fila",
+    "hint": "Relê este livro digitalizado. Deixe o DPI em branco para o valor predefinido ou aumente-o (ex.: 300) para uma leitura mais nítida. É executado em segundo plano."
   },
   "bookRow": {
     "missingFile": "Em falta",

--- a/frontend/src/views/LoginView.jsx
+++ b/frontend/src/views/LoginView.jsx
@@ -6,6 +6,7 @@ import { auth as authApi } from '../api'
 export default function LoginView({ onLogin }) {
   const { t } = useTranslation()
   const [form, setForm] = useState({ username: '', password: '' })
+  const [showPassword, setShowPassword] = useState(false)
   const [error, setError] = useState('')
   const [loading, setLoading] = useState(false)
   const [config, setConfig] = useState({
@@ -237,15 +238,28 @@ export default function LoginView({ onLogin }) {
                     <label htmlFor="login-password" style={labelStyle}>
                       {t('login.password')}
                     </label>
-                    <input
-                      id="login-password"
-                      type="password"
-                      value={form.password}
-                      onChange={(e) => setForm({ ...form, password: e.target.value })}
-                      required
-                      autoComplete="current-password"
-                      style={{ width: '100%' }}
-                    />
+                    <div style={{ position: 'relative' }}>
+                      <input
+                        id="login-password"
+                        type={showPassword ? 'text' : 'password'}
+                        value={form.password}
+                        onChange={(e) => setForm({ ...form, password: e.target.value })}
+                        required
+                        autoComplete="current-password"
+                        style={{ width: '100%', paddingRight: 44 }}
+                      />
+                      <button
+                        type="button"
+                        onClick={() => setShowPassword((v) => !v)}
+                        aria-label={
+                          showPassword ? t('login.hidePassword') : t('login.showPassword')
+                        }
+                        aria-pressed={showPassword}
+                        style={revealBtnStyle}
+                      >
+                        {showPassword ? t('login.hide') : t('login.show')}
+                      </button>
+                    </div>
                   </div>
 
                   {error && (
@@ -383,6 +397,21 @@ const submitBtnStyle = (loading) => ({
   cursor: loading ? 'not-allowed' : 'pointer',
   border: '1px solid var(--gold)',
 })
+
+const revealBtnStyle = {
+  position: 'absolute',
+  top: '50%',
+  right: 10,
+  transform: 'translateY(-50%)',
+  background: 'none',
+  border: 'none',
+  color: 'var(--text-muted)',
+  cursor: 'pointer',
+  fontSize: 12,
+  letterSpacing: '0.03em',
+  textTransform: 'uppercase',
+  padding: 4,
+}
 
 const oidcBtnStyle = {
   width: '100%',

--- a/frontend/src/views/LoginView.test.jsx
+++ b/frontend/src/views/LoginView.test.jsx
@@ -19,6 +19,20 @@ describe('LoginView', () => {
     expect(screen.getByLabelText('Password')).toBeInTheDocument()
   })
 
+  it('toggles password visibility with the reveal button', async () => {
+    render(<LoginView onLogin={vi.fn()} />)
+    const input = screen.getByLabelText('Password')
+    expect(input).toHaveAttribute('type', 'password')
+
+    const toggle = screen.getByRole('button', { name: /show password/i })
+    fireEvent.click(toggle)
+    expect(input).toHaveAttribute('type', 'text')
+    expect(screen.getByRole('button', { name: /hide password/i })).toBeInTheDocument()
+
+    fireEvent.click(screen.getByRole('button', { name: /hide password/i }))
+    expect(input).toHaveAttribute('type', 'password')
+  })
+
   it('calls onLogin with token and user on successful login', async () => {
     global.fetch = vi.fn().mockResolvedValue({
       ok: true,


### PR DESCRIPTION
## Summary


## Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / cleanup
- [ ] Docs / configuration only

## Testing

<!-- How did you verify this works? Check all that apply. -->

- [ ] Backend tests pass (`pytest -q`)
- [ ] Frontend tests pass (`npm test`)
- [ ] Tested manually in the browser

## Notes for reviewer

<!-- Anything that needs extra context, known limitations, or follow-up work. Delete if not needed. -->
