### PR TITLE
Fix: Correct stats endpoint system count to not use system-agnostic as a system

### DIFF
--- a/backend/routers/library/core.py
+++ b/backend/routers/library/core.py
@@ -87,7 +87,9 @@ def get_stats(
             if not stored_key or x_api_key != stored_key:
                 raise HTTPException(401, "Authentication required")
         return {
-            "game_systems": db.query(GameSystem).count(),
+            "game_systems": db.query(GameSystem)
+            .filter(GameSystem.is_system_agnostic != True)  # noqa: E712
+            .count(),
             "books": db.query(Book).count(),
             "maps": db.query(GenericMap).count(),
             "tokens": db.query(Token).count(),

--- a/backend/tests/test_library.py
+++ b/backend/tests/test_library.py
@@ -49,6 +49,18 @@ class TestLibraryStats:
         after = client.get("/api/stats", headers=admin_headers).json()
         assert after["books"] >= before_books + 1
 
+    def test_stats_excludes_system_agnostic_from_game_systems(self, client, admin_headers):
+        # The system-agnostic pseudo-system is a GameSystem row but is not a
+        # real game system; it renders separately in the library and must not
+        # inflate the game_systems stat (matches the library header count).
+        before = client.get("/api/stats", headers=admin_headers).json()["game_systems"]
+
+        make_game_system()  # normal system: counted
+        make_game_system(is_system_agnostic=True)  # agnostic: not counted
+
+        after = client.get("/api/stats", headers=admin_headers).json()["game_systems"]
+        assert after == before + 1
+
     def test_player_can_view_stats(self, client, player_headers):
         resp = client.get("/api/stats", headers=player_headers)
         assert resp.status_code == 200


### PR DESCRIPTION
## Summary

<!-- What does this PR do? A few sentences is fine. -->

## Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / cleanup
- [ ] Docs / configuration only

## Testing

<!-- How did you verify this works? Check all that apply. -->

- [x] Backend tests pass (`pytest -q`)
- [x] Frontend tests pass (`npm test`)
- [x] Tested manually in the browser

## Notes for reviewer

<!-- Anything that needs extra context, known limitations, or follow-up work. Delete if not needed. -->
