### PR TITLE
Fix: Allow PDF maps to be displayed using the same PDF viewing as with books

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ A Docker-based web application for managing your tabletop RPG PDF collection. Br
 - **Library Browser** - Organizes your collection by game system with automatic folder detection
 - **Full-Text Search** - Every page of every PDF is indexed with SQLite FTS5 for instant search; also finds maps, tokens, and audio by filename, folder, or tag
 - **Page-by-Page Viewer** - PDFs rendered as images for fast mobile viewing with pinch-to-zoom, swipe navigation, and spread mode
-- **Map Gallery** - Browse battlemaps by directory structure with tag filtering, grid metadata, and full-res download
+- **Map Gallery** - Browse battlemaps by directory structure with tag filtering, grid metadata, and full-res download. Image and PDF maps both display in-app; multi-page PDF maps open in a viewer with single-page, two-page spread, and raw-PDF modes
 - **Token Browser** - Browse and tag character tokens and portrait assets
 - **Audio Library** - Browse ambient tracks, soundscapes, music, and sound effects by directory structure with tag filtering and in-browser playback (MP3, OGG, Opus, FLAC, WAV, M4A, AAC). Reads embedded duration and title/artist/album tags, and uses folder `cover`/`folder` images or embedded album art for artwork
 - **Global Audio Player** - A persistent pop-out player that keeps playing while you navigate. Build a local queue by playing a whole folder, queueing tracks one at a time ("Play Next"), having a GM play a campaign resource group, or playing all the audio embedded in a wiki note. Expand it to see and reorder upcoming tracks, with a repeat-current-track toggle
