### PR TITLE
Fix: lazy-load media images to fix library thumbnail request storm

### DIFF
--- a/backend/routers/books/core.py
+++ b/backend/routers/books/core.py
@@ -12,6 +12,7 @@ from ...auth import CurrentUser, get_current_user, require_gm_or_admin
 from ...config import _PAGE_CACHE_HEADERS, SessionLocal, THUMB_DIR
 from ...security import SAME_ORIGIN_FRAME_HEADERS
 
+from ...indexer import slugify
 from ...models import Book, GameSystem
 from ._helpers import _allow_explicit, _assert_book_access, _invalidate_book_cache
 from ._schemas import BookUpdate
@@ -215,8 +216,18 @@ def serve_book_thumbnail(book_id: str, current_user: CurrentUser = Depends(get_c
         if not book:
             raise HTTPException(404)
         _assert_book_access(db, book, current_user)
+        # Thumbnails are written at index time as "{slugify(title)}_{fhash}.webp"
+        # (see indexer.generate_thumbnail call sites). On a large library the
+        # per-request glob over tens of thousands of files is costly and this
+        # endpoint is hit once per visible cover, so reconstruct the expected
+        # filename and serve it directly. Fall back to the glob only when the
+        # title has drifted from what it was at index time (renamed book).
         fhash = hashlib.md5(book.filepath.encode()).hexdigest()[:8]
-        matches = glob.glob(os.path.join(THUMB_DIR, "books", f"*_{fhash}.webp"))
+        thumb_dir = os.path.join(THUMB_DIR, "books")
+        expected = os.path.join(thumb_dir, f"{slugify(book.title)}_{fhash}.webp")
+        if os.path.isfile(expected):
+            return FileResponse(expected, media_type="image/webp", headers=_PAGE_CACHE_HEADERS)
+        matches = glob.glob(os.path.join(thumb_dir, f"*_{fhash}.webp"))
         if matches:
             return FileResponse(matches[0], media_type="image/webp", headers=_PAGE_CACHE_HEADERS)
         raise HTTPException(404, "No thumbnail available")

--- a/backend/tests/test_books.py
+++ b/backend/tests/test_books.py
@@ -500,6 +500,36 @@ class TestServeBookThumbnail:
         finally:
             os.unlink(thumb_path)
 
+    def test_thumbnail_served_via_reconstructed_filename(self, client, admin_headers, sys):
+        # Fast path: when the on-disk file matches "{slugify(title)}_{fhash}.webp"
+        # it is served directly without a directory glob.
+        import hashlib
+
+        from backend.config import THUMB_DIR
+
+        fpath = "/tmp/thumb-fastpath-unique-xyz.cbz"
+        book = make_book(
+            system_id=sys.id,
+            title="Fast Path Cover",
+            filename="fastpath.cbz",
+            filepath=fpath,
+            mime_type="application/vnd.comicbook+zip",
+            has_thumbnail=True,
+        )
+        fhash = hashlib.md5(fpath.encode()).hexdigest()[:8]
+        thumb_dir = os.path.join(THUMB_DIR, "books")
+        os.makedirs(thumb_dir, exist_ok=True)
+        # slugify("Fast Path Cover") == "fast-path-cover"
+        thumb_path = os.path.join(thumb_dir, f"fast-path-cover_{fhash}.webp")
+        with open(thumb_path, "wb") as f:
+            f.write(b"RIFF\x00\x00\x00\x00WEBP")
+        try:
+            resp = client.get(f"/api/books/{book.id}/thumbnail", headers=admin_headers)
+            assert resp.status_code == 200
+            assert resp.headers["content-type"] == "image/webp"
+        finally:
+            os.unlink(thumb_path)
+
     def test_thumbnail_nonexistent_book_returns_404(self, client, admin_headers):
         resp = client.get("/api/books/no-such-book/thumbnail", headers=admin_headers)
         assert resp.status_code == 404

--- a/frontend/src/components/LazyImg.jsx
+++ b/frontend/src/components/LazyImg.jsx
@@ -1,0 +1,21 @@
+/**
+ * Image wrapper that defaults to lazy loading and async decoding so dense
+ * grids/lists (library covers, favorites, campaign resources, …) only fetch
+ * images as they scroll into view — see issue #220.
+ *
+ * Pass `eager` for images that should load immediately (reader pages, an
+ * above-the-fold hero, a persistently-visible logo), which sets
+ * loading="eager" and lets the browser decode synchronously.
+ *
+ * All other props (src, alt, style, className, …) pass straight through to the
+ * underlying <img>. Callers may still override `loading`/`decoding` explicitly.
+ */
+export default function LazyImg({ eager = false, loading, decoding, ...props }) {
+  return (
+    <img
+      loading={loading ?? (eager ? 'eager' : 'lazy')}
+      decoding={decoding ?? (eager ? 'auto' : 'async')}
+      {...props}
+    />
+  )
+}

--- a/frontend/src/components/LazyImg.test.jsx
+++ b/frontend/src/components/LazyImg.test.jsx
@@ -1,0 +1,37 @@
+import { render } from '@testing-library/react'
+import { describe, it, expect } from 'vitest'
+import LazyImg from './LazyImg'
+
+describe('LazyImg', () => {
+  it('defaults to lazy loading and async decoding', () => {
+    const { container } = render(<LazyImg src="/x.webp" alt="cover" />)
+    const img = container.querySelector('img')
+    expect(img).toHaveAttribute('loading', 'lazy')
+    expect(img).toHaveAttribute('decoding', 'async')
+    expect(img).toHaveAttribute('src', '/x.webp')
+    expect(img).toHaveAttribute('alt', 'cover')
+  })
+
+  it('loads eagerly when eager is set', () => {
+    const { container } = render(<LazyImg src="/hero.webp" alt="" eager />)
+    const img = container.querySelector('img')
+    expect(img).toHaveAttribute('loading', 'eager')
+    expect(img).toHaveAttribute('decoding', 'auto')
+  })
+
+  it('lets an explicit loading/decoding override the default', () => {
+    const { container } = render(<LazyImg src="/x.webp" alt="" loading="eager" decoding="sync" />)
+    const img = container.querySelector('img')
+    expect(img).toHaveAttribute('loading', 'eager')
+    expect(img).toHaveAttribute('decoding', 'sync')
+  })
+
+  it('passes through other props like style and className', () => {
+    const { container } = render(
+      <LazyImg src="/x.webp" alt="" className="cover" style={{ width: '100%' }} />
+    )
+    const img = container.querySelector('img')
+    expect(img).toHaveClass('cover')
+    expect(img).toHaveStyle({ width: '100%' })
+  })
+})

--- a/frontend/src/components/audio/AudioQueuePanel.jsx
+++ b/frontend/src/components/audio/AudioQueuePanel.jsx
@@ -3,6 +3,7 @@ import { useTranslation } from 'react-i18next'
 import { LuX, LuMusic, LuVolume2, LuGripVertical } from 'react-icons/lu'
 import { mediaUrl } from '../../api'
 import { useAudioPlayer } from '../../context/AudioPlayerContext'
+import LazyImg from '../LazyImg'
 
 /**
  * The expandable "upcoming tracks" list shown above the global player bar.
@@ -134,7 +135,7 @@ export default function AudioQueuePanel({ bottom = 72, left = 0 }) {
                   }}
                 >
                   {track.artwork ? (
-                    <img
+                    <LazyImg
                       src={mediaUrl(`/audio/${track.id}/artwork`)}
                       alt=""
                       style={{ width: '100%', height: '100%', objectFit: 'cover' }}

--- a/frontend/src/components/campaigns/CampaignCard.jsx
+++ b/frontend/src/components/campaigns/CampaignCard.jsx
@@ -4,6 +4,7 @@ import { LuScroll, LuUsers, LuUser, LuLink, LuCalendar, LuNotebook } from 'react
 import { campaigns } from '../../api'
 import WikiMarkdown from './WikiMarkdown'
 import CampaignRoleBadge from './CampaignRoleBadge'
+import LazyImg from '../LazyImg'
 
 function formatSessionDate(dateStr) {
   if (!dateStr) return ''
@@ -71,7 +72,7 @@ export default function CampaignCard({
         }}
       >
         {bannerSrc ? (
-          <img
+          <LazyImg
             src={bannerSrc}
             alt=""
             style={{ width: '100%', height: '100%', objectFit: 'contain', display: 'block' }}

--- a/frontend/src/components/campaigns/CampaignCard.test.jsx
+++ b/frontend/src/components/campaigns/CampaignCard.test.jsx
@@ -1,0 +1,114 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { render, screen } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+import CampaignCard from './CampaignCard'
+
+vi.mock('../../api', () => ({
+  campaigns: { bannerUrl: (id) => `/api/campaigns/${id}/banner?token=x` },
+}))
+vi.mock('./WikiMarkdown', () => ({
+  default: ({ body }) => <div data-testid="wiki">{body}</div>,
+}))
+vi.mock('./CampaignRoleBadge', () => ({ default: ({ label }) => <span>{label}</span> }))
+
+beforeEach(() => vi.clearAllMocks())
+
+const campaign = (over = {}) => ({
+  id: 'c1',
+  name: 'Curse of Strahd',
+  owner_id: 'u1',
+  members: [],
+  has_banner: false,
+  updated_at: '2026-01-01T00:00:00',
+  ...over,
+})
+
+describe('CampaignCard', () => {
+  it('renders the name and calls onClick when activated', async () => {
+    const onClick = vi.fn()
+    render(<CampaignCard campaign={campaign()} onClick={onClick} onOpenNotes={vi.fn()} />)
+    expect(screen.getByText('Curse of Strahd')).toBeInTheDocument()
+    await userEvent.click(screen.getByText('Curse of Strahd'))
+    expect(onClick).toHaveBeenCalled()
+  })
+
+  it('opens notes without bubbling to the card onClick', async () => {
+    const onClick = vi.fn()
+    const onOpenNotes = vi.fn()
+    render(<CampaignCard campaign={campaign()} onClick={onClick} onOpenNotes={onOpenNotes} />)
+    await userEvent.click(screen.getByRole('button', { name: /notes/i }))
+    expect(onOpenNotes).toHaveBeenCalled()
+    expect(onClick).not.toHaveBeenCalled()
+  })
+
+  it('renders a cache-busted banner (lazy) when has_banner', () => {
+    const { container } = render(
+      <CampaignCard
+        campaign={campaign({ has_banner: true })}
+        onClick={vi.fn()}
+        onOpenNotes={vi.fn()}
+      />
+    )
+    const img = container.querySelector('img')
+    expect(img.getAttribute('src')).toContain('/api/campaigns/c1/banner')
+    expect(img.getAttribute('src')).toContain('v=2026-01-01')
+    expect(img).toHaveAttribute('loading', 'lazy')
+  })
+
+  it('renders the description via WikiMarkdown and the badge label', () => {
+    render(
+      <CampaignCard
+        campaign={campaign({ description: 'Gothic horror' })}
+        onClick={vi.fn()}
+        onOpenNotes={vi.fn()}
+        badgeLabel="GM"
+      />
+    )
+    expect(screen.getByTestId('wiki')).toHaveTextContent('Gothic horror')
+    expect(screen.getByText('GM')).toBeInTheDocument()
+  })
+
+  it('activates via the keyboard (Enter)', async () => {
+    const onClick = vi.fn()
+    render(<CampaignCard campaign={campaign()} onClick={onClick} onOpenNotes={vi.fn()} />)
+    const card = screen.getByRole('button', { name: /open campaign/i })
+    card.focus()
+    await userEvent.keyboard('{Enter}')
+    expect(onClick).toHaveBeenCalled()
+  })
+
+  it('formats an upcoming session date and keeps description clicks from opening the card', async () => {
+    const onClick = vi.fn()
+    render(
+      <CampaignCard
+        campaign={campaign({ next_session: '2026-08-15', description: 'read me' })}
+        onClick={onClick}
+        onOpenNotes={vi.fn()}
+      />
+    )
+    // The formatted date renders (exercises formatSessionDate's non-empty path).
+    expect(screen.getByText(/Aug/)).toBeInTheDocument()
+    // Clicking inside the description must not bubble to the card's onClick.
+    await userEvent.click(screen.getByTestId('wiki'))
+    expect(onClick).not.toHaveBeenCalled()
+  })
+
+  it('shows the player count for a GM campaign owned by the viewer', () => {
+    render(
+      <CampaignCard
+        campaign={campaign({
+          is_gm_campaign: true,
+          members: [
+            { status: 'accepted', is_owner: false },
+            { status: 'accepted', is_owner: false },
+            { status: 'pending', is_owner: false },
+          ],
+        })}
+        userId="u1"
+        onClick={vi.fn()}
+        onOpenNotes={vi.fn()}
+      />
+    )
+    expect(screen.getByText(/2/)).toBeInTheDocument()
+  })
+})

--- a/frontend/src/components/campaigns/EmbedCard.jsx
+++ b/frontend/src/components/campaigns/EmbedCard.jsx
@@ -2,6 +2,7 @@ import { useTranslation } from 'react-i18next'
 import { LuBookOpen, LuMap, LuUser, LuMusic, LuFile } from 'react-icons/lu'
 import { campaigns } from '../../api'
 import AudioPlayer from '../audio/AudioPlayer'
+import LazyImg from '../LazyImg'
 
 const embedCardStyle = {
   display: 'inline-flex',
@@ -64,7 +65,7 @@ export default function EmbedCard({ spec, campaignId, onNavigate }) {
   if (type === 'image') {
     if (!campaignId) return null
     return (
-      <img
+      <LazyImg
         src={campaigns.fileUrl(campaignId, id)}
         alt=""
         style={{ maxWidth: '100%', borderRadius: 8, display: 'block', margin: '8px 0' }}

--- a/frontend/src/components/campaigns/GrimoireEmbedPicker.jsx
+++ b/frontend/src/components/campaigns/GrimoireEmbedPicker.jsx
@@ -16,6 +16,7 @@ import { campaigns, mediaUrl } from '../../api'
 import Spinner from '../Spinner'
 import ImageUploadPanel from './ImageUploadPanel'
 import { miniBtn, miniBtnGhost } from './embedPickerStyles'
+import LazyImg from '../LazyImg'
 
 const TYPE_ICON = { book: LuBookOpen, map: LuMap, token: LuUser, audio: LuMusic, file: LuFile }
 
@@ -196,7 +197,7 @@ export default function GrimoireEmbedPicker({ campaignId, onInsert, onClose }) {
                         }}
                       >
                         {thumbUrl ? (
-                          <img
+                          <LazyImg
                             src={thumbUrl}
                             alt=""
                             style={{ width: '100%', height: '100%', objectFit: 'cover' }}

--- a/frontend/src/components/campaigns/MemberRow.jsx
+++ b/frontend/src/components/campaigns/MemberRow.jsx
@@ -19,6 +19,7 @@ import { campaigns } from '../../api'
 import SheetTemplatePicker from './SheetTemplatePicker'
 import ReplaceSheetDialog from './ReplaceSheetDialog'
 import { STATUS_COLORS, sheetActionBtn, smallBtn } from './memberStyles'
+import LazyImg from '../LazyImg'
 
 // Lazy so pdf.js (a large dependency) is only fetched when a sheet is edited.
 const PdfSheetEditor = lazy(() => import('./PdfSheetEditor'))
@@ -164,7 +165,7 @@ export default function MemberRow({
         }}
       >
         {member.has_art && member.id ? (
-          <img
+          <LazyImg
             src={campaigns.memberArtUrl(campaignId, member.id)}
             alt={member.character_name || displayLabel}
             style={{ width: '100%', height: '100%', objectFit: 'cover' }}

--- a/frontend/src/components/campaigns/ResourcePicker.jsx
+++ b/frontend/src/components/campaigns/ResourcePicker.jsx
@@ -4,6 +4,7 @@ import { LuBookOpen, LuSearch, LuX } from 'react-icons/lu'
 import { campaigns, mediaUrl } from '../../api'
 import Spinner from '../Spinner'
 import { TYPE_ICONS } from './resourcesShared'
+import LazyImg from '../LazyImg'
 
 /** Search-and-link picker for adding library resources to a campaign. */
 export default function ResourcePicker({ campaignId, linkedIds, onAdd, onClose }) {
@@ -220,7 +221,7 @@ export default function ResourcePicker({ campaignId, linkedIds, onAdd, onClose }
                   }}
                 >
                   {item.has_thumbnail ? (
-                    <img
+                    <LazyImg
                       src={mediaUrl(
                         `/${item.resource_type === 'book' ? 'books' : item.resource_type + 's'}/${item.resource_id}/thumbnail`
                       )}

--- a/frontend/src/components/campaigns/ResourcePicker.test.jsx
+++ b/frontend/src/components/campaigns/ResourcePicker.test.jsx
@@ -1,0 +1,91 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { render, screen, waitFor } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+import ResourcePicker from './ResourcePicker'
+import { campaigns } from '../../api'
+
+vi.mock('../../api', () => ({
+  mediaUrl: (p) => `http://localhost${p}`,
+  campaigns: {
+    searchResources: vi.fn(),
+    addResource: vi.fn(),
+  },
+}))
+
+const results = [
+  { resource_type: 'book', resource_id: 'b1', name: "Player's Handbook", has_thumbnail: true },
+  { resource_type: 'map', resource_id: 'm1', name: 'Tavern Map', has_thumbnail: false },
+]
+
+beforeEach(() => {
+  vi.clearAllMocks()
+  campaigns.searchResources.mockResolvedValue(results)
+  campaigns.addResource.mockResolvedValue({})
+})
+
+describe('ResourcePicker', () => {
+  it('searches on mount and lists the results', async () => {
+    render(
+      <ResourcePicker campaignId="c1" linkedIds={new Set()} onAdd={vi.fn()} onClose={vi.fn()} />
+    )
+    expect(campaigns.searchResources).toHaveBeenCalledWith('', '')
+    expect(await screen.findByText("Player's Handbook")).toBeInTheDocument()
+    expect(screen.getByText('Tavern Map')).toBeInTheDocument()
+  })
+
+  it('renders a lazy thumbnail for a result that has one', async () => {
+    const { container } = render(
+      <ResourcePicker campaignId="c1" linkedIds={new Set()} onAdd={vi.fn()} onClose={vi.fn()} />
+    )
+    await screen.findByText("Player's Handbook")
+    const img = container.querySelector('img')
+    expect(img.getAttribute('src')).toContain('/books/b1/thumbnail')
+    expect(img).toHaveAttribute('loading', 'lazy')
+  })
+
+  it('adds a resource and calls onAdd', async () => {
+    const onAdd = vi.fn()
+    render(<ResourcePicker campaignId="c1" linkedIds={new Set()} onAdd={onAdd} onClose={vi.fn()} />)
+    await screen.findByText("Player's Handbook")
+    const addButtons = screen.getAllByRole('button', { name: /add/i })
+    await userEvent.click(addButtons[0])
+    await waitFor(() =>
+      expect(campaigns.addResource).toHaveBeenCalledWith('c1', {
+        resource_type: 'book',
+        resource_id: 'b1',
+        visibility: 'public',
+      })
+    )
+    expect(onAdd).toHaveBeenCalled()
+  })
+
+  it('disables the button and skips adding for an already-linked resource', async () => {
+    render(
+      <ResourcePicker
+        campaignId="c1"
+        linkedIds={new Set(['book:b1'])}
+        onAdd={vi.fn()}
+        onClose={vi.fn()}
+      />
+    )
+    expect(await screen.findByText('Linked')).toBeInTheDocument()
+  })
+
+  it('re-searches when a type tab is selected', async () => {
+    render(
+      <ResourcePicker campaignId="c1" linkedIds={new Set()} onAdd={vi.fn()} onClose={vi.fn()} />
+    )
+    await screen.findByText("Player's Handbook")
+    await userEvent.click(screen.getByRole('button', { name: 'Maps' }))
+    expect(campaigns.searchResources).toHaveBeenCalledWith('', 'map')
+  })
+
+  it('closes when the close button is clicked', async () => {
+    const onClose = vi.fn()
+    render(
+      <ResourcePicker campaignId="c1" linkedIds={new Set()} onAdd={vi.fn()} onClose={onClose} />
+    )
+    await userEvent.click(screen.getByRole('button', { name: /close/i }))
+    expect(onClose).toHaveBeenCalled()
+  })
+})

--- a/frontend/src/components/campaigns/ResourceRow.jsx
+++ b/frontend/src/components/campaigns/ResourceRow.jsx
@@ -5,6 +5,7 @@ import { LuBookOpen, LuTrash2, LuChevronRight } from 'react-icons/lu'
 import { campaigns, mediaUrl } from '../../api'
 import { TYPE_ICONS, RESOURCE_NAV, VISIBILITY_OPTIONS, selectStyle } from './resourcesShared'
 import AudioPlayer from '../audio/AudioPlayer'
+import LazyImg from '../LazyImg'
 
 /** A single linked campaign resource with owner controls (visibility, category, share). */
 export default function ResourceRow({
@@ -86,7 +87,7 @@ export default function ResourceRow({
         }}
       >
         {thumbUrl ? (
-          <img
+          <LazyImg
             src={thumbUrl}
             alt=""
             style={{ width: '100%', height: '100%', objectFit: 'cover' }}

--- a/frontend/src/components/campaigns/WikiMarkdown.jsx
+++ b/frontend/src/components/campaigns/WikiMarkdown.jsx
@@ -5,6 +5,7 @@ import ReactMarkdown from 'react-markdown'
 import remarkGfm from 'remark-gfm'
 import { LuFileQuestion } from 'react-icons/lu'
 import EmbedCard from './EmbedCard'
+import LazyImg from '../LazyImg'
 
 // We avoid a custom remark tokenizer by rewriting [[...]] tokens into ordinary
 // markdown links with a private href scheme, then interpreting that scheme in a
@@ -169,7 +170,7 @@ export default function WikiMarkdown({ body, campaignId, pageSlugs = [], onOpenS
       },
       img({ src, alt }) {
         return (
-          <img
+          <LazyImg
             src={src}
             alt={alt || ''}
             style={{ maxWidth: '100%', borderRadius: 8, display: 'block', margin: '8px 0' }}

--- a/frontend/src/components/favorites/AudioFavorite.jsx
+++ b/frontend/src/components/favorites/AudioFavorite.jsx
@@ -9,6 +9,7 @@ import {
   hoverOut,
   rowFavoriteButtonStyle,
 } from './favoriteStyles'
+import LazyImg from '../LazyImg'
 
 export default function AudioFavorite({ item, grid }) {
   const navigate = useNavigate()
@@ -32,7 +33,7 @@ export default function AudioFavorite({ item, grid }) {
           }}
         >
           {item.has_artwork ? (
-            <img
+            <LazyImg
               src={mediaUrl(`/audio/${item.item_id}/artwork`)}
               alt=""
               style={{ width: '100%', height: '100%', objectFit: 'cover' }}
@@ -71,10 +72,9 @@ export default function AudioFavorite({ item, grid }) {
         }}
       >
         {item.has_artwork ? (
-          <img
+          <LazyImg
             src={mediaUrl(`/audio/${item.item_id}/artwork`)}
             alt=""
-            loading="lazy"
             style={{ width: '100%', height: '100%', objectFit: 'cover' }}
           />
         ) : (

--- a/frontend/src/components/favorites/BookFavorite.jsx
+++ b/frontend/src/components/favorites/BookFavorite.jsx
@@ -11,6 +11,7 @@ import {
   hoverOut,
   rowFavoriteButtonStyle,
 } from './favoriteStyles'
+import LazyImg from '../LazyImg'
 
 export default function BookFavorite({ item, grid }) {
   const { t } = useTranslation()
@@ -33,10 +34,9 @@ export default function BookFavorite({ item, grid }) {
           }}
         >
           {item.has_thumbnail ? (
-            <img
+            <LazyImg
               src={mediaUrl(`/books/${item.item_id}/thumbnail`)}
               alt=""
-              loading="lazy"
               style={{ width: '100%', height: '100%', objectFit: 'cover' }}
             />
           ) : (
@@ -80,7 +80,7 @@ export default function BookFavorite({ item, grid }) {
         }}
       >
         {item.has_thumbnail ? (
-          <img
+          <LazyImg
             src={mediaUrl(`/books/${item.item_id}/thumbnail`)}
             alt=""
             style={{ width: '100%', height: '100%', objectFit: 'cover' }}

--- a/frontend/src/components/favorites/MapFavorite.jsx
+++ b/frontend/src/components/favorites/MapFavorite.jsx
@@ -9,6 +9,7 @@ import {
   hoverOut,
   rowFavoriteButtonStyle,
 } from './favoriteStyles'
+import LazyImg from '../LazyImg'
 
 export default function MapFavorite({ item, grid }) {
   const navigate = useNavigate()
@@ -31,7 +32,7 @@ export default function MapFavorite({ item, grid }) {
           }}
         >
           {item.has_thumbnail ? (
-            <img
+            <LazyImg
               src={mediaUrl(`/maps/${item.item_id}/thumbnail`)}
               alt=""
               style={{ width: '100%', height: '100%', objectFit: 'cover' }}
@@ -70,10 +71,9 @@ export default function MapFavorite({ item, grid }) {
         }}
       >
         {item.has_thumbnail ? (
-          <img
+          <LazyImg
             src={mediaUrl(`/maps/${item.item_id}/thumbnail`)}
             alt=""
-            loading="lazy"
             style={{ width: '100%', height: '100%', objectFit: 'cover' }}
           />
         ) : (

--- a/frontend/src/components/favorites/SystemFavorite.jsx
+++ b/frontend/src/components/favorites/SystemFavorite.jsx
@@ -9,6 +9,7 @@ import {
   hoverOut,
   rowFavoriteButtonStyle,
 } from './favoriteStyles'
+import LazyImg from '../LazyImg'
 
 export default function SystemFavorite({ item, grid }) {
   const navigate = useNavigate()
@@ -29,10 +30,9 @@ export default function SystemFavorite({ item, grid }) {
           }}
         >
           {item.cover_book_id ? (
-            <img
+            <LazyImg
               src={mediaUrl(`/books/${item.cover_book_id}/thumbnail`)}
               alt=""
-              loading="lazy"
               style={{ width: '100%', height: '100%', objectFit: 'cover' }}
             />
           ) : (
@@ -87,7 +87,7 @@ export default function SystemFavorite({ item, grid }) {
         }}
       >
         {item.cover_book_id ? (
-          <img
+          <LazyImg
             src={mediaUrl(`/books/${item.cover_book_id}/thumbnail`)}
             alt=""
             style={{ width: '100%', height: '100%', objectFit: 'cover' }}

--- a/frontend/src/components/favorites/SystemFavorite.test.jsx
+++ b/frontend/src/components/favorites/SystemFavorite.test.jsx
@@ -1,0 +1,52 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { render, screen } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+import SystemFavorite from './SystemFavorite'
+
+const navigate = vi.fn()
+vi.mock('react-router-dom', () => ({ useNavigate: () => navigate }))
+vi.mock('../../api', () => ({ mediaUrl: (p) => `http://localhost${p}` }))
+vi.mock('../FavoriteButton', () => ({ default: () => <button>fav</button> }))
+
+beforeEach(() => vi.clearAllMocks())
+
+const item = (over = {}) => ({
+  item_id: 's1',
+  name: 'Dungeons & Dragons',
+  cover_book_id: null,
+  publishers: [],
+  ...over,
+})
+
+describe('SystemFavorite', () => {
+  it('renders the name in grid mode and navigates on click', async () => {
+    render(<SystemFavorite item={item()} grid />)
+    expect(screen.getByText('Dungeons & Dragons')).toBeInTheDocument()
+    await userEvent.click(screen.getByText('Dungeons & Dragons'))
+    expect(navigate).toHaveBeenCalledWith('/library/system/s1')
+  })
+
+  it('renders in row mode and navigates on click', async () => {
+    render(<SystemFavorite item={item()} grid={false} />)
+    await userEvent.click(screen.getByText('Dungeons & Dragons'))
+    expect(navigate).toHaveBeenCalledWith('/library/system/s1')
+  })
+
+  it('joins publisher names when present', () => {
+    render(<SystemFavorite item={item({ publishers: [{ name: 'WotC' }, { name: 'TSR' }] })} grid />)
+    expect(screen.getByText('WotC, TSR')).toBeInTheDocument()
+  })
+
+  it('renders the cover thumbnail (lazy) when cover_book_id is set', () => {
+    const { container } = render(<SystemFavorite item={item({ cover_book_id: 'b9' })} grid />)
+    const img = container.querySelector('img')
+    expect(img.getAttribute('src')).toContain('/books/b9/thumbnail')
+    expect(img).toHaveAttribute('loading', 'lazy')
+  })
+
+  it('falls back to an icon when there is no cover', () => {
+    const { container } = render(<SystemFavorite item={item()} grid={false} />)
+    expect(container.querySelector('img')).toBeNull()
+    expect(container.querySelector('svg')).toBeTruthy()
+  })
+})

--- a/frontend/src/components/favorites/TokenFavorite.jsx
+++ b/frontend/src/components/favorites/TokenFavorite.jsx
@@ -9,6 +9,7 @@ import {
   hoverOut,
   rowFavoriteButtonStyle,
 } from './favoriteStyles'
+import LazyImg from '../LazyImg'
 
 export default function TokenFavorite({ item, grid }) {
   const navigate = useNavigate()
@@ -31,7 +32,7 @@ export default function TokenFavorite({ item, grid }) {
           }}
         >
           {item.has_thumbnail ? (
-            <img
+            <LazyImg
               src={mediaUrl(`/tokens/${item.item_id}/thumbnail`)}
               alt=""
               style={{ width: '100%', height: '100%', objectFit: 'cover' }}
@@ -70,10 +71,9 @@ export default function TokenFavorite({ item, grid }) {
         }}
       >
         {item.has_thumbnail ? (
-          <img
+          <LazyImg
             src={mediaUrl(`/tokens/${item.item_id}/thumbnail`)}
             alt=""
-            loading="lazy"
             style={{ width: '100%', height: '100%', objectFit: 'cover' }}
           />
         ) : (

--- a/frontend/src/components/favorites/TokenFavorite.test.jsx
+++ b/frontend/src/components/favorites/TokenFavorite.test.jsx
@@ -1,0 +1,46 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { render, screen } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+import TokenFavorite from './TokenFavorite'
+
+const navigate = vi.fn()
+vi.mock('react-router-dom', () => ({ useNavigate: () => navigate }))
+vi.mock('../../api', () => ({ mediaUrl: (p) => `http://localhost${p}` }))
+vi.mock('../FavoriteButton', () => ({ default: () => <button>fav</button> }))
+
+beforeEach(() => vi.clearAllMocks())
+
+const item = (over = {}) => ({
+  item_id: 't1',
+  filename: 'goblin.png',
+  has_thumbnail: false,
+  ...over,
+})
+
+describe('TokenFavorite', () => {
+  it('renders the filename in grid mode and navigates on click', async () => {
+    render(<TokenFavorite item={item()} grid />)
+    expect(screen.getByText('goblin.png')).toBeInTheDocument()
+    await userEvent.click(screen.getByText('goblin.png'))
+    expect(navigate).toHaveBeenCalledWith('/tokens/t1')
+  })
+
+  it('renders in row mode and navigates on click', async () => {
+    render(<TokenFavorite item={item()} grid={false} />)
+    await userEvent.click(screen.getByText('goblin.png'))
+    expect(navigate).toHaveBeenCalledWith('/tokens/t1')
+  })
+
+  it('renders the thumbnail (lazy) when has_thumbnail is set', () => {
+    const { container } = render(<TokenFavorite item={item({ has_thumbnail: true })} grid />)
+    const img = container.querySelector('img')
+    expect(img.getAttribute('src')).toContain('/tokens/t1/thumbnail')
+    expect(img).toHaveAttribute('loading', 'lazy')
+  })
+
+  it('falls back to an icon when no thumbnail', () => {
+    const { container } = render(<TokenFavorite item={item()} grid />)
+    expect(container.querySelector('img')).toBeNull()
+    expect(container.querySelector('svg')).toBeTruthy()
+  })
+})

--- a/frontend/src/components/library/SystemCard.jsx
+++ b/frontend/src/components/library/SystemCard.jsx
@@ -4,6 +4,7 @@ import { LuLibrary, LuCheck } from 'react-icons/lu'
 import { mediaUrl } from '../../api'
 import Tag from '../Tag'
 import FavoriteButton from '../FavoriteButton'
+import LazyImg from '../LazyImg'
 
 /**
  * Game-system card for the library grid. Renders one of three layouts —
@@ -96,7 +97,7 @@ export default function SystemCard({
           }}
         >
           {system.cover_book_id ? (
-            <img
+            <LazyImg
               src={mediaUrl(`/books/${system.cover_book_id}/thumbnail`)}
               alt=""
               style={{ width: '100%', height: '100%', objectFit: 'cover' }}
@@ -183,7 +184,7 @@ export default function SystemCard({
           }}
         >
           {system.cover_book_id ? (
-            <img
+            <LazyImg
               src={mediaUrl(`/books/${system.cover_book_id}/thumbnail`)}
               alt=""
               style={{ width: '100%', height: '100%', objectFit: 'cover', display: 'block' }}
@@ -244,7 +245,7 @@ export default function SystemCard({
             justifyContent: 'center',
           }}
         >
-          <img
+          <LazyImg
             src={mediaUrl(`/books/${system.cover_book_id}/thumbnail`)}
             alt=""
             style={{ maxWidth: '100%', maxHeight: '100%', objectFit: 'contain', display: 'block' }}

--- a/frontend/src/components/media/MediaCard.jsx
+++ b/frontend/src/components/media/MediaCard.jsx
@@ -6,6 +6,7 @@ import { formatSize } from '../../utils'
 import FavoriteButton from '../FavoriteButton'
 import DownloadButton from '../DownloadButton'
 import AudioPlayer from '../audio/AudioPlayer'
+import LazyImg from '../LazyImg'
 
 const CORNER_POS = {
   'bottom-left': { bottom: 6, left: 6 },
@@ -103,10 +104,9 @@ export default function MediaCard({ config, item, onClick, bulkMode, selected, o
           }}
         >
           {hasThumbnail ? (
-            <img
+            <LazyImg
               src={mediaUrl(config.thumbnailUrl(item.id))}
               alt=""
-              loading="lazy"
               style={{ width: '100%', height: '100%', objectFit: 'cover' }}
             />
           ) : (
@@ -228,10 +228,9 @@ export default function MediaCard({ config, item, onClick, bulkMode, selected, o
         }}
       >
         {hasThumbnail ? (
-          <img
+          <LazyImg
             src={mediaUrl(config.thumbnailUrl(item.id))}
             alt=""
-            loading="lazy"
             style={{ width: '100%', height: '100%', objectFit: 'cover' }}
           />
         ) : (

--- a/frontend/src/components/system/BookRow.jsx
+++ b/frontend/src/components/system/BookRow.jsx
@@ -16,6 +16,7 @@ import { getBookPrefs } from '../../hooks/useBookPrefs'
 import FavoriteButton from '../FavoriteButton'
 import DownloadButton from '../DownloadButton'
 import ReocrButton from '../ReocrButton'
+import LazyImg from '../LazyImg'
 
 /**
  * A single book entry. Renders as a list row by default; pass `card` or
@@ -204,10 +205,9 @@ export default function BookRow({
           }}
         >
           {book.has_thumbnail ? (
-            <img
+            <LazyImg
               src={mediaUrl(`/books/${book.id}/thumbnail`)}
               alt=""
-              loading="lazy"
               style={{ width: '100%', height: '100%', objectFit: 'cover' }}
             />
           ) : (
@@ -372,7 +372,7 @@ export default function BookRow({
         }}
       >
         {book.has_thumbnail ? (
-          <img
+          <LazyImg
             src={mediaUrl(`/books/${book.id}/thumbnail`)}
             alt=""
             style={{ width: '100%', height: '100%', objectFit: 'cover' }}

--- a/frontend/src/components/system/SystemBulkEditFields.jsx
+++ b/frontend/src/components/system/SystemBulkEditFields.jsx
@@ -2,6 +2,7 @@ import { useState, useEffect, useRef } from 'react'
 import { useTranslation } from 'react-i18next'
 import { LuImage, LuX, LuPlus } from 'react-icons/lu'
 import api, { mediaUrl } from '../../api'
+import LazyImg from '../LazyImg'
 
 // Rich editor body for one system inside the bulk-edit carousel. Mirrors the
 // single-system SystemEditor: description, tag chips, publisher rows, character
@@ -219,7 +220,7 @@ export default function SystemBulkEditFields({ system, draft, setField }) {
                   flexShrink: 0,
                 }}
               >
-                <img
+                <LazyImg
                   src={mediaUrl(`/books/${b.id}/thumbnail`)}
                   alt={b.title}
                   style={{ width: '100%', height: '100%', objectFit: 'cover', display: 'block' }}

--- a/frontend/src/components/system/SystemEditor.jsx
+++ b/frontend/src/components/system/SystemEditor.jsx
@@ -2,6 +2,7 @@ import { useState, useRef } from 'react'
 import { useTranslation } from 'react-i18next'
 import { LuImage, LuX, LuPlus } from 'react-icons/lu'
 import api, { mediaUrl } from '../../api'
+import LazyImg from '../LazyImg'
 
 export default function SystemEditor({ system, onSave }) {
   const { t } = useTranslation()
@@ -317,7 +318,7 @@ export default function SystemEditor({ system, onSave }) {
                   boxShadow: form.cover_book_id === b.id ? '0 0 0 2px var(--gold-dim)' : 'none',
                 }}
               >
-                <img
+                <LazyImg
                   src={mediaUrl(`/books/${b.id}/thumbnail`)}
                   alt={b.title}
                   style={{ width: '100%', height: '100%', objectFit: 'cover', display: 'block' }}

--- a/frontend/src/components/system/SystemEditor.test.jsx
+++ b/frontend/src/components/system/SystemEditor.test.jsx
@@ -1,0 +1,162 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { render, screen, waitFor } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+import SystemEditor from './SystemEditor'
+import api from '../../api'
+
+vi.mock('../../api', () => ({
+  default: { patch: vi.fn() },
+  mediaUrl: (p) => `http://localhost${p}`,
+}))
+
+beforeEach(() => {
+  vi.clearAllMocks()
+  api.patch.mockResolvedValue({})
+})
+
+const system = (over = {}) => ({
+  id: 'sys1',
+  description: '',
+  publishers: [],
+  character_builder_url: '',
+  tags: [],
+  genre: '',
+  cover_book_id: null,
+  is_explicit: false,
+  books: [],
+  ...over,
+})
+
+describe('SystemEditor', () => {
+  it('saves the patched fields and calls onSave', async () => {
+    const onSave = vi.fn()
+    render(<SystemEditor system={system({ genre: 'Fantasy' })} onSave={onSave} />)
+    await userEvent.click(screen.getByText(/save changes/i))
+    await waitFor(() => expect(api.patch).toHaveBeenCalledWith('/systems/sys1', expect.any(Object)))
+    expect(api.patch.mock.calls[0][1].genre).toBe('Fantasy')
+    expect(onSave).toHaveBeenCalled()
+  })
+
+  it('adds a tag on Enter and includes it in the save payload', async () => {
+    render(<SystemEditor system={system()} onSave={vi.fn()} />)
+    const tagInput = screen.getByPlaceholderText(/tag/i)
+    await userEvent.type(tagInput, 'grimdark{Enter}')
+    expect(screen.getByText('grimdark')).toBeInTheDocument()
+    await userEvent.click(screen.getByText(/save changes/i))
+    await waitFor(() => expect(api.patch).toHaveBeenCalled())
+    expect(api.patch.mock.calls[0][1].tags).toContain('grimdark')
+  })
+
+  it('drops empty publishers from the save payload', async () => {
+    render(
+      <SystemEditor
+        system={system({
+          publishers: [
+            { name: 'WotC', url: '' },
+            { name: '', url: '' },
+          ],
+        })}
+        onSave={vi.fn()}
+      />
+    )
+    await userEvent.click(screen.getByText(/save changes/i))
+    await waitFor(() => expect(api.patch).toHaveBeenCalled())
+    expect(api.patch.mock.calls[0][1].publishers).toEqual([{ name: 'WotC', url: '' }])
+  })
+
+  it('renders cover choices lazily and toggles the selection', async () => {
+    const { container } = render(
+      <SystemEditor
+        system={system({ books: [{ id: 'b1', title: 'Core Book', has_thumbnail: true }] })}
+        onSave={vi.fn()}
+      />
+    )
+    const img = container.querySelector('img')
+    expect(img.getAttribute('src')).toContain('/books/b1/thumbnail')
+    expect(img).toHaveAttribute('loading', 'lazy')
+
+    await userEvent.click(screen.getByTitle('Core Book'))
+    await userEvent.click(screen.getByText(/save changes/i))
+    await waitFor(() => expect(api.patch).toHaveBeenCalled())
+    expect(api.patch.mock.calls[0][1].cover_book_id).toBe('b1')
+  })
+
+  it('edits the description and character-builder URL fields', async () => {
+    render(<SystemEditor system={system()} onSave={vi.fn()} />)
+    const desc = document.getElementById('system-field-description')
+    await userEvent.type(desc, 'A grim world')
+    const cb = document.getElementById('system-field-character_builder_url')
+    await userEvent.type(cb, 'https://builder.example')
+    await userEvent.click(screen.getByText(/save changes/i))
+    await waitFor(() => expect(api.patch).toHaveBeenCalled())
+    const payload = api.patch.mock.calls[0][1]
+    expect(payload.description).toBe('A grim world')
+    expect(payload.character_builder_url).toBe('https://builder.example')
+  })
+
+  it('removes the last tag on Backspace in an empty input', async () => {
+    render(<SystemEditor system={system({ tags: ['alpha', 'beta'] })} onSave={vi.fn()} />)
+    const tagInput = document.getElementById('system-tag-input')
+    tagInput.focus()
+    await userEvent.keyboard('{Backspace}')
+    expect(screen.queryByText('beta')).toBeNull()
+    expect(screen.getByText('alpha')).toBeInTheDocument()
+  })
+
+  it('removes a tag via its remove button', async () => {
+    render(<SystemEditor system={system({ tags: ['keepme', 'dropme'] })} onSave={vi.fn()} />)
+    const dropTag = screen.getByText('dropme')
+    await userEvent.click(dropTag.querySelector('button'))
+    expect(screen.queryByText('dropme')).toBeNull()
+  })
+
+  it('adds, edits, and removes publishers', async () => {
+    render(<SystemEditor system={system()} onSave={vi.fn()} />)
+    // system() has no publishers, so the form seeds one empty row.
+    await userEvent.click(screen.getByText(/add publisher/i))
+    const names = screen.getAllByLabelText(/publisher name/i)
+    expect(names.length).toBe(2)
+    await userEvent.type(names[0], 'Paizo')
+    const urls = screen.getAllByLabelText(/url \(optional\)/i)
+    await userEvent.type(urls[0], 'https://paizo.com')
+    await userEvent.click(screen.getByText(/save changes/i))
+    await waitFor(() => expect(api.patch).toHaveBeenCalled())
+    expect(api.patch.mock.calls[0][1].publishers).toEqual([
+      { name: 'Paizo', url: 'https://paizo.com' },
+    ])
+  })
+
+  it('toggles the explicit checkbox into the payload', async () => {
+    render(<SystemEditor system={system()} onSave={vi.fn()} />)
+    await userEvent.click(document.getElementById('system-is-explicit'))
+    await userEvent.click(screen.getByText(/save changes/i))
+    await waitFor(() => expect(api.patch).toHaveBeenCalled())
+    expect(api.patch.mock.calls[0][1].is_explicit).toBe(true)
+  })
+
+  it('clears a selected cover', async () => {
+    render(
+      <SystemEditor
+        system={system({
+          cover_book_id: 'b1',
+          books: [{ id: 'b1', title: 'Core Book', has_thumbnail: true }],
+        })}
+        onSave={vi.fn()}
+      />
+    )
+    await userEvent.click(screen.getByText(/clear/i))
+    await userEvent.click(screen.getByText(/save changes/i))
+    await waitFor(() => expect(api.patch).toHaveBeenCalled())
+    expect(api.patch.mock.calls[0][1].cover_book_id).toBeNull()
+  })
+
+  it('omits the cover picker when no book has a thumbnail', () => {
+    render(
+      <SystemEditor
+        system={system({ books: [{ id: 'b1', title: 'No Thumb', has_thumbnail: false }] })}
+        onSave={vi.fn()}
+      />
+    )
+    expect(screen.queryByTitle('No Thumb')).toBeNull()
+  })
+})

--- a/frontend/src/views/LibraryView.jsx
+++ b/frontend/src/views/LibraryView.jsx
@@ -17,6 +17,7 @@ import FavToggle from '../components/library/FavToggle'
 import TagFilterBar from '../components/media/TagFilterBar'
 import BulkActionBar from '../components/BulkActionBar'
 import BulkEditModal from '../components/BulkEditModal'
+import LazyImg from '../components/LazyImg'
 
 export default function LibraryView() {
   const { t } = useTranslation()
@@ -211,7 +212,7 @@ export default function LibraryView() {
                     }}
                   >
                     {book.has_thumbnail ? (
-                      <img
+                      <LazyImg
                         src={mediaUrl(`/books/${book.id}/thumbnail`)}
                         alt=""
                         style={{ width: '100%', height: '100%', objectFit: 'cover' }}


### PR DESCRIPTION
## Summary

Refactored images under a single component.

## Type of change

- [x] Bug fix
- [ ] New feature
- [x] Refactor / cleanup
- [ ] Docs / configuration only

## Testing

<!-- How did you verify this works? Check all that apply. -->

- [x] Backend tests pass (`pytest -q`)
- [x] Frontend tests pass (`npm test`)
- [x] Tested manually in the browser

## Notes for reviewer

<!-- Anything that needs extra context, known limitations, or follow-up work. Delete if not needed. -->
