### PR TITLE
Fix: Authenticate media via HttpOnly cookie instead of ?token= in URL. (#156)

### DIFF
--- a/README.md
+++ b/README.md
@@ -495,6 +495,10 @@ The credential-checking endpoints - `/api/auth/login`, `/api/auth/setup`, `/api/
 
 Every response carries a `Content-Security-Policy` scoped to what the SPA actually loads (own scripts, inline styles used by React, Google Fonts, and `data:`/`blob:` images for rendered pages), plus `X-Content-Type-Options: nosniff`, `X-Frame-Options: DENY` (matching the CSP `frame-ancestors 'none'`), and `Referrer-Policy: strict-origin-when-cross-origin`. `Strict-Transport-Security` is emitted **only when the request is HTTPS** - either directly or via an `X-Forwarded-Proto: https` header from your TLS-terminating proxy - so it is never sent over plain HTTP.
 
+### Session cookie for images and downloads
+
+Browser `<img>` and download requests can't send an `Authorization` header, so they authenticate via an `HttpOnly`, `SameSite=Lax` session cookie (`grimoire_session`) set at login rather than a token in the URL. **This means the JWT no longer appears in image/download URLs, so a reverse proxy, CDN, or load balancer in front of Grimoire no longer records it in access logs** (query-string tokens also leaked via `Referer` headers and browser history). Set `BASE_URL` to your `https://` public URL so the cookie is marked `Secure` and only ever sent over TLS. The old `?token=` query param is still accepted for backward compatibility but is deprecated.
+
 ---
 
 ## Pre-seeding users

--- a/backend/auth.py
+++ b/backend/auth.py
@@ -6,7 +6,7 @@ import logging
 from typing import Optional
 
 import jwt
-from fastapi import Depends, HTTPException, Query
+from fastapi import Cookie, Depends, HTTPException, Query, Response
 from fastapi.security import HTTPBearer, HTTPAuthorizationCredentials
 from passlib.context import CryptContext
 
@@ -15,6 +15,19 @@ logger = logging.getLogger("grimoire.auth")
 SECRET_KEY = os.environ.get("SECRET_KEY", "grimoire-dev-secret-change-in-production")
 ALGORITHM = "HS256"
 TOKEN_EXPIRE_DAYS = 30
+
+# Name of the HttpOnly session cookie that carries the JWT. This lets
+# <img>/download GETs authenticate without the token appearing in the URL
+# (query params leak into proxy/access logs, Referer headers, and history).
+AUTH_COOKIE_NAME = "grimoire_session"
+
+# Mark the cookie Secure whenever the instance is served over HTTPS, so it is
+# never sent over plaintext. Derived from BASE_URL — a bare "http://" self-host
+# (e.g. behind a LAN reverse proxy without TLS) still needs the cookie to be
+# sent, so Secure is off there.
+COOKIE_SECURE = os.environ.get("BASE_URL", "http://localhost:9481").lower().startswith(
+    "https://"
+)
 
 if SECRET_KEY == "grimoire-dev-secret-change-in-production":
     logger.warning(
@@ -60,6 +73,37 @@ def decode_token(token: str) -> dict:
     return jwt.decode(token, SECRET_KEY, algorithms=[ALGORITHM])
 
 
+def set_auth_cookie(response: Response, token: str) -> None:
+    """Attach the session JWT as an HttpOnly cookie on a login/setup response.
+
+    HttpOnly keeps it out of reach of JS (XSS can't exfiltrate it); SameSite=Lax
+    prevents it riding cross-site requests (CSRF) while still being sent on the
+    top-level navigations that download links rely on; Secure is set when served
+    over HTTPS. Lifetime matches the JWT's own expiry.
+    """
+    response.set_cookie(
+        AUTH_COOKIE_NAME,
+        token,
+        max_age=TOKEN_EXPIRE_DAYS * 24 * 60 * 60,
+        httponly=True,
+        secure=COOKIE_SECURE,
+        samesite="lax",
+        path="/",
+    )
+
+
+def clear_auth_cookie(response: Response) -> None:
+    """Remove the session cookie (logout). Attributes must match set_auth_cookie
+    so the browser matches and deletes the right cookie."""
+    response.delete_cookie(
+        AUTH_COOKIE_NAME,
+        httponly=True,
+        secure=COOKIE_SECURE,
+        samesite="lax",
+        path="/",
+    )
+
+
 class CurrentUser:
     def __init__(self, id: str, username: str, role: str):
         self.id = id
@@ -69,9 +113,13 @@ class CurrentUser:
 
 def get_current_user(
     credentials: Optional[HTTPAuthorizationCredentials] = Depends(bearer_scheme),
+    cookie_token: Optional[str] = Cookie(None, alias=AUTH_COOKIE_NAME),
     token: Optional[str] = Query(None),
 ) -> CurrentUser:
-    raw = credentials.credentials if credentials else token
+    # Header (normal API calls) → cookie (image/download GETs) → ?token= query
+    # param. The query param is a deprecated fallback kept only so pre-existing
+    # links/clients keep working; new clients should never put the JWT in a URL.
+    raw = (credentials.credentials if credentials else None) or cookie_token or token
     if not raw:
         raise HTTPException(401, "Not authenticated")
 
@@ -90,10 +138,11 @@ def get_current_user(
 
 def optional_get_current_user(
     credentials: Optional[HTTPAuthorizationCredentials] = Depends(bearer_scheme),
+    cookie_token: Optional[str] = Cookie(None, alias=AUTH_COOKIE_NAME),
     token: Optional[str] = Query(None),
 ) -> Optional["CurrentUser"]:
     """Like get_current_user but returns None instead of raising when no/invalid token."""
-    raw = credentials.credentials if credentials else token
+    raw = (credentials.credentials if credentials else None) or cookie_token or token
     if not raw:
         return None
     try:

--- a/backend/routers/auth/__init__.py
+++ b/backend/routers/auth/__init__.py
@@ -1,7 +1,15 @@
 """Auth package — registers public (unauthenticated) and authenticated routes."""
 from fastapi import APIRouter
 
-from .core import auth_config, auth_login, auth_me, auth_setup, auth_status, guest_login
+from .core import (
+    auth_config,
+    auth_login,
+    auth_logout,
+    auth_me,
+    auth_setup,
+    auth_status,
+    guest_login,
+)
 
 public_router = APIRouter(prefix="/api/auth", tags=["auth"])
 public_router.add_api_route(
@@ -39,6 +47,16 @@ public_router.add_api_route(
     description=(
         "Exchanges a campaign guest invite code for a JWT scoped to a guest "
         "account. Available only when guest access is enabled."
+    ),
+)
+public_router.add_api_route(
+    "/logout",
+    auth_logout,
+    methods=["POST"],
+    summary="Log out",
+    description=(
+        "Clears the session cookie. The JWT itself is stateless and not "
+        "revoked; the client should also discard its stored token."
     ),
 )
 public_router.add_api_route(

--- a/backend/routers/auth/core.py
+++ b/backend/routers/auth/core.py
@@ -1,12 +1,15 @@
 """Authentication endpoint handlers."""
-from fastapi import Depends, HTTPException, Request
+from fastapi import Depends, HTTPException, Request, Response
 from sqlalchemy import func
 
 from ...auth import (
+    AUTH_COOKIE_NAME,
     CurrentUser,
+    clear_auth_cookie,
     create_token,
     get_current_user,
     hash_password,
+    set_auth_cookie,
     verify_password,
 )
 from ...config import SessionLocal
@@ -31,7 +34,7 @@ def auth_status():
 
 
 @limiter.limit(AUTH_RATE_LIMIT)
-def auth_setup(request: Request, data: SetupRequest):
+def auth_setup(request: Request, data: SetupRequest, response: Response):
     db = SessionLocal()
     try:
         if db.query(User).count() > 0:
@@ -45,6 +48,7 @@ def auth_setup(request: Request, data: SetupRequest):
         db.commit()
         db.refresh(user)
         token = create_token(user.id, user.username, user.role)
+        set_auth_cookie(response, token)
         return {
             "token": token,
             "user": {
@@ -59,7 +63,7 @@ def auth_setup(request: Request, data: SetupRequest):
 
 
 @limiter.limit(AUTH_RATE_LIMIT)
-def auth_login(request: Request, data: LoginRequest):
+def auth_login(request: Request, data: LoginRequest, response: Response):
     db = SessionLocal()
     try:
         if not password_auth_effective(_get_raw(db)):
@@ -74,6 +78,7 @@ def auth_login(request: Request, data: LoginRequest):
         if not user or not verify_password(data.password, user.hashed_password):
             raise HTTPException(401, "Invalid username or password")
         token = create_token(user.id, user.username, user.role)
+        set_auth_cookie(response, token)
         return {
             "token": token,
             "user": {
@@ -88,7 +93,7 @@ def auth_login(request: Request, data: LoginRequest):
 
 
 @limiter.limit(AUTH_RATE_LIMIT)
-def guest_login(request: Request, data: GuestLoginRequest):
+def guest_login(request: Request, data: GuestLoginRequest, response: Response):
     db = SessionLocal()
     try:
         if not guest_access_effective(_get_raw(db)):
@@ -109,6 +114,7 @@ def guest_login(request: Request, data: GuestLoginRequest):
             raise HTTPException(401, "Invalid invite code")
 
         token = create_token(user.id, user.username, user.role)
+        set_auth_cookie(response, token)
         return {
             "token": token,
             "user": {
@@ -121,6 +127,13 @@ def guest_login(request: Request, data: GuestLoginRequest):
         }
     finally:
         db.close()
+
+
+def auth_logout(response: Response):
+    """Clear the session cookie. Deliberately requires no auth so a client with
+    an already-expired or otherwise unusable cookie can still log out cleanly."""
+    clear_auth_cookie(response)
+    return {"ok": True}
 
 
 def auth_config():
@@ -145,7 +158,16 @@ def auth_config():
         db.close()
 
 
-def auth_me(user: CurrentUser = Depends(get_current_user)):
+def auth_me(request: Request, response: Response, user: CurrentUser = Depends(get_current_user)):
+    # Re-establish the session cookie for clients that authenticated with a
+    # Bearer header but have no cookie yet — chiefly users who were logged in
+    # before the cookie was introduced (issue #156). Reuse their existing token
+    # rather than minting a new one so the expiry isn't silently extended.
+    if AUTH_COOKIE_NAME not in request.cookies:
+        auth_header = request.headers.get("Authorization", "")
+        if auth_header.startswith("Bearer "):
+            set_auth_cookie(response, auth_header[len("Bearer ") :])
+
     db = SessionLocal()
     try:
         u = db.query(User).filter_by(id=user.id).first()

--- a/backend/routers/oidc/core.py
+++ b/backend/routers/oidc/core.py
@@ -15,7 +15,7 @@ import httpx
 from fastapi import Depends, HTTPException, Query
 from fastapi.responses import RedirectResponse
 
-from ...auth import CurrentUser, create_token, require_admin
+from ...auth import CurrentUser, create_token, require_admin, set_auth_cookie
 from ...config import SessionLocal
 from ..settings._helpers import (
     _get_raw,
@@ -226,10 +226,13 @@ def oidc_callback(
 
         token = create_token(user.id, user.username, user.role)
         # Hand the token to the frontend via the URL fragment so it isn't
-        # logged by intermediate proxies.
+        # logged by intermediate proxies. Also set the session cookie so
+        # <img>/download GETs authenticate without the JWT in the URL.
         return_to = saved.get("return_to") or "/"
         if not return_to.startswith("/"):
             return_to = "/"
-        return RedirectResponse(f"{return_to}#oidc_token={token}", status_code=302)
+        resp = RedirectResponse(f"{return_to}#oidc_token={token}", status_code=302)
+        set_auth_cookie(resp, token)
+        return resp
     finally:
         db.close()

--- a/backend/tests/conftest.py
+++ b/backend/tests/conftest.py
@@ -40,6 +40,16 @@ def client():
         yield c
 
 
+@pytest.fixture(autouse=True)
+def _reset_client_cookies(client):
+    """The session-scoped client shares a cookie jar across tests. Auth flows
+    now set a session cookie (issue #156), which would otherwise silently
+    authenticate later "unauthenticated" requests. Clear it before every test so
+    each starts with no ambient credentials."""
+    client.cookies.clear()
+    yield
+
+
 # ---------------------------------------------------------------------------
 # Bootstrap admin (runs once per session via /api/auth/setup)
 # ---------------------------------------------------------------------------

--- a/backend/tests/test_auth.py
+++ b/backend/tests/test_auth.py
@@ -115,10 +115,14 @@ class TestAuthMe:
         assert body["role"] == "admin"
 
     def test_me_no_token(self, client):
+        # Clear any ambient session cookie left by the shared session client so
+        # "no token" really means no credentials of any kind.
+        client.cookies.clear()
         resp = client.get("/api/auth/me")
         assert resp.status_code == 401
 
     def test_me_invalid_token(self, client):
+        client.cookies.clear()
         resp = client.get("/api/auth/me", headers={"Authorization": "Bearer invalid.token.here"})
         assert resp.status_code == 401
 
@@ -133,6 +137,99 @@ class TestAuthMe:
         assert resp.json()["role"] == "player"
 
     def test_token_as_query_param(self, client, admin_token):
+        # ?token= is a deprecated fallback (issue #156) — still accepted so old
+        # links don't break, but the frontend no longer generates it. Clear the
+        # cookie jar so this exercises the query-param path specifically.
+        client.cookies.clear()
         resp = client.get(f"/api/auth/me?token={admin_token}")
         assert resp.status_code == 200
         assert resp.json()["username"] == "admin"
+
+
+def _cookie_header(resp):
+    """Raw Set-Cookie header for the session cookie, or '' if absent."""
+    for key, value in resp.headers.items():
+        if key.lower() == "set-cookie" and "grimoire_session=" in value:
+            return value
+    return ""
+
+
+class TestAuthCookie:
+    """The session cookie lets image/download GETs authenticate without the JWT
+    appearing in the URL (issue #156)."""
+
+    def test_login_sets_httponly_cookie(self, client, admin_setup):
+        resp = client.post(
+            "/api/auth/login",
+            json={"username": "admin", "password": "adminpass123"},
+        )
+        assert resp.status_code == 200
+        # Cookie value matches the JWT returned in the body.
+        assert client.cookies.get("grimoire_session") == resp.json()["token"]
+        raw = _cookie_header(resp)
+        assert "httponly" in raw.lower()
+        assert "samesite=lax" in raw.lower()
+
+    def test_cookie_authenticates_request(self, client, admin_token):
+        """A bare cookie (no Authorization header) authenticates — this is what
+        <img>/download GETs rely on."""
+        client.cookies.clear()
+        client.cookies.set("grimoire_session", admin_token)
+        resp = client.get("/api/auth/me")
+        assert resp.status_code == 200
+        assert resp.json()["username"] == "admin"
+
+    def test_header_takes_priority_over_cookie(self, client, admin_token):
+        """A valid header wins even if a garbage cookie is present."""
+        client.cookies.clear()
+        client.cookies.set("grimoire_session", "not-a-real-token")
+        resp = client.get(
+            "/api/auth/me", headers={"Authorization": f"Bearer {admin_token}"}
+        )
+        assert resp.status_code == 200
+        assert resp.json()["username"] == "admin"
+
+    def test_invalid_cookie_rejected(self, client, admin_setup):
+        client.cookies.clear()
+        client.cookies.set("grimoire_session", "garbage")
+        resp = client.get("/api/auth/me")
+        assert resp.status_code == 401
+
+    def test_me_reestablishes_cookie_for_header_only_client(self, client, admin_token):
+        """Users logged in before cookies existed present a Bearer header but no
+        cookie; /auth/me re-issues the cookie from their existing token."""
+        client.cookies.clear()
+        resp = client.get(
+            "/api/auth/me", headers={"Authorization": f"Bearer {admin_token}"}
+        )
+        assert resp.status_code == 200
+        # The same token is reused, not a freshly minted one.
+        assert client.cookies.get("grimoire_session") == admin_token
+
+    def test_me_does_not_reset_cookie_when_already_present(self, client, admin_token):
+        """When the cookie is already sent, /auth/me issues no new Set-Cookie."""
+        client.cookies.clear()
+        client.cookies.set("grimoire_session", admin_token)
+        resp = client.get(
+            "/api/auth/me", headers={"Authorization": f"Bearer {admin_token}"}
+        )
+        assert resp.status_code == 200
+        assert _cookie_header(resp) == ""
+
+
+class TestAuthLogout:
+    def test_logout_clears_cookie(self, client, admin_token):
+        client.cookies.set("grimoire_session", admin_token)
+        resp = client.post("/api/auth/logout")
+        assert resp.status_code == 200
+        assert resp.json() == {"ok": True}
+        # The Set-Cookie expires the cookie (empty value / Max-Age=0).
+        raw = _cookie_header(resp).lower()
+        assert 'grimoire_session=""' in raw or "grimoire_session=;" in raw or "max-age=0" in raw
+
+    def test_logout_without_cookie_still_ok(self, client, admin_setup):
+        """Logout requires no auth so a client with an unusable cookie can still
+        clear it."""
+        client.cookies.clear()
+        resp = client.post("/api/auth/logout")
+        assert resp.status_code == 200

--- a/backend/tests/test_oidc.py
+++ b/backend/tests/test_oidc.py
@@ -500,6 +500,128 @@ class TestOIDCLoginStart:
         )
 
 
+class TestOIDCCallback:
+    """The callback exchanges the code, resolves the user, and hands back a
+    token — via the URL fragment AND an HttpOnly session cookie (issue #156)."""
+
+    def _configure(self, client, admin_headers):
+        client.patch(
+            "/api/settings",
+            headers=admin_headers,
+            json={
+                "oidc_enabled": True,
+                "oidc_issuer_url": "https://idp.example.com/realm",
+                "oidc_authorization_endpoint": "https://idp.example.com/realm/auth",
+                "oidc_token_endpoint": "https://idp.example.com/realm/token",
+                "oidc_jwks_uri": "https://idp.example.com/realm/jwks",
+                "oidc_client_id": "grimoire",
+                "oidc_client_secret": "secret",
+                "oidc_auto_register": True,
+            },
+        )
+
+    def _cleanup(self, client, admin_headers):
+        client.patch(
+            "/api/settings",
+            headers=admin_headers,
+            json={
+                "oidc_enabled": False,
+                "oidc_issuer_url": "",
+                "oidc_authorization_endpoint": "",
+                "oidc_token_endpoint": "",
+                "oidc_jwks_uri": "",
+                "oidc_client_id": "",
+                "oidc_client_secret": "__CLEAR__",
+                "oidc_auto_register": False,
+            },
+        )
+
+    def test_callback_sets_session_cookie_on_success(self, client, admin_headers):
+        from backend.routers.oidc import core as oidc_core
+
+        self._configure(client, admin_headers)
+        try:
+            # Seed the state the login step would have stored.
+            oidc_core._state_store.put(
+                "state123",
+                {"code_verifier": "verifier", "nonce": "nonce123", "return_to": "/"},
+            )
+
+            token_resp = httpx.Response(
+                200,
+                json={"id_token": "id-tok", "access_token": "acc-tok"},
+                request=httpx.Request("POST", "https://idp.example.com/realm/token"),
+            )
+            with (
+                patch.object(oidc_core.httpx, "post", return_value=token_resp),
+                patch.object(oidc_core, "_discover_issuer", return_value="https://idp.example.com/realm"),
+                patch.object(
+                    oidc_core,
+                    "_validate_id_token",
+                    return_value={"sub": "oidc-sub-1", "email": "oidc@example.com"},
+                ),
+                patch.object(oidc_core, "_fetch_userinfo", return_value={}),
+            ):
+                resp = client.get(
+                    "/api/auth/openid/callback?code=abc&state=state123",
+                    follow_redirects=False,
+                )
+
+            assert resp.status_code == 302
+            # Token still handed to the SPA via the fragment...
+            assert "#oidc_token=" in resp.headers["location"]
+            # ...and the session cookie is set so media GETs authenticate.
+            set_cookie = "".join(
+                v for k, v in resp.headers.items() if k.lower() == "set-cookie"
+            )
+            assert "grimoire_session=" in set_cookie
+            assert "httponly" in set_cookie.lower()
+        finally:
+            self._cleanup(client, admin_headers)
+
+    def test_callback_idp_error_redirects_to_login(self, client):
+        resp = client.get(
+            "/api/auth/openid/callback?error=access_denied&error_description=nope",
+            follow_redirects=False,
+        )
+        assert resp.status_code == 302
+        assert "oidc_error=nope" in resp.headers["location"]
+
+    def test_callback_missing_code_or_state(self, client):
+        resp = client.get("/api/auth/openid/callback?code=abc", follow_redirects=False)
+        assert resp.status_code == 302
+        assert "oidc_error=" in resp.headers["location"]
+
+    def test_callback_invalid_state(self, client):
+        resp = client.get(
+            "/api/auth/openid/callback?code=abc&state=never-issued",
+            follow_redirects=False,
+        )
+        assert resp.status_code == 302
+        assert "invalid" in resp.headers["location"].lower()
+
+    def test_callback_token_exchange_failure(self, client, admin_headers):
+        from backend.routers.oidc import core as oidc_core
+
+        self._configure(client, admin_headers)
+        try:
+            oidc_core._state_store.put(
+                "state-fail",
+                {"code_verifier": "verifier", "nonce": "n", "return_to": "/"},
+            )
+            with patch.object(
+                oidc_core.httpx, "post", side_effect=httpx.HTTPError("boom")
+            ):
+                resp = client.get(
+                    "/api/auth/openid/callback?code=abc&state=state-fail",
+                    follow_redirects=False,
+                )
+            assert resp.status_code == 302
+            assert "token%20exchange%20failed" in resp.headers["location"]
+        finally:
+            self._cleanup(client, admin_headers)
+
+
 # ---------------------------------------------------------------------------
 # Pure-function helpers
 # ---------------------------------------------------------------------------

--- a/backend/tests/test_opds.py
+++ b/backend/tests/test_opds.py
@@ -206,14 +206,19 @@ class TestOPDSTokenManagement:
         assert resp.json()["has_token"] is False
 
     def test_unauthenticated_cannot_get_status(self, opds_client):
+        # A prior login in this module-scoped client leaves a session cookie in
+        # the jar; clear it so this really is an unauthenticated request.
+        opds_client.cookies.clear()
         resp = opds_client.get("/api/users/me/opds")
         assert resp.status_code == 401
 
     def test_unauthenticated_cannot_generate(self, opds_client):
+        opds_client.cookies.clear()
         resp = opds_client.post("/api/users/me/opds/generate")
         assert resp.status_code == 401
 
     def test_unauthenticated_cannot_revoke(self, opds_client):
+        opds_client.cookies.clear()
         resp = opds_client.delete("/api/users/me/opds")
         assert resp.status_code == 401
 

--- a/docs/api.md
+++ b/docs/api.md
@@ -15,19 +15,24 @@ The live API is self-documented via OpenAPI. With the server running:
 
 ## Authentication
 
-All endpoints except `/api/health`, `/api/auth/status`, `/api/auth/setup`, `/api/auth/login`, `/api/auth/guest-login`, and `/api/auth/config` require a JWT.
+All endpoints except `/api/health`, `/api/auth/status`, `/api/auth/setup`, `/api/auth/login`, `/api/auth/guest-login`, `/api/auth/logout`, and `/api/auth/config` require a JWT.
 
 **Header** (preferred for API clients):
 ```
 Authorization: Bearer <token>
 ```
 
-**Query parameter** (required for browser-embedded images and file downloads):
+**Session cookie** (used by browser-embedded images and file downloads):
+
+On a successful `/api/auth/login`, `/api/auth/setup`, `/api/auth/guest-login`, or OIDC callback, the server also sets an `HttpOnly`, `SameSite=Lax` cookie named `grimoire_session` carrying the JWT (marked `Secure` when `BASE_URL` is `https://`). `<img>` and download requests — which can't set an `Authorization` header — authenticate via this cookie, so the token never appears in the URL. `POST /api/auth/logout` clears it.
+
+**Query parameter** (deprecated):
 ```
 ?token=<token>
 ```
+Still accepted so pre-existing links keep working, but the JWT in a URL leaks into proxy/access logs, `Referer` headers, and browser history (see [#156](https://github.com/hunter-read/grimoire/issues/156)). The frontend no longer generates `?token=` URLs — use the cookie instead. This fallback may be removed in a future release.
 
-Tokens are returned by `/api/auth/login` and expire after **30 days**.
+Tokens are returned by `/api/auth/login` and expire after **30 days**. The auth precedence for any request is: `Authorization` header → `grimoire_session` cookie → `?token=` query param.
 
 ### Rate limiting
 
@@ -57,12 +62,13 @@ The credential-checking endpoints - `/api/auth/login`, `/api/auth/setup`, `/api/
 |----------|--------|------|-------------|
 | `/api/auth/status` | GET | - | Returns `{"initialized": bool}` - used by the frontend to decide whether to show first-run setup |
 | `/api/auth/config` | GET | - | Public auth configuration for the login screen: `{password_auth_enabled, guest_access_enabled, custom_login_message_enabled, custom_login_message, oidc_enabled, oidc_button_text, oidc_auto_launch}`. The custom message is only returned when its toggle is on. OIDC fields are only true/non-empty when the IdP is fully configured. |
-| `/api/auth/setup` | POST | - | First-run admin account creation. Body: `{username, password}`. Returns `{token, user}`. Fails with 400 if any users exist. |
-| `/api/auth/login` | POST | - | Authenticate. Body: `{username, password}`. Returns `{token, user}` (`user` includes `display_name`). Returns 403 if password authentication is disabled. |
-| `/api/auth/guest-login` | POST | - | Exchange a campaign guest invite code for a JWT. Body: `{code}`. Returns `{token, user, campaign_id}` - `user.display_name` is the GM-set guest nickname. Returns 403 if guest access is disabled, 401 for an unknown/expired code. |
-| `/api/auth/me` | GET | any | Current user: `{id, username, display_name, email, role, allow_explicit, campaign_access, oidc_linked}` |
+| `/api/auth/setup` | POST | - | First-run admin account creation. Body: `{username, password}`. Returns `{token, user}` and sets the `grimoire_session` cookie. Fails with 400 if any users exist. |
+| `/api/auth/login` | POST | - | Authenticate. Body: `{username, password}`. Returns `{token, user}` (`user` includes `display_name`) and sets the `grimoire_session` cookie. Returns 403 if password authentication is disabled. |
+| `/api/auth/guest-login` | POST | - | Exchange a campaign guest invite code for a JWT. Body: `{code}`. Returns `{token, user, campaign_id}` and sets the `grimoire_session` cookie - `user.display_name` is the GM-set guest nickname. Returns 403 if guest access is disabled, 401 for an unknown/expired code. |
+| `/api/auth/logout` | POST | - | Clears the `grimoire_session` cookie. Requires no auth (a client with an expired cookie can still log out). The JWT itself is stateless and not revoked; the client should also discard its stored token. |
+| `/api/auth/me` | GET | any | Current user: `{id, username, display_name, email, role, allow_explicit, campaign_access, oidc_linked}`. Also (re-)sets the `grimoire_session` cookie when the request authenticated via header but had no cookie, so clients that predate the cookie get one on next load. |
 | `/api/auth/openid/login` | GET | - | Start an OIDC login. Redirects to the IdP. Optional `?return_to=/path` to redirect after callback. Returns 503 if OIDC isn't configured. |
-| `/api/auth/openid/callback` | GET | - | OIDC callback. Validates the code, finds/creates the local user, and redirects to the frontend with `#oidc_token=<jwt>`. |
+| `/api/auth/openid/callback` | GET | - | OIDC callback. Validates the code, finds/creates the local user, sets the `grimoire_session` cookie, and redirects to the frontend with `#oidc_token=<jwt>`. |
 | `/api/auth/openid/discover` | POST | admin | Server-side discovery fetch. Body: `{issuer_url}`. Returns the relevant endpoints from `.well-known/openid-configuration`. |
 
 ### Users
@@ -352,7 +358,7 @@ Guests authenticate via [`/api/auth/guest-login`](#auth) and may write only thei
 
 #### Banner, character art & sheets
 
-Files are stored on disk under `DATA_PATH/campaign_uploads/`. Banners are keyed by campaign id; character art and sheets are keyed by the **CampaignMember id** (`member.id` from the campaign-detail response), so a player in multiple campaigns gets a distinct file per membership. Image uploads (banner, art) accept PNG/JPEG/WebP/GIF up to 5 MB; sheets additionally accept PDF up to 15 MB. Serving endpoints accept the `?token=` query param for use in `<img>`/download URLs.
+Files are stored on disk under `DATA_PATH/campaign_uploads/`. Banners are keyed by campaign id; character art and sheets are keyed by the **CampaignMember id** (`member.id` from the campaign-detail response), so a player in multiple campaigns gets a distinct file per membership. Image uploads (banner, art) accept PNG/JPEG/WebP/GIF up to 5 MB; sheets additionally accept PDF up to 15 MB. Serving endpoints authenticate via the `grimoire_session` cookie for use in `<img>`/download URLs (the deprecated `?token=` query param is still accepted — see [Authentication](#authentication)).
 
 The GET (serving) endpoints for banners, art, sheets, and campaign files (`/files/:file_id`) set `Cache-Control: private, max-age=300, must-revalidate` along with `ETag`/`Last-Modified` validators derived from the file's mtime + size. A conditional request (`If-None-Match`/`If-Modified-Since`) with a matching validator returns `304 Not Modified`; re-uploading a file changes its validator so clients refetch.
 

--- a/frontend/src/api.js
+++ b/frontend/src/api.js
@@ -20,9 +20,12 @@ async function handleResponse(res) {
   return body
 }
 
+// Build a URL for an <img>/download/media endpoint. These requests can't send
+// an Authorization header, so they authenticate via the HttpOnly session cookie
+// set at login — the JWT is deliberately NOT put in the URL (query params leak
+// into proxy logs, Referer headers, and browser history; see issue #156).
 export const mediaUrl = (path, params = {}) => {
-  const token = getToken()
-  const qs = new URLSearchParams({ ...params, ...(token ? { token } : {}) }).toString()
+  const qs = new URLSearchParams(params).toString()
   return `/api${path}${qs ? `?${qs}` : ''}`
 }
 
@@ -165,6 +168,9 @@ export const campaigns = {
 export const auth = {
   config: () => api.get('/auth/config'),
   guestLogin: (code) => api.post('/auth/guest-login', { code }),
+  // Clears the server-side session cookie. Best-effort — the client also drops
+  // its stored token regardless of whether this succeeds.
+  logout: () => api.post('/auth/logout'),
 }
 
 export const opds = {

--- a/frontend/src/api.test.js
+++ b/frontend/src/api.test.js
@@ -139,21 +139,27 @@ describe('api', () => {
   // ---------------------------------------------------------------------------
 
   describe('mediaUrl', () => {
-    it('appends token as query param when logged in', () => {
+    // Media auth now rides the HttpOnly session cookie, so the JWT must never
+    // appear in the URL — even when one is stored (issue #156).
+    it('never puts the token in the URL, even when logged in', () => {
       localStorage.setItem('grimoire_token', 'my-token')
-      expect(mediaUrl('/books/1/thumbnail')).toBe('/api/books/1/thumbnail?token=my-token')
+      const url = mediaUrl('/books/1/thumbnail')
+      expect(url).toBe('/api/books/1/thumbnail')
+      expect(url).not.toContain('my-token')
+      expect(url).not.toContain('token=')
     })
 
     it('returns path without query string when not logged in', () => {
       expect(mediaUrl('/books/1/thumbnail')).toBe('/api/books/1/thumbnail')
     })
 
-    it('merges extra params alongside the token', () => {
+    it('includes extra params but no token', () => {
       localStorage.setItem('grimoire_token', 'tok')
       const url = mediaUrl('/books/1/page/3', { scale: '2' })
       const params = new URLSearchParams(url.split('?')[1])
       expect(params.get('scale')).toBe('2')
-      expect(params.get('token')).toBe('tok')
+      expect(params.get('token')).toBeNull()
+      expect(url).not.toContain('tok')
     })
   })
 
@@ -339,6 +345,7 @@ describe('api', () => {
       await Promise.all([
         auth.config(),
         auth.guestLogin('CODE'),
+        auth.logout(),
         opds.getStatus(),
         opds.generateToken(),
         opds.revokeToken(),

--- a/frontend/src/context/AuthContext.jsx
+++ b/frontend/src/context/AuthContext.jsx
@@ -1,4 +1,5 @@
 import { createContext, useContext, useState, useEffect, useCallback } from 'react'
+import { auth as authApi } from '../api'
 
 // status: 'loading' | 'uninitialized' | 'unauthenticated' | 'authenticated'
 const AuthContext = createContext(null)
@@ -53,6 +54,9 @@ export function AuthProvider({ children }) {
   }, [])
 
   const logout = useCallback(() => {
+    // Clear the server-side session cookie so media/download GETs can no longer
+    // authenticate. Best-effort — local state is cleared regardless.
+    authApi.logout().catch(() => {})
     localStorage.removeItem('grimoire_token')
     // One-shot: prevents the OIDC auto-launch from immediately redirecting
     // the user back to the IdP after they explicitly logged out.

--- a/frontend/src/context/AuthContext.test.jsx
+++ b/frontend/src/context/AuthContext.test.jsx
@@ -128,6 +128,8 @@ describe('AuthContext', () => {
         ok: true,
         json: () => Promise.resolve({ id: '1', username: 'alice', role: 'admin' }),
       })
+      // logout POSTs to /api/auth/logout to clear the server session cookie
+      .mockResolvedValueOnce({ ok: true, status: 200, json: () => Promise.resolve({ ok: true }) })
 
     renderAuth()
     await waitFor(() => expect(screen.getByTestId('status').textContent).toBe('authenticated'))
@@ -136,6 +138,11 @@ describe('AuthContext', () => {
 
     expect(screen.getByTestId('status').textContent).toBe('unauthenticated')
     expect(localStorage.getItem('grimoire_token')).toBeNull()
+    // The server-side cookie clear was requested.
+    expect(global.fetch).toHaveBeenCalledWith(
+      '/api/auth/logout',
+      expect.objectContaining({ method: 'POST' })
+    )
   })
 
   it('becomes unauthenticated when fetch throws a network error', async () => {


### PR DESCRIPTION
## Summary

<!-- What does this PR do? A few sentences is fine. -->

## Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / cleanup
- [ ] Docs / configuration only

## Testing

<!-- How did you verify this works? Check all that apply. -->

- [x] Backend tests pass (`pytest -q`)
- [x] Frontend tests pass (`npm test`)
- [x] Tested manually in the browser

## Notes for reviewer

<!-- Anything that needs extra context, known limitations, or follow-up work. Delete if not needed. -->