@@ -329,7 +329,7 @@ maps/
     └── map-file.png
 ```
 
-The folder name is shown as a group header in the map gallery.
+The folder name is shown as a group header in the map gallery. Both image maps and PDF maps (including multi-page PDFs) are supported and viewable in-app.
 
 ### Tokens - organize by type
 

--- a/backend/routers/maps/__init__.py
+++ b/backend/routers/maps/__init__.py
@@ -8,6 +8,7 @@ from .core import (
     update_map_folder,
     get_map,
     serve_map_file,
+    serve_map_page,
     serve_map_thumbnail,
     update_map,
 )
@@ -54,6 +55,13 @@ router.add_api_route(
     methods=["GET"],
     summary="Download map file",
     description="Streams the original map image or PDF. Accepts `?token=` for browser-embedded images.",
+)
+router.add_api_route(
+    "/maps/{map_id}/page/{page_num}",
+    serve_map_page,
+    methods=["GET"],
+    summary="Render a map page",
+    description="Renders a single page of a PDF map to WebP (`?width=` sets the target pixel width, default 1600, max 3000). Image maps are streamed as-is and only accept page 1. Accepts `?token=` for browser-embedded images.",
 )
 router.add_api_route(
     "/maps/{map_id}/thumbnail",

--- a/backend/routers/maps/_helpers.py
+++ b/backend/routers/maps/_helpers.py
@@ -1,9 +1,75 @@
 """Image metadata helpers for map endpoints."""
+import hashlib
+import io
+import os
 import re
 from pathlib import Path
 from typing import Optional
 
+import fitz  # type: ignore[import-untyped]
 from PIL import Image as PILImage  # type: ignore[import-untyped]
+
+from ...config import PAGE_CACHE_DIR, _valkey, logger
+from ..books._helpers import _get_pdf_doc
+
+
+def _is_pdf(filepath: str) -> bool:
+    return Path(filepath).suffix.lower() == ".pdf"
+
+
+def render_map_pdf_page(filepath: str, page_num: int, width: int) -> bytes:
+    """Render one PDF map page to WebP bytes, caching to Valkey/disk like books.
+
+    Mirrors ``books.pages.serve_book_page`` rendering (PyMuPDF → WebP) but without
+    the book-specific text/word extraction. ``page_num`` is 1-based.
+    """
+    valkey_key = f"mappage:{filepath}:{page_num}:{width}"
+    if _valkey is not None:
+        try:
+            cached = _valkey.get(valkey_key)
+            if cached:
+                return cached
+        except Exception as e:
+            logger.warning(f"Valkey get error: {e}")
+
+    # Derive cache filename from the DB-sourced filepath (never user input) so no
+    # tainted data touches the filesystem path.
+    file_hash = hashlib.sha1(filepath.encode()).hexdigest()[:16]
+    cache_path = os.path.join(PAGE_CACHE_DIR, f"map_{file_hash}_{page_num}_{width}.webp")
+    if os.path.exists(cache_path):
+        with open(cache_path, "rb") as f:
+            data = f.read()
+        if _valkey is not None:
+            try:
+                _valkey.set(valkey_key, data)
+            except Exception as e:
+                logger.warning(f"Valkey set error: {e}")
+        return data
+
+    doc = _get_pdf_doc(filepath)
+    if page_num < 1 or page_num > len(doc):
+        raise ValueError(f"Page must be between 1 and {len(doc)}")
+    page = doc[page_num - 1]
+    zoom = width / page.rect.width
+    pix = page.get_pixmap(matrix=fitz.Matrix(zoom, zoom), alpha=False)
+    buf = io.BytesIO()
+    PILImage.frombytes("RGB", (pix.width, pix.height), pix.samples).save(
+        buf, format="webp", quality=85, method=0
+    )
+    img_bytes = buf.getvalue()
+
+    if _valkey is not None:
+        try:
+            _valkey.set(valkey_key, img_bytes)
+        except Exception as e:
+            logger.warning(f"Valkey set error: {e}")
+            with open(cache_path, "wb") as f:
+                f.write(img_bytes)
+    else:
+        with open(cache_path, "wb") as f:
+            f.write(img_bytes)
+
+    return img_bytes
 
 
 # Matches: (20x25), [30 by 40], 20x25, 20 X 25, 20×25, 20 by 25, 20-by-25
@@ -39,18 +105,42 @@ def _estimate_grid(
 
 
 def _map_image_info(filepath: str, relative_path: str) -> dict:
-    info: dict = {"pixel_width": None, "pixel_height": None, "dpi": None, "grid": None}
-    try:
-        img = PILImage.open(filepath)
-        info["pixel_width"], info["pixel_height"] = img.size
-        raw_dpi = img.info.get("dpi")
-        if raw_dpi:
-            dpi_val = float(raw_dpi[0]) if isinstance(raw_dpi, (tuple, list)) else float(raw_dpi)
-            if 10 < dpi_val < 2000:
-                info["dpi"] = round(dpi_val)
-        img.close()
-    except Exception:
-        return info
+    info: dict = {
+        "pixel_width": None,
+        "pixel_height": None,
+        "dpi": None,
+        "grid": None,
+        "is_pdf": False,
+        "page_count": None,
+    }
+    if _is_pdf(filepath):
+        info["is_pdf"] = True
+        try:
+            doc = _get_pdf_doc(filepath)
+            info["page_count"] = len(doc)
+            if len(doc):
+                rect = doc[0].rect
+                # PDF user-space units are 1/72". Report page-1 pixel size at 72
+                # DPI (i.e. the point dimensions) so grid detection can run.
+                info["pixel_width"] = round(rect.width)
+                info["pixel_height"] = round(rect.height)
+                info["dpi"] = 72
+        except Exception:
+            return info
+    else:
+        try:
+            img = PILImage.open(filepath)
+            info["pixel_width"], info["pixel_height"] = img.size
+            raw_dpi = img.info.get("dpi")
+            if raw_dpi:
+                dpi_val = (
+                    float(raw_dpi[0]) if isinstance(raw_dpi, (tuple, list)) else float(raw_dpi)
+                )
+                if 10 < dpi_val < 2000:
+                    info["dpi"] = round(dpi_val)
+            img.close()
+        except Exception:
+            return info
 
     pw, ph = info["pixel_width"], info["pixel_height"]
 
@@ -70,8 +160,9 @@ def _map_image_info(filepath: str, relative_path: str) -> dict:
             if 2 <= gw <= 300 and 2 <= gh <= 300 and err < 0.05:
                 info["grid"] = {"width": gw, "height": gh, "cell_px": info["dpi"], "source": "dpi"}
 
-        # 3. Estimate from common pixel-per-cell sizes
-        if not info["grid"]:
+        # 3. Estimate from common pixel-per-cell sizes (raster maps only — the
+        #    candidate cell sizes are meaningless against PDF point dimensions).
+        if not info["grid"] and not info["is_pdf"]:
             est = _estimate_grid(pw, ph, info["dpi"])
             if est:
                 info["grid"] = {
@@ -80,5 +171,14 @@ def _map_image_info(filepath: str, relative_path: str) -> dict:
                     "cell_px": est[2],
                     "source": "computed",
                 }
+
+    if info["is_pdf"]:
+        # The point-based dimensions and the synthetic 72 DPI were only useful for
+        # grid inference; they don't describe a real raster, so don't surface them.
+        info["pixel_width"] = None
+        info["pixel_height"] = None
+        info["dpi"] = None
+        if info["grid"] and "cell_px" in info["grid"]:
+            info["grid"].pop("cell_px")
 
     return info

--- a/backend/routers/maps/core.py
+++ b/backend/routers/maps/core.py
@@ -1,18 +1,19 @@
 """Map CRUD, file-serving, and folder-tagging endpoints."""
 import hashlib
+import io
 import os
 from pathlib import Path
 from typing import Optional
 
 from fastapi import APIRouter, Depends, HTTPException, Query
-from fastapi.responses import FileResponse
+from fastapi.responses import FileResponse, StreamingResponse
 
-from ...config import SessionLocal, THUMB_DIR
+from ...config import _PAGE_CACHE_HEADERS, SessionLocal, THUMB_DIR
 from ...models import GenericMap, MapFolder
 from ...auth import require_gm_or_admin, get_current_user, CurrentUser
 from ...indexer import slugify
 from .._media_access import assert_media_access
-from ._helpers import _map_image_info
+from ._helpers import _is_pdf, _map_image_info, render_map_pdf_page
 from ._schemas import FolderTagsUpdate, MapUpdate
 
 router = APIRouter()
@@ -134,6 +135,51 @@ def serve_map_file(map_id: str, current_user: CurrentUser = Depends(get_current_
         return FileResponse(m.filepath, media_type=media, filename=m.filename)
     finally:
         db.close()
+
+
+def serve_map_page(
+    map_id: str,
+    page_num: int,
+    width: int = Query(1600, le=3000),
+    current_user: CurrentUser = Depends(get_current_user),
+):
+    """Render a single page of a PDF map to WebP.
+
+    Image maps have exactly one page and are streamed as-is (page_num must be 1).
+    PDF maps are rendered server-side with PyMuPDF and cached, mirroring the book
+    page reader but without text extraction.
+    """
+    db = SessionLocal()
+    try:
+        m = db.query(GenericMap).filter_by(id=map_id).first()
+        if not m:
+            raise HTTPException(404)
+        assert_media_access(db, current_user, "map", m.id)
+        if not os.path.exists(m.filepath):
+            if not m.is_missing:
+                m.is_missing = True
+                db.commit()
+            raise HTTPException(404, "File not found on disk")
+        filepath = m.filepath
+    finally:
+        db.close()
+
+    if not _is_pdf(filepath):
+        if page_num != 1:
+            raise HTTPException(400, "Image maps have only one page")
+        ext = Path(filepath).suffix.lower().lstrip(".")
+        media_type = "image/jpeg" if ext == "jpg" else f"image/{ext}"
+        return FileResponse(filepath, media_type=media_type, headers=_PAGE_CACHE_HEADERS)
+
+    try:
+        img_bytes = render_map_pdf_page(filepath, page_num, width)
+    except ValueError as e:
+        raise HTTPException(400, str(e))
+    except Exception:
+        raise HTTPException(500, "Failed to render page") from None
+    return StreamingResponse(
+        io.BytesIO(img_bytes), media_type="image/webp", headers=_PAGE_CACHE_HEADERS
+    )
 
 
 def serve_map_thumbnail(map_id: str, current_user: CurrentUser = Depends(get_current_user)):

--- a/backend/tests/test_maps.py
+++ b/backend/tests/test_maps.py
@@ -104,6 +104,25 @@ class TestGetMap:
         resp = client.get("/api/maps/does-not-exist", headers=admin_headers)
         assert resp.status_code == 404
 
+    def test_raster_map_reports_not_pdf(self, client, admin_headers, map_entry):
+        resp = client.get(f"/api/maps/{map_entry.id}", headers=admin_headers)
+        body = resp.json()
+        assert body["is_pdf"] is False
+        assert body["page_count"] is None
+
+    def test_pdf_map_reports_page_count(self, client, admin_headers, tmp_path):
+        f = tmp_path / "dungeon.pdf"
+        _write_pdf(f, pages=4)
+        m = make_map(filename="dungeon.pdf", filepath=str(f))
+        resp = client.get(f"/api/maps/{m.id}", headers=admin_headers)
+        assert resp.status_code == 200
+        body = resp.json()
+        assert body["is_pdf"] is True
+        assert body["page_count"] == 4
+        # PDF point dimensions/DPI aren't surfaced as raster info.
+        assert body["pixel_width"] is None
+        assert body["dpi"] is None
+
 
 class TestUpdateMap:
     def test_gm_can_update_map(self, client, gm_headers, map_entry):
@@ -245,6 +264,69 @@ class TestServeMapFile:
         gone = tmp_path / "gone.png"
         m = make_map(filename="gone.png", filepath=str(gone))
         resp = client.get(f"/api/maps/{m.id}/file", headers=admin_headers)
+        assert resp.status_code == 404
+        db = SessionLocal()
+        try:
+            from backend.models import GenericMap
+
+            assert db.query(GenericMap).filter_by(id=m.id).first().is_missing
+        finally:
+            db.close()
+
+
+def _write_pdf(path, pages=1):
+    """Create a real multi-page PDF on disk so PyMuPDF can render it."""
+    import fitz
+
+    doc = fitz.open()
+    for i in range(pages):
+        page = doc.new_page(width=612, height=792)
+        page.insert_text((72, 72), f"Map page {i + 1}")
+    doc.save(str(path))
+    doc.close()
+
+
+class TestServeMapPage:
+    def test_image_map_page1_returns_file(self, client, admin_headers, tmp_path):
+        f = tmp_path / "battle.png"
+        f.write_bytes(b"fake-png-bytes")
+        m = make_map(filename="battle.png", filepath=str(f))
+        resp = client.get(f"/api/maps/{m.id}/page/1", headers=admin_headers)
+        assert resp.status_code == 200
+        assert resp.headers["content-type"] == "image/png"
+        assert resp.content == b"fake-png-bytes"
+
+    def test_image_map_page_beyond_1_is_400(self, client, admin_headers, tmp_path):
+        f = tmp_path / "battle.png"
+        f.write_bytes(b"fake-png-bytes")
+        m = make_map(filename="battle.png", filepath=str(f))
+        resp = client.get(f"/api/maps/{m.id}/page/2", headers=admin_headers)
+        assert resp.status_code == 400
+
+    def test_pdf_map_page_rendered_as_webp(self, client, admin_headers, tmp_path):
+        f = tmp_path / "atlas.pdf"
+        _write_pdf(f, pages=3)
+        m = make_map(filename="atlas.pdf", filepath=str(f))
+        resp = client.get(f"/api/maps/{m.id}/page/2", headers=admin_headers)
+        assert resp.status_code == 200
+        assert resp.headers["content-type"] == "image/webp"
+        assert resp.content[:4] == b"RIFF"  # WebP container magic
+
+    def test_pdf_map_page_out_of_range_is_400(self, client, admin_headers, tmp_path):
+        f = tmp_path / "atlas.pdf"
+        _write_pdf(f, pages=1)
+        m = make_map(filename="atlas.pdf", filepath=str(f))
+        resp = client.get(f"/api/maps/{m.id}/page/5", headers=admin_headers)
+        assert resp.status_code == 400
+
+    def test_missing_map_returns_404(self, client, admin_headers):
+        resp = client.get("/api/maps/nope/page/1", headers=admin_headers)
+        assert resp.status_code == 404
+
+    def test_file_absent_from_disk_marks_missing(self, client, admin_headers, tmp_path):
+        gone = tmp_path / "gone.pdf"
+        m = make_map(filename="gone.pdf", filepath=str(gone))
+        resp = client.get(f"/api/maps/{m.id}/page/1", headers=admin_headers)
         assert resp.status_code == 404
         db = SessionLocal()
         try:

--- a/backend/tests/test_maps_helpers.py
+++ b/backend/tests/test_maps_helpers.py
@@ -1,0 +1,148 @@
+"""Unit tests for map metadata + PDF page rendering helpers."""
+import fitz
+from PIL import Image
+
+from backend.routers.maps._helpers import (
+    _estimate_grid,
+    _is_pdf,
+    _map_image_info,
+    _parse_grid_dims,
+    render_map_pdf_page,
+)
+
+
+def _png(path, w, h, dpi=None):
+    img = Image.new("RGB", (w, h), "white")
+    img.save(str(path), dpi=(dpi, dpi) if dpi else None)
+
+
+def _pdf(path, pages=1, w=612, h=792):
+    doc = fitz.open()
+    for _ in range(pages):
+        doc.new_page(width=w, height=h)
+    doc.save(str(path))
+    doc.close()
+
+
+class TestParseGridDims:
+    def test_parses_x_notation(self):
+        assert _parse_grid_dims("Cavern (20x25)") == (20, 25)
+
+    def test_parses_by_notation(self):
+        assert _parse_grid_dims("Cavern 30 by 40") == (30, 40)
+
+    def test_rejects_out_of_range(self):
+        assert _parse_grid_dims("999x999") is None
+
+    def test_none_when_no_match(self):
+        assert _parse_grid_dims("just a name") is None
+
+
+class TestEstimateGrid:
+    def test_finds_clean_multiple(self):
+        # 700x1400 is a clean multiple of the smallest candidate cell (50px).
+        assert _estimate_grid(700, 1400) == (14, 28, 50)
+
+    def test_none_when_no_cell_fits(self):
+        # Dimensions that don't align near any candidate cell size or fall below
+        # the 2-cell minimum yield no estimate.
+        assert _estimate_grid(37, 200) is None
+
+
+class TestIsPdf:
+    def test_true_for_pdf(self):
+        assert _is_pdf("/x/atlas.PDF") is True
+
+    def test_false_for_png(self):
+        assert _is_pdf("/x/battle.png") is False
+
+
+class TestMapImageInfo:
+    def test_grid_from_filename(self, tmp_path):
+        f = tmp_path / "cave.png"
+        _png(f, 500, 500)
+        info = _map_image_info(str(f), "DnD/Maps/cave (12x15).png")
+        assert info["grid"] == {"width": 12, "height": 15, "source": "filename"}
+        assert info["is_pdf"] is False
+        assert info["pixel_width"] == 500
+
+    def test_grid_from_dpi(self, tmp_path):
+        f = tmp_path / "grid.png"
+        # 700x1050 at 70 DPI → 10x15 cells with 1 inch = 1 cell.
+        _png(f, 700, 1050, dpi=70)
+        info = _map_image_info(str(f), "DnD/Maps/grid.png")
+        assert info["dpi"] == 70
+        assert info["grid"]["source"] == "dpi"
+        assert (info["grid"]["width"], info["grid"]["height"]) == (10, 15)
+
+    def test_grid_computed(self, tmp_path):
+        f = tmp_path / "plain.png"
+        _png(f, 700, 1400)  # no dpi, no filename dims → estimated
+        info = _map_image_info(str(f), "DnD/Maps/plain.png")
+        assert info["grid"]["source"] == "computed"
+
+    def test_unreadable_file_returns_nulls(self, tmp_path):
+        info = _map_image_info(str(tmp_path / "missing.png"), "DnD/Maps/missing.png")
+        assert info["pixel_width"] is None
+        assert info["grid"] is None
+
+    def test_pdf_reports_page_count_without_raster_fields(self, tmp_path):
+        f = tmp_path / "atlas.pdf"
+        _pdf(f, pages=3)
+        info = _map_image_info(str(f), "DnD/Maps/atlas.pdf")
+        assert info["is_pdf"] is True
+        assert info["page_count"] == 3
+        assert info["pixel_width"] is None
+        assert info["dpi"] is None
+
+    def test_pdf_grid_from_filename(self, tmp_path):
+        f = tmp_path / "battlemap.pdf"
+        _pdf(f, pages=1)
+        info = _map_image_info(str(f), "DnD/Maps/battlemap (24x18).pdf")
+        assert info["grid"] == {"width": 24, "height": 18, "source": "filename"}
+        # cell_px must be stripped for PDFs even when grid is detected.
+        assert "cell_px" not in info["grid"]
+
+    def test_broken_pdf_returns_nulls(self, tmp_path):
+        f = tmp_path / "broken.pdf"
+        f.write_bytes(b"not really a pdf")
+        info = _map_image_info(str(f), "DnD/Maps/broken.pdf")
+        assert info["is_pdf"] is True
+        assert info["page_count"] is None
+
+
+class TestRenderMapPdfPage:
+    def test_renders_webp_bytes(self, tmp_path, monkeypatch):
+        import backend.routers.maps._helpers as helpers
+
+        monkeypatch.setattr(helpers, "PAGE_CACHE_DIR", str(tmp_path))
+        f = tmp_path / "map.pdf"
+        _pdf(f, pages=2)
+        data = render_map_pdf_page(str(f), 1, 400)
+        assert data[:4] == b"RIFF"
+
+    def test_second_call_hits_disk_cache(self, tmp_path, monkeypatch):
+        import backend.routers.maps._helpers as helpers
+
+        cache = tmp_path / "cache"
+        cache.mkdir()
+        monkeypatch.setattr(helpers, "PAGE_CACHE_DIR", str(cache))
+        f = tmp_path / "map.pdf"
+        _pdf(f, pages=1)
+        first = render_map_pdf_page(str(f), 1, 400)
+        # A file should now exist in the cache dir; the second call reads it back.
+        assert any(cache.iterdir())
+        second = render_map_pdf_page(str(f), 1, 400)
+        assert first == second
+
+    def test_out_of_range_raises_value_error(self, tmp_path, monkeypatch):
+        import backend.routers.maps._helpers as helpers
+
+        monkeypatch.setattr(helpers, "PAGE_CACHE_DIR", str(tmp_path))
+        f = tmp_path / "map.pdf"
+        _pdf(f, pages=1)
+        try:
+            render_map_pdf_page(str(f), 9, 400)
+            raise AssertionError("expected ValueError")
+        except ValueError:
+            pass

--- a/docs/api.md
+++ b/docs/api.md
@@ -244,9 +244,10 @@ Returns `{"status": "not_running"}` if no scan is in progress. Cancellation is c
 | Endpoint | Method | Auth | Description |
 |----------|--------|------|-------------|
 | `/api/maps` | GET | any | Paginated map list. Query: `limit`, `offset`, `map_type`, `folder` (exact folder path; `""` for top level) |
-| `/api/maps/:id` | GET | any | Map detail: filename, tags, `map_type`, `grid_size`, `file_size`, `has_thumbnail` |
+| `/api/maps/:id` | GET | any | Map detail: filename, tags, `map_type`, `grid_size`, `file_size`, `has_thumbnail`, `is_pdf`, `page_count` (PDF maps only; `null` otherwise) |
 | `/api/maps/:id` | PATCH | gm/admin | Update `description`, `tags`, `map_type`, `grid_size` |
-| `/api/maps/:id/file` | GET | any | Download/stream the map image |
+| `/api/maps/:id/file` | GET | any | Download/stream the original map image or PDF |
+| `/api/maps/:id/page/:n` | GET | any | Render page `n` of a PDF map to WebP (`width?` target pixel width, default 1600, max 3000). Image maps stream as-is and only accept page 1 |
 | `/api/maps/:id/thumbnail` | GET | any | WebP thumbnail |
 | `/api/map-folders` | GET | any | List folder tag assignments |
 | `/api/map-folders` | PATCH | gm/admin | Set tags on a folder path. Body: `{path, tags}` |

--- a/frontend/src/components/maps/MapDetailView.jsx
+++ b/frontend/src/components/maps/MapDetailView.jsx
@@ -15,6 +15,7 @@ import api, { mediaUrl } from '../../api'
 import Spinner from '../Spinner'
 import { formatSize } from '../../utils'
 import InlineTagEditor from './InlineTagEditor'
+import MapPdfViewer from './MapPdfViewer'
 import AddToCampaignButton from '../campaigns/AddToCampaignButton'
 import MetaRow from '../MetaRow'
 import TagSection from '../TagSection'
@@ -110,6 +111,7 @@ export default function MapDetailView() {
   })()
 
   const currentFolderTags = map.folder_tags ?? []
+  const isPdf = !!map.is_pdf
 
   const saveMapTags = async (tags) => {
     await api.patch(`/maps/${mapId}`, { tags })
@@ -242,53 +244,64 @@ export default function MapDetailView() {
           flexDirection: isMobilePhone ? 'column' : 'row',
         }}
       >
-        {/* Image pane */}
-        <div
-          ref={imagePane}
-          style={{
-            position: 'relative',
-            flex: 1,
-            overflow: 'auto',
-            background: 'var(--bg-deep)',
-            display: 'flex',
-            alignItems: 'center',
-            justifyContent: 'center',
-            padding: 24,
-          }}
-        >
-          <img
-            src={mediaUrl(`/maps/${mapId}/file`)}
-            alt={map.filename}
+        {/* Image / PDF pane */}
+        {isPdf ? (
+          <div style={{ flex: 1, minWidth: 0, display: 'flex' }}>
+            <MapPdfViewer
+              mapId={mapId}
+              filename={map.filename}
+              totalPages={map.page_count || 1}
+              isMobilePhone={isMobilePhone}
+            />
+          </div>
+        ) : (
+          <div
+            ref={imagePane}
             style={{
-              maxWidth: '100%',
-              maxHeight: isMobilePhone ? undefined : 'calc(100vh - 60px)',
-              borderRadius: 4,
-              boxShadow: '0 4px 24px rgba(0,0,0,0.6)',
-              ...imageStyle,
+              position: 'relative',
+              flex: 1,
+              overflow: 'auto',
+              background: 'var(--bg-deep)',
+              display: 'flex',
+              alignItems: 'center',
+              justifyContent: 'center',
+              padding: 24,
             }}
-            draggable={false}
-          />
-          {hasPrev && (
-            <button
-              onClick={onPrev}
-              aria-label={t('maps.detail.previous')}
-              title={t('maps.detail.previous')}
-              style={{ ...navButtonStyle, left: 12 }}
-            >
-              <LuChevronLeft size={26} />
-            </button>
-          )}
-          {hasNext && (
-            <button
-              onClick={onNext}
-              aria-label={t('maps.detail.next')}
-              title={t('maps.detail.next')}
-              style={{ ...navButtonStyle, right: 12 }}
-            >
-              <LuChevronRight size={26} />
-            </button>
-          )}
-        </div>
+          >
+            <img
+              src={mediaUrl(`/maps/${mapId}/file`)}
+              alt={map.filename}
+              style={{
+                maxWidth: '100%',
+                maxHeight: isMobilePhone ? undefined : 'calc(100vh - 60px)',
+                borderRadius: 4,
+                boxShadow: '0 4px 24px rgba(0,0,0,0.6)',
+                ...imageStyle,
+              }}
+              draggable={false}
+            />
+            {hasPrev && (
+              <button
+                onClick={onPrev}
+                aria-label={t('maps.detail.previous')}
+                title={t('maps.detail.previous')}
+                style={{ ...navButtonStyle, left: 12 }}
+              >
+                <LuChevronLeft size={26} />
+              </button>
+            )}
+            {hasNext && (
+              <button
+                onClick={onNext}
+                aria-label={t('maps.detail.next')}
+                title={t('maps.detail.next')}
+                style={{ ...navButtonStyle, right: 12 }}
+              >
+                <LuChevronRight size={26} />
+              </button>
+            )}
+          </div>
+        )}
 
         {/* Metadata sidebar — always visible on desktop, toggle-controlled on mobile */}
         <div

--- a/frontend/src/components/maps/MapDetailView.test.jsx
+++ b/frontend/src/components/maps/MapDetailView.test.jsx
@@ -27,6 +27,11 @@ vi.mock('./InlineTagEditor', () => ({
 vi.mock('../TagSection', () => ({
   default: ({ label, onEdit }) => <button onClick={onEdit}>{`edit-${label}`}</button>,
 }))
+vi.mock('./MapPdfViewer', () => ({
+  default: ({ mapId, totalPages }) => (
+    <div data-testid="pdf-viewer">{`pdf:${mapId}:${totalPages}`}</div>
+  ),
+}))
 
 // Three maps in the same folder, sorted by filename: m1, m2, m3.
 const SIBLINGS = [
@@ -127,6 +132,22 @@ describe('MapDetailView', () => {
     expect(navigate).toHaveBeenCalledWith('/maps/m3')
     await userEvent.keyboard('{ArrowLeft}')
     expect(navigate).toHaveBeenCalledWith('/maps/m1')
+  })
+
+  it('renders the PDF viewer for a PDF map instead of an <img>', async () => {
+    mockApi('m2', { filename: 'm2.pdf', is_pdf: true, page_count: 4 })
+    render(<MapDetailView />)
+    const viewer = await screen.findByTestId('pdf-viewer')
+    expect(viewer).toHaveTextContent('pdf:m2:4')
+    expect(document.querySelector('img')).toBeNull()
+  })
+
+  it('renders an <img> (not the PDF viewer) for a raster map', async () => {
+    mockApi('m2')
+    render(<MapDetailView />)
+    await waitFor(() => expect(screen.getByText('m2.png')).toBeInTheDocument())
+    expect(screen.queryByTestId('pdf-viewer')).toBeNull()
+    expect(document.querySelector('img')).toBeInTheDocument()
   })
 
   it('saves edited map tags', async () => {

--- a/frontend/src/components/maps/MapPdfViewer.jsx
+++ b/frontend/src/components/maps/MapPdfViewer.jsx
@@ -1,0 +1,345 @@
+import { useState, useEffect, useCallback, useRef } from 'react'
+import { useTranslation } from 'react-i18next'
+import {
+  LuChevronLeft,
+  LuChevronRight,
+  LuFileText,
+  LuColumns2,
+  LuFile,
+  LuPanelLeft,
+} from 'react-icons/lu'
+import { mediaUrl } from '../../api'
+import useReaderGestures from '../../hooks/useReaderGestures'
+import { getUserPrefs } from '../../hooks/useUserPrefs'
+import { getBookPrefs, saveBookPrefs } from '../../hooks/useBookPrefs'
+import SinglePage from '../reader/SinglePage'
+import SpreadPage from '../reader/SpreadPage'
+import { PAGE_WIDTH, SPREAD_WIDTH } from '../reader/pageRender'
+
+const MODES = [
+  { key: 'page', Icon: LuFileText },
+  { key: 'spread', Icon: LuColumns2 },
+  { key: 'pdf', Icon: LuFile },
+]
+
+// Inject the page-turn keyframes the reader page components rely on (the reader
+// registers these too, but a map PDF may be opened without ever mounting it).
+if (typeof document !== 'undefined' && !document.getElementById('reader-anim')) {
+  const s = document.createElement('style')
+  s.id = 'reader-anim'
+  s.textContent = `
+    @keyframes pageEnterRight  { from { opacity: 0.2; transform: translateX(60px);  } to { opacity: 1; transform: none; } }
+    @keyframes pageEnterLeft   { from { opacity: 0.2; transform: translateX(-60px); } to { opacity: 1; transform: none; } }
+    @keyframes pageEnterBottom { from { opacity: 0.2; transform: translateY(60px);  } to { opacity: 1; transform: none; } }
+    @keyframes pageEnterTop    { from { opacity: 0.2; transform: translateY(-60px); } to { opacity: 1; transform: none; } }
+  `
+  document.head.appendChild(s)
+}
+
+const toolbarBtn = (active) => ({
+  background: active ? 'var(--bg-card-hover)' : 'var(--bg-card)',
+  color: active ? 'var(--gold)' : 'var(--text-dim)',
+  border: 'none',
+  padding: '5px 12px',
+  cursor: 'pointer',
+  fontSize: 13,
+  display: 'flex',
+  alignItems: 'center',
+  gap: 5,
+})
+
+const stepBtn = {
+  background: 'var(--bg-card)',
+  border: '1px solid var(--border)',
+  color: 'var(--text)',
+  borderRadius: 4,
+  padding: '4px 8px',
+  display: 'flex',
+  alignItems: 'center',
+  cursor: 'pointer',
+}
+
+/**
+ * PDF map viewer with the same single / spread / raw-PDF modes as the book
+ * reader, but without the text-highlight overlay. `mapId` identifies the map,
+ * `filename` is used for the raw-PDF iframe title, and `totalPages` is the PDF
+ * page count.
+ */
+export default function MapPdfViewer({ mapId, filename, totalPages, isMobilePhone }) {
+  const { t } = useTranslation()
+
+  const _prefs = getBookPrefs(`map:${mapId}`)
+  const _userPrefs = getUserPrefs()
+  const _globalMode = ['page', 'spread', 'pdf'].includes(_userPrefs.readerMode)
+    ? _userPrefs.readerMode
+    : null
+  const initialMode = isMobilePhone
+    ? 'page'
+    : (_globalMode ?? (['page', 'spread', 'pdf'].includes(_prefs.mode) ? _prefs.mode : 'page'))
+  const initialSpreadOffset = _prefs.spreadOffset ?? 0
+
+  const [mode, setMode] = useState(initialMode)
+  const [spreadOffset, setSpreadOffset] = useState(initialSpreadOffset)
+  const [currentPage, setCurrentPage] = useState(1)
+  const [pageInput, setPageInput] = useState('1')
+  const [zoom, setZoom] = useState(1)
+  const [pan, setPan] = useState({ x: 0, y: 0 })
+
+  const directionRef = useRef(1)
+  const axisRef = useRef('x')
+  const currentPageRef = useRef(1)
+  const contentRef = useRef(null)
+  const preloadCacheRef = useRef({})
+
+  const pageUrl = useCallback(
+    (p, width) => mediaUrl(`/maps/${mapId}/page/${p}`, { width }),
+    [mapId]
+  )
+
+  const goToPage = useCallback(
+    (p, currentMode, axis = 'x') => {
+      if (totalPages === 0) return
+      let page = Math.max(1, Math.min(p, totalPages))
+      if ((currentMode ?? mode) === 'spread') {
+        const isLeftPage = spreadOffset === 1 ? page % 2 !== 0 : page % 2 === 0 || page === 1
+        if (!isLeftPage) page = page - 1
+      }
+      directionRef.current = page >= currentPageRef.current ? 1 : -1
+      axisRef.current = axis
+      currentPageRef.current = page
+      setCurrentPage(page)
+      setPageInput(String(page))
+    },
+    [totalPages, mode, spreadOffset]
+  )
+
+  // Reset zoom/pan when the page changes.
+  useEffect(() => {
+    setZoom(1)
+    setPan({ x: 0, y: 0 })
+  }, [currentPage])
+
+  // Re-snap the current page to a valid left page when spread settings change.
+  useEffect(() => {
+    if (mode === 'spread') goToPage(currentPageRef.current, 'spread')
+  }, [mode, spreadOffset]) // eslint-disable-line react-hooks/exhaustive-deps
+
+  // Preload neighbouring pages for snappy navigation.
+  useEffect(() => {
+    if (mode === 'pdf') return
+    const w = mode === 'spread' ? SPREAD_WIDTH : PAGE_WIDTH
+    const forward = directionRef.current >= 0
+    const ahead = mode === 'spread' ? 12 : 6
+    const behind = mode === 'spread' ? 4 : 2
+    const start = currentPage - (forward ? behind : ahead)
+    const end = currentPage + (forward ? ahead : behind)
+    const visible = new Set(mode === 'spread' ? [currentPage, currentPage + 1] : [currentPage])
+    for (let p = start; p <= end; p++) {
+      if (p < 1 || p > totalPages || visible.has(p)) continue
+      const key = `${p}:${w}`
+      if (!preloadCacheRef.current[key]) {
+        const img = new Image()
+        img.src = pageUrl(p, w)
+        preloadCacheRef.current[key] = img
+      }
+    }
+  }, [currentPage, mode, totalPages, pageUrl])
+
+  const step = mode === 'spread' ? 2 : 1
+
+  useEffect(() => {
+    const handleKeyDown = (e) => {
+      if (e.target.tagName === 'INPUT' || e.target.tagName === 'TEXTAREA') return
+      if (mode === 'pdf') return
+      if (e.key === 'ArrowLeft') {
+        e.preventDefault()
+        goToPage(currentPage - step, undefined, 'x')
+      }
+      if (e.key === 'ArrowRight') {
+        e.preventDefault()
+        goToPage(currentPage + step, undefined, 'x')
+      }
+      if (e.key === 'ArrowUp') {
+        e.preventDefault()
+        goToPage(currentPage - step, undefined, 'y')
+      }
+      if (e.key === 'ArrowDown') {
+        e.preventDefault()
+        goToPage(currentPage + step, undefined, 'y')
+      }
+    }
+    window.addEventListener('keydown', handleKeyDown)
+    return () => window.removeEventListener('keydown', handleKeyDown)
+  }, [mode, currentPage, step, goToPage])
+
+  const wheelNav = getUserPrefs().wheelNav !== false
+  const { handleTouchStart, handleTouchMove, handleTouchEnd } = useReaderGestures({
+    mode,
+    currentPage,
+    zoom,
+    pan,
+    setZoom,
+    setPan,
+    goToPage,
+    contentRef,
+    wheelNav,
+  })
+
+  const rightPage = currentPage + 1
+  const hasRight =
+    mode === 'spread' && (spreadOffset === 1 || currentPage !== 1) && rightPage <= totalPages
+
+  const getAlt = (p) => `${t('reader.page')} ${p} — ${filename}`
+
+  const changeMode = (key) => {
+    setMode(key)
+    saveBookPrefs(`map:${mapId}`, { mode: key })
+  }
+
+  return (
+    <div style={{ display: 'flex', flexDirection: 'column', height: '100%', width: '100%' }}>
+      {/* Sub-toolbar: page nav + mode toggle */}
+      <div
+        style={{
+          display: 'flex',
+          alignItems: 'center',
+          gap: 12,
+          padding: '8px 16px',
+          background: 'var(--bg-panel)',
+          borderBottom: '1px solid var(--border)',
+          flexWrap: 'wrap',
+          flexShrink: 0,
+        }}
+      >
+        {mode !== 'pdf' && totalPages > 0 && (
+          <div style={{ display: 'flex', alignItems: 'center', gap: 8 }}>
+            <button
+              onClick={() => goToPage(currentPage - step)}
+              disabled={currentPage <= 1}
+              aria-label={t('reader.previousPage')}
+              style={{ ...stepBtn, opacity: currentPage <= 1 ? 0.4 : 1 }}
+            >
+              <LuChevronLeft size={14} />
+            </button>
+            <input
+              type="text"
+              value={pageInput}
+              onChange={(e) => setPageInput(e.target.value)}
+              onKeyDown={(e) => e.key === 'Enter' && goToPage(parseInt(pageInput) || 1)}
+              onBlur={() => goToPage(parseInt(pageInput) || 1)}
+              aria-label={t('reader.currentPageNumber')}
+              style={{ width: 50, textAlign: 'center', padding: '4px 6px', fontSize: 15 }}
+            />
+            {mode === 'spread' && hasRight && (
+              <span style={{ fontSize: 15, color: 'var(--text-muted)' }}>– {rightPage}</span>
+            )}
+            <span style={{ fontSize: 15, color: 'var(--text-muted)' }}>
+              {t('common.pageOf', { total: totalPages })}
+            </span>
+            <button
+              onClick={() => goToPage(currentPage + step)}
+              disabled={currentPage >= totalPages}
+              aria-label={t('reader.nextPage')}
+              style={{ ...stepBtn, opacity: currentPage >= totalPages ? 0.4 : 1 }}
+            >
+              <LuChevronRight size={14} />
+            </button>
+          </div>
+        )}
+
+        <div style={{ flex: 1 }} />
+
+        {/* Mode toggle — hidden on mobile phones (forced to single page) */}
+        <div
+          style={{
+            display: isMobilePhone ? 'none' : 'flex',
+            border: '1px solid var(--border)',
+            borderRadius: 6,
+            overflow: 'hidden',
+          }}
+        >
+          {MODES.map(({ key, Icon }) => (
+            <button
+              key={key}
+              onClick={() => changeMode(key)}
+              title={t(`reader.${key}`)}
+              style={{
+                ...toolbarBtn(mode === key),
+                borderRight: key !== 'pdf' ? '1px solid var(--border)' : 'none',
+              }}
+            >
+              <Icon size={13} /> {t(`reader.${key}`)}
+            </button>
+          ))}
+        </div>
+
+        {/* Spread offset toggle — only in spread mode */}
+        {mode === 'spread' && !isMobilePhone && (
+          <button
+            onClick={() => {
+              const next = spreadOffset === 0 ? 1 : 0
+              setSpreadOffset(next)
+              saveBookPrefs(`map:${mapId}`, { spreadOffset: next })
+            }}
+            title={
+              spreadOffset === 0 ? t('reader.spreadIncludeCover') : t('reader.spreadExcludeCover')
+            }
+            style={{
+              ...toolbarBtn(spreadOffset === 1),
+              border: '1px solid var(--border)',
+              borderRadius: 6,
+            }}
+          >
+            <LuPanelLeft size={13} /> {t('reader.spreadCover')}
+          </button>
+        )}
+      </div>
+
+      {/* Page content */}
+      <div
+        ref={contentRef}
+        style={{
+          flex: 1,
+          minHeight: 0,
+          overflow: 'hidden',
+          display: 'flex',
+          background: 'var(--bg-deep)',
+          touchAction: 'none',
+        }}
+        onTouchStart={handleTouchStart}
+        onTouchMove={handleTouchMove}
+        onTouchEnd={handleTouchEnd}
+      >
+        {mode === 'pdf' ? (
+          <iframe
+            src={mediaUrl(`/maps/${mapId}/file`) + `#page=${currentPage}`}
+            style={{ width: '100%', height: '100%', border: 'none' }}
+            title={filename}
+          />
+        ) : mode === 'spread' ? (
+          <SpreadPage
+            currentPage={currentPage}
+            rightPage={rightPage}
+            hasRight={hasRight}
+            getAlt={getAlt}
+            zoom={zoom}
+            pan={pan}
+            axisRef={axisRef}
+            directionRef={directionRef}
+            pageUrl={pageUrl}
+          />
+        ) : (
+          <SinglePage
+            currentPage={currentPage}
+            getAlt={getAlt}
+            zoom={zoom}
+            pan={pan}
+            axisRef={axisRef}
+            directionRef={directionRef}
+            pageUrl={pageUrl}
+          />
+        )}
+      </div>
+    </div>
+  )
+}

