### PR TITLE
Fix: Escape FTS5 search snippet source text to prevent stored HTML injection

### DIFF
--- a/backend/routers/search/_helpers.py
+++ b/backend/routers/search/_helpers.py
@@ -1,7 +1,44 @@
 """Shared search helpers and category prioritization for the search router."""
+from html import escape
+
 from sqlalchemy import String, cast, or_
 
 from ...models import Audio, AudioFolder, GenericMap, MapFolder, Token, TokenFolder
+
+
+# FTS5 snippet() wraps matches in these sentinels rather than literal <mark>
+# tags. The snippet's surrounding text comes from a PDF's text layer and is
+# untrusted; it is HTML-escaped below before the sentinels are swapped for real
+# <mark> tags, so injected markup (e.g. "<script>" in a scanned page) is rendered
+# inert while our own highlight markup survives.
+#
+# The sentinels are private-use-area codepoints (U+E000..): they survive a SQL
+# string literal (unlike NUL, which SQLite's driver rejects) and html.escape()
+# untouched, and don't occur in real document text. Even if a document did embed
+# one, the worst case is a stray (already-escaped) highlight — never markup
+# injection, since escaping runs first.
+_SNIPPET_OPEN = "\ue000"
+_SNIPPET_CLOSE = "\ue001"
+
+# The snippet() column call callers embed in their FTS query. Column index 2 is
+# ``content``; ``40`` is the token budget; ``...`` is the ellipsis for truncation.
+SNIPPET_SQL = f"snippet(book_search, 2, '{_SNIPPET_OPEN}', '{_SNIPPET_CLOSE}', '...', 40)"
+
+
+def escape_snippet(raw: str) -> str:
+    """Make an FTS5 snippet() result safe for dangerouslySetInnerHTML.
+
+    HTML-escapes the whole snippet (the surrounding text is untrusted document
+    content), then replaces the escaped highlight sentinels with real
+    ``<mark>``/``</mark>`` tags. Returns "" for a None/empty snippet.
+    """
+    if not raw:
+        return ""
+    return (
+        escape(raw)
+        .replace(escape(_SNIPPET_OPEN), "<mark>")
+        .replace(escape(_SNIPPET_CLOSE), "</mark>")
+    )
 
 
 # Lower number = shown first in results

--- a/backend/routers/search/core.py
+++ b/backend/routers/search/core.py
@@ -7,7 +7,14 @@ from sqlalchemy.orm import Session
 
 from ...config import get_db
 from ...models import Book, GameSystem