--- a/frontend/src/components/maps/MapPdfViewer.test.jsx
+++ b/frontend/src/components/maps/MapPdfViewer.test.jsx
@@ -1,0 +1,134 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { render, screen } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+import MapPdfViewer from './MapPdfViewer'
+
+vi.mock('../../api', () => ({
+  mediaUrl: (p, params) => {
+    const qs = params ? new URLSearchParams(params).toString() : ''
+    return `/api${p}${qs ? `?${qs}` : ''}`
+  },
+}))
+
+vi.mock('../../hooks/useReaderGestures', () => ({
+  default: () => ({
+    handleTouchStart: vi.fn(),
+    handleTouchMove: vi.fn(),
+    handleTouchEnd: vi.fn(),
+  }),
+}))
+
+vi.mock('../../hooks/useUserPrefs', () => ({
+  getUserPrefs: () => ({}),
+}))
+
+vi.mock('../../hooks/useBookPrefs', () => ({
+  getBookPrefs: () => ({}),
+  saveBookPrefs: vi.fn(),
+}))
+
+// Render the page components as their requested URL so assertions can inspect it.
+vi.mock('../reader/SinglePage', () => ({
+  default: ({ currentPage, pageUrl }) => (
+    <div data-testid="single-page">{pageUrl(currentPage, 1600)}</div>
+  ),
+}))
+vi.mock('../reader/SpreadPage', () => ({
+  default: ({ currentPage, rightPage, hasRight, pageUrl }) => (
+    <div data-testid="spread-page">
+      {pageUrl(currentPage, 1000)}
+      {hasRight ? `|${pageUrl(rightPage, 1000)}` : ''}
+    </div>
+  ),
+}))
+
+beforeEach(() => vi.clearAllMocks())
+
+const setup = (over = {}) =>
+  render(
+    <MapPdfViewer
+      mapId="m1"
+      filename="dungeon.pdf"
+      totalPages={5}
+      isMobilePhone={false}
+      {...over}
+    />
+  )
+
+describe('MapPdfViewer', () => {
+  it('renders the single-page view by default, requesting page 1', () => {
+    setup()
+    expect(screen.getByTestId('single-page')).toHaveTextContent('/api/maps/m1/page/1?width=1600')
+  })
+
+  it('advances the page with the next control', async () => {
+    setup()
+    await userEvent.click(screen.getByRole('button', { name: /next page/i }))
+    expect(screen.getByTestId('single-page')).toHaveTextContent('/maps/m1/page/2?width=1600')
+  })
+
+  it('disables the previous control on the first page', () => {
+    setup()
+    expect(screen.getByRole('button', { name: /previous page/i })).toBeDisabled()
+  })
+
+  it('switches to spread mode and pairs facing pages', async () => {
+    setup()
+    // Move to page 2 first, then switch to spread — page 2 pairs with page 3.
+    await userEvent.click(screen.getByRole('button', { name: /next page/i }))
+    await userEvent.click(screen.getByRole('button', { name: /spread/i }))
+    const spread = screen.getByTestId('spread-page')
+    expect(spread).toHaveTextContent('/api/maps/m1/page/2?width=1000')
+    expect(spread).toHaveTextContent('/api/maps/m1/page/3?width=1000')
+  })
+
+  it('navigates pages with the arrow keys', async () => {
+    setup()
+    await userEvent.keyboard('{ArrowRight}')
+    expect(screen.getByTestId('single-page')).toHaveTextContent('/maps/m1/page/2?width=1600')
+    await userEvent.keyboard('{ArrowDown}')
+    expect(screen.getByTestId('single-page')).toHaveTextContent('/maps/m1/page/3?width=1600')
+    await userEvent.keyboard('{ArrowLeft}')
+    expect(screen.getByTestId('single-page')).toHaveTextContent('/maps/m1/page/2?width=1600')
+    await userEvent.keyboard('{ArrowUp}')
+    expect(screen.getByTestId('single-page')).toHaveTextContent('/maps/m1/page/1?width=1600')
+  })
+
+  it('jumps to a typed page number', async () => {
+    setup()
+    const input = screen.getByRole('textbox', { name: /current page/i })
+    await userEvent.clear(input)
+    await userEvent.type(input, '4{Enter}')
+    expect(screen.getByTestId('single-page')).toHaveTextContent('/maps/m1/page/4?width=1600')
+  })
+
+  it('toggles the spread cover offset in spread mode', async () => {
+    setup()
+    await userEvent.click(screen.getByRole('button', { name: /spread/i }))
+    // Offset toggle appears only in spread mode.
+    const coverToggle = screen.getByRole('button', { name: /cover/i })
+    await userEvent.click(coverToggle)
+    // With offset 1, page 1 pairs with page 2 as a spread.
+    const spread = screen.getByTestId('spread-page')
+    expect(spread).toHaveTextContent('/api/maps/m1/page/1?width=1000')
+    expect(spread).toHaveTextContent('/api/maps/m1/page/2?width=1000')
+  })
+
+  it('renders the raw PDF in an iframe in pdf mode', async () => {
+    setup()
+    await userEvent.click(screen.getByRole('button', { name: /^pdf$/i }))
+    const frame = document.querySelector('iframe')
+    expect(frame).toBeInTheDocument()
+    expect(frame.getAttribute('src')).toBe('/api/maps/m1/file#page=1')
+  })
+
+  it('hides the mode toggle on mobile phones', () => {
+    setup({ isMobilePhone: true })
+    // Mode toggle container is display:none; the spread/pdf buttons should not be
+    // reachable, but single-page content still renders.
+    expect(screen.getByTestId('single-page')).toBeInTheDocument()
+    const spreadBtn = screen.queryByRole('button', { name: /spread/i })
+    // The button exists in the DOM but its container is hidden; assert single mode.
+    if (spreadBtn) expect(spreadBtn.closest('div')).toHaveStyle({ display: 'none' })
+  })
+})

--- a/frontend/src/components/reader/SinglePage.jsx
+++ b/frontend/src/components/reader/SinglePage.jsx
@@ -2,7 +2,13 @@ import { mediaUrl } from '../../api'
 import TextOverlay from './TextOverlay'
 import { PAGE_WIDTH, animStyle } from './pageRender'
 
-/** Single-page view for the reader. */
+/**
+ * Single-page view for the reader and PDF-map viewer.
+ *
+ * Pass `pageUrl(page, width)` to override where page images come from (defaults
+ * to the book page endpoint). When `wordsCacheRef` is omitted the selectable
+ * text overlay is skipped — used by maps, which render pages without text.
+ */
 export default function SinglePage({
   bookId,
   currentPage,
@@ -14,8 +20,10 @@ export default function SinglePage({
   directionRef,
   activeSearchQuery,
   activeHighlight,
+  pageUrl,
 }) {
-  const wd = wordsCacheRef.current[currentPage]
+  const urlFor = pageUrl ?? ((p, width) => mediaUrl(`/books/${bookId}/page/${p}`, { width }))
+  const wd = wordsCacheRef?.current[currentPage]
   return (
     <div
       key={currentPage}
@@ -41,7 +49,7 @@ export default function SinglePage({
           }}
         >
           <img
-            src={mediaUrl(`/books/${bookId}/page/${currentPage}`, { width: PAGE_WIDTH })}
+            src={urlFor(currentPage, PAGE_WIDTH)}
             alt={getAlt(currentPage)}
             draggable={false}
             style={{
@@ -63,7 +71,7 @@ export default function SinglePage({
         </div>
       ) : (
         <img
-          src={mediaUrl(`/books/${bookId}/page/${currentPage}`, { width: PAGE_WIDTH })}
+          src={urlFor(currentPage, PAGE_WIDTH)}
           alt={getAlt(currentPage)}
           style={{
             maxHeight: '100%',

--- a/frontend/src/components/reader/SpreadPage.jsx
+++ b/frontend/src/components/reader/SpreadPage.jsx
@@ -2,7 +2,13 @@ import { mediaUrl } from '../../api'
 import TextOverlay from './TextOverlay'
 import { SPREAD_WIDTH, animStyle } from './pageRender'
 
-/** Two-page spread view for the reader. */
+/**
+ * Two-page spread view for the reader and PDF-map viewer.
+ *
+ * Pass `pageUrl(page, width)` to override where page images come from (defaults
+ * to the book page endpoint). When `wordsCacheRef` is omitted the selectable
+ * text overlay is skipped — used by maps, which render pages without text.
+ */
 export default function SpreadPage({
   bookId,
   currentPage,
@@ -16,7 +22,9 @@ export default function SpreadPage({
   directionRef,
   activeSearchQuery,
   activeHighlight,
+  pageUrl,
 }) {
+  const urlFor = pageUrl ?? ((p, width) => mediaUrl(`/books/${bookId}/page/${p}`, { width }))
   return (
     <div
       key={currentPage}
@@ -33,7 +41,7 @@ export default function SpreadPage({
       }}
     >
       {[currentPage, hasRight ? rightPage : null].filter(Boolean).map((p) => {
-        const wd = wordsCacheRef.current[p]
+        const wd = wordsCacheRef?.current[p]
         return wd ? (
           <div
             key={p}
@@ -46,7 +54,7 @@ export default function SpreadPage({
             }}
           >
             <img
-              src={mediaUrl(`/books/${bookId}/page/${p}`, { width: SPREAD_WIDTH })}
+              src={urlFor(p, SPREAD_WIDTH)}
               alt={getAlt(p)}
               draggable={false}
               style={{
@@ -69,7 +77,7 @@ export default function SpreadPage({
         ) : (
           <img
             key={p}
-            src={mediaUrl(`/books/${bookId}/page/${p}`, { width: SPREAD_WIDTH })}
+            src={urlFor(p, SPREAD_WIDTH)}
             alt={getAlt(p)}
             style={{
               maxHeight: '100%',


### PR DESCRIPTION
## Summary

<!-- What does this PR do? A few sentences is fine. -->

## Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / cleanup
- [ ] Docs / configuration only

## Testing

<!-- How did you verify this works? Check all that apply. -->

- [ ] Backend tests pass (`pytest -q`)
- [ ] Frontend tests pass (`npm test`)
- [ ] Tested manually in the browser

## Notes for reviewer

<!-- Anything that needs extra context, known limitations, or follow-up work. Delete if not needed. -->