-from ._helpers import _CATEGORY_PRIORITY, _search_maps, _search_tokens, _search_audio
+from ._helpers import (
+    SNIPPET_SQL,
+    _CATEGORY_PRIORITY,
+    _search_audio,
+    _search_maps,
+    _search_tokens,
+    escape_snippet,
+)
 
 
 def search_library(
@@ -17,11 +24,15 @@ def search_library(
     system_id: Optional[str] = None,
     db: Session = Depends(get_db),
 ):
+    # snippet() wraps matches in NUL sentinels, not literal <mark> tags; the
+    # untrusted surrounding text is HTML-escaped and the sentinels swapped for
+    # real <mark> tags in escape_snippet() below (the client renders the snippet
+    # via dangerouslySetInnerHTML). See ._helpers.SNIPPET_SQL / escape_snippet.
     if book_id:
         sql = text(
-            """
+            f"""
             SELECT book_id, page_number,
-                   snippet(book_search, 2, '<mark>', '</mark>', '...', 40) as snippet,
+                   {SNIPPET_SQL} as snippet,
                    rank
             FROM book_search
             WHERE content MATCH :query AND book_id = :book_id
@@ -32,9 +43,9 @@ def search_library(
         rows = db.execute(sql, {"query": q, "book_id": book_id, "limit": limit}).fetchall()
     elif system_id:
         sql = text(
-            """
+            f"""
             SELECT book_id, page_number,
-                   snippet(book_search, 2, '<mark>', '</mark>', '...', 40) as snippet,
+                   {SNIPPET_SQL} as snippet,
                    rank
             FROM book_search
             WHERE content MATCH :query
@@ -46,9 +57,9 @@ def search_library(
         rows = db.execute(sql, {"query": q, "system_id": system_id, "limit": limit}).fetchall()
     else:
         sql = text(
-            """
+            f"""
             SELECT book_id, page_number,
-                   snippet(book_search, 2, '<mark>', '</mark>', '...', 40) as snippet,
+                   {SNIPPET_SQL} as snippet,
                    rank
             FROM book_search
             WHERE content MATCH :query
@@ -79,7 +90,12 @@ def search_library(
                 }
         if bid in book_cache:
             enriched.append(
-                {**book_cache[bid], "page_number": row[1], "snippet": row[2], "_rank": row[3]}
+                {
+                    **book_cache[bid],
+                    "page_number": row[1],
+                    "snippet": escape_snippet(row[2]),
+                    "_rank": row[3],
+                }
             )
 
     # Re-sort: category priority first, then BM25 rank (more negative = better match)

--- a/backend/tests/test_search.py
+++ b/backend/tests/test_search.py
@@ -210,3 +210,65 @@ class TestSearch:
         resp = client.get("/api/search?q=fireball&system_id=nonexistent-system-id", headers=admin_headers)
         assert resp.status_code == 200
         assert resp.json()["results"] == []
+
+
+@pytest.fixture(scope="module")
+def booby_trapped_book():
+    """A book whose PDF text layer contains raw HTML/JS markup.
+
+    The snippet is rendered via dangerouslySetInnerHTML on the client, so the
+    surrounding source text must be HTML-escaped server-side; only the highlight
+    <mark> tags we inject should survive as real markup.
+    """
+    sys = make_game_system()
+    book = make_book(system_id=sys.id, title="Cursed Tome", indexed=True)
+    payload = (
+        'necromancy <script>alert(document.cookie)</script> ritual '
+        '<img src=x onerror=alert(1)> and <b>bold</b> incantations & sigils'
+    )
+    db = SessionLocal()
+    try:
+        db.execute(
+            text(
+                "INSERT INTO book_search (book_id, page_number, content) "
+                "VALUES (:bid, :pn, :content)"
+            ),
+            {"bid": book.id, "pn": 1, "content": payload},
+        )
+        db.commit()
+    finally:
+        db.close()
+    return book
+
+
+class TestSnippetEscaping:
+    def _snippet(self, client, admin_headers, book_id, query):
+        resp = client.get(f"/api/search?q={query}", headers=admin_headers)
+        assert resp.status_code == 200
+        row = next(r for r in resp.json()["results"] if r["id"] == book_id)
+        return row["snippet"]
+
+    def test_source_markup_is_escaped(self, client, admin_headers, booby_trapped_book):
+        snippet = self._snippet(client, admin_headers, booby_trapped_book.id, "necromancy")
+        # Raw tags from the PDF text layer must not survive as live markup.
+        assert "\ue000" not in snippet
+        assert "\ue001" not in snippet
+        assert "<b>" not in snippet
+        # They are present, but escaped.
+        assert "&lt;script&gt;" in snippet
+        assert "&lt;img" in snippet
+        assert "onerror" in snippet  # kept as inert text, not an attribute
+        # Ampersands in source text are escaped too.
+        assert "&amp; sigils" in snippet
+
+    def test_highlight_marks_are_preserved(self, client, admin_headers, booby_trapped_book):
+        snippet = self._snippet(client, admin_headers, booby_trapped_book.id, "necromancy")
+        # The matched term is still wrapped in a real <mark> highlight.
+        assert "<mark>" in snippet and "</mark>" in snippet
+        assert "<mark>necromancy</mark>" in snippet.lower()
+
+    def test_no_raw_sentinel_leaks(self, client, admin_headers, booby_trapped_book):
+        """The internal highlight sentinels must never appear in the response."""
+        snippet = self._snippet(client, admin_headers, booby_trapped_book.id, "ritual")
+        assert "" not in snippet
+        assert "" not in snippet

--- a/docs/api.md
+++ b/docs/api.md
@@ -323,6 +323,11 @@ Bookmarks are per-user - users cannot see or modify each other's bookmarks.
 
 `maps` and `tokens` are empty when `book_id` or `system_id` is scoped.
 
+Each result's `snippet` is HTML-safe: the matched term is wrapped in `<mark>…</mark>`
+and all surrounding text (which originates from an untrusted PDF text layer) is
+HTML-escaped server-side, so the client can render it via `dangerouslySetInnerHTML`
+without risking markup injection.
+
 ### Campaigns
 
 #### Campaign CRUD


### PR DESCRIPTION
## Summary

<!-- What does this PR do? A few sentences is fine. -->

## Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / cleanup
- [ ] Docs / configuration only

## Testing

<!-- How did you verify this works? Check all that apply. -->

- [x] Backend tests pass (`pytest -q`)
- [x] Frontend tests pass (`npm test`)
- [x] Tested manually in the browser

## Notes for reviewer

<!-- Anything that needs extra context, known limitations, or follow-up work. Delete if not needed. -->
