### PR TITLE
Fix: Wiki page editor fills the viewport height

### DIFF
--- a/frontend/src/components/campaigns/PageEditor.jsx
+++ b/frontend/src/components/campaigns/PageEditor.jsx
@@ -20,6 +20,8 @@ import IconPicker from './IconPicker'
 import WikiLinkAutocomplete, { findActiveLinkQuery } from './WikiLinkAutocomplete'
 import { buildTitleTrie } from './wikiLinkTarget'
 import { caretCoordinates } from './caretPosition'
+import useFillViewport from './useFillViewport'
+import useIsMobile from '../../hooks/useIsMobile'
 import {
   descendantIds,
   toolbarControl,
@@ -62,6 +64,13 @@ export default function PageEditor({
   const [showEmbedPicker, setShowEmbedPicker] = useState(false)
   const [showPreview, setShowPreview] = useState(false)
   const bodyRef = useRef(null)
+
+  // Fill the viewport so a long note doesn't push Save/Cancel off-screen (#293).
+  // On phones the editor already owns the whole screen and the on-screen
+  // keyboard shrinks the visual viewport, so it keeps the natural page flow.
+  const isMobile = useIsMobile()
+  const rootRef = useRef(null)
+  const fillHeight = useFillViewport(rootRef, { enabled: !isMobile })
 
   // --- [[link]] autocomplete (issue #196) ---
   // Titles come from the dedicated endpoint rather than `allPages` because they
@@ -257,8 +266,17 @@ export default function PageEditor({
     )
 
   return (
-    <div style={{ display: 'flex', flexDirection: 'column', gap: 14 }}>
-      <div style={{ display: 'flex', gap: 8, alignItems: 'stretch' }}>
+    <div
+      ref={rootRef}
+      style={{
+        display: 'flex',
+        flexDirection: 'column',
+        gap: 14,
+        height: fillHeight ?? undefined,
+        minHeight: 0,
+      }}
+    >
+      <div style={{ display: 'flex', gap: 8, alignItems: 'stretch', flexShrink: 0 }}>
         <IconPicker
           value={icon}
           onChange={setIcon}
@@ -288,7 +306,9 @@ export default function PageEditor({
       </div>
 
       {/* Toolbar */}
-      <div style={{ display: 'flex', gap: 8, flexWrap: 'wrap', alignItems: 'center' }}>
+      <div
+        style={{ display: 'flex', gap: 8, flexWrap: 'wrap', alignItems: 'center', flexShrink: 0 }}
+      >
         <select
           value={visibility}
           onChange={(e) => setVisibility(e.target.value)}
@@ -377,12 +397,15 @@ export default function PageEditor({
         <button
           type="button"
           onClick={() => {
-            insertAtCursor('[[]]')
             const ta = bodyRef.current
+            // Where the caret lands once "[[]]" is in: between the two pairs.
+            // Computed up front rather than read back a frame later, so this
+            // doesn't race insertAtCursor's own caret restore.
+            const caret = (ta?.selectionStart ?? body.length) + 2
+            insertAtCursor('[[]]')
             requestAnimationFrame(() => {
               if (!ta) return
-              const pos = (ta.selectionStart ?? 0) - 2
-              ta.setSelectionRange(pos, pos)
+              ta.setSelectionRange(caret, caret)
               refreshSuggest(ta)
             })
           }}
@@ -421,6 +444,7 @@ export default function PageEditor({
             borderRadius: 8,
             padding: '10px 12px',
             background: 'var(--bg-deep)',
+            flexShrink: 0,
           }}
         >
           <div style={{ fontSize: 12, color: 'var(--text-muted)', marginBottom: 8 }}>
@@ -454,10 +478,29 @@ export default function PageEditor({
         </div>
       )}
 
-      {/* Editor + live preview */}
-      <div style={{ display: 'flex', gap: 14, flexWrap: 'wrap' }}>
-        <div style={{ flex: '1 1 360px', minWidth: 280, position: 'relative' }}>
-          <div style={paneLabel}>{t('wiki.markdown')}</div>
+      {/* Editor + live preview. When filling the viewport the row takes the
+          leftover height and each pane scrolls inside itself, so the buttons
+          below stay put; otherwise it keeps the original content-sized flow. */}
+      <div
+        style={{
+          display: 'flex',
+          gap: 14,
+          flexWrap: 'wrap',
+          flex: fillHeight ? '1 1 auto' : undefined,
+          minHeight: 0,
+        }}
+      >
+        <div
+          style={{
+            flex: '1 1 360px',
+            minWidth: 280,
+            position: 'relative',
+            display: 'flex',
+            flexDirection: 'column',
+            minHeight: 0,
+          }}
+        >
+          <div style={{ ...paneLabel, flexShrink: 0 }}>{t('wiki.markdown')}</div>
           <textarea
             ref={bodyRef}
             value={body}
@@ -484,7 +527,11 @@ export default function PageEditor({
               color: 'var(--text)',
               fontSize: 14,
               lineHeight: 1.6,
-              resize: 'vertical',
+              // Filling the viewport, the textarea is sized by the flex row and
+              // scrolls its own overflow, so manual resizing would fight it.
+              ...(fillHeight
+                ? { flex: '1 1 auto', minHeight: 0, resize: 'none' }
+                : { resize: 'vertical' }),
               fontFamily: 'ui-monospace, SFMono-Regular, Menlo, monospace',
               boxSizing: 'border-box',
             }}
@@ -500,8 +547,16 @@ export default function PageEditor({
           )}
         </div>
         {showPreview && (
-          <div style={{ flex: '1 1 360px', minWidth: 280 }}>
-            <div style={paneLabel}>
+          <div
+            style={{
+              flex: '1 1 360px',
+              minWidth: 280,
+              display: 'flex',
+              flexDirection: 'column',
+              minHeight: 0,
+            }}
+          >
+            <div style={{ ...paneLabel, flexShrink: 0 }}>
               <LuEye size={12} style={{ verticalAlign: 'middle', marginRight: 4 }} />
               {t('wiki.preview')}
             </div>
@@ -512,6 +567,7 @@ export default function PageEditor({
                 border: '1px solid var(--border)',
                 borderRadius: 10,
                 minHeight: 200,
+                ...(fillHeight ? { flex: '1 1 auto', minHeight: 0, overflowY: 'auto' } : undefined),
               }}
             >
               <WikiMarkdown
@@ -525,9 +581,9 @@ export default function PageEditor({
         )}
       </div>
 
-      {error && <div style={{ color: 'var(--danger)', fontSize: 13 }}>{error}</div>}
+      {error && <div style={{ color: 'var(--danger)', fontSize: 13, flexShrink: 0 }}>{error}</div>}
 
-      <div style={{ display: 'flex', gap: 10, justifyContent: 'flex-end' }}>
+      <div style={{ display: 'flex', gap: 10, justifyContent: 'flex-end', flexShrink: 0 }}>
         <button type="button" onClick={onCancel} style={ghostBtn}>
           {t('common.cancel')}
         </button>

--- a/frontend/src/components/campaigns/PageEditor.test.jsx
+++ b/frontend/src/components/campaigns/PageEditor.test.jsx
@@ -396,3 +396,68 @@ describe('PageEditor [[link]] autocomplete', () => {
     expect(options()).toEqual([])
   })
 })
+
+// Issue #293: the editor should fill the viewport, scroll the editing surface
+// internally, and keep Save/Cancel reachable without scrolling.
+describe('PageEditor viewport fill', () => {
+  it('sizes its root to the remaining viewport height', () => {
+    const { container } = renderEditor()
+    // jsdom reports a 0 top and a 768px viewport, leaving 744 after the gap.
+    expect(container.firstChild.style.height).toBe('744px')
+  })
+
+  it('lets the editor row take the leftover space while the buttons stay fixed', () => {
+    const { container } = renderEditor()
+    const rows = Array.from(container.firstChild.children)
+    // The markdown/preview row is the only one allowed to grow.
+    const growing = rows.filter((r) => r.style.flex === '1 1 auto')
+    expect(growing).toHaveLength(1)
+    // Every other row is pinned, so Save/Cancel can't be pushed off-screen.
+    const saveRow = rows[rows.length - 1]
+    expect(saveRow).toHaveTextContent('Save')
+    expect(saveRow.style.flexShrink).toBe('0')
+  })
+
+  it('makes the textarea flex and scroll instead of resize', () => {
+    renderEditor()
+    const body = screen.getByRole('textbox', { name: 'Markdown' })
+    expect(body.style.flex).toBe('1 1 auto')
+    expect(body.style.resize).toBe('none')
+  })
+
+  it('scrolls the preview pane internally', async () => {
+    const user = userEvent.setup()
+    renderEditor()
+    await user.click(screen.getByRole('button', { name: /preview/i }))
+    const pane = screen.getByTestId('preview').parentElement
+    expect(pane.style.overflowY).toBe('auto')
+  })
+
+  it('falls back to natural flow when the viewport is too short', () => {
+    const original = window.innerHeight
+    Object.defineProperty(window, 'innerHeight', { value: 200, configurable: true })
+    try {
+      const { container } = renderEditor()
+      expect(container.firstChild.style.height).toBe('')
+      const body = screen.getByRole('textbox', { name: 'Markdown' })
+      expect(body.style.resize).toBe('vertical')
+    } finally {
+      Object.defineProperty(window, 'innerHeight', { value: original, configurable: true })
+    }
+  })
+
+  it('keeps the natural page flow on mobile', () => {
+    const original = window.matchMedia
+    window.matchMedia = vi.fn(() => ({
+      matches: true,
+      addEventListener: () => {},
+      removeEventListener: () => {},
+    }))
+    try {
+      const { container } = renderEditor()
+      expect(container.firstChild.style.height).toBe('')
+    } finally {
+      window.matchMedia = original
+    }
+  })
+})

--- a/frontend/src/components/campaigns/useFillViewport.js
+++ b/frontend/src/components/campaigns/useFillViewport.js
@@ -1,0 +1,54 @@
+import { useState, useLayoutEffect } from 'react'
+
+// Space left below the element so it stops short of the window edge instead of
+// running flush against it (matches the surrounding views' 24px padding).
+const BOTTOM_GAP = 24
+
+/**
+ * Height that makes `ref`'s element reach the bottom of the viewport.
+ *
+ * The wiki editor is mounted at different depths (the full-page notes view, the
+ * campaign detail tab) and its distance from the top changes as headers show
+ * and hide, so the offset is measured from the live element rather than
+ * hardcoded per host. Returns `null` until measured, and whenever the available
+ * space is below `min` — callers then fall back to natural content height, so a
+ * short window scrolls the page normally instead of squashing the editor.
+ */
+export default function useFillViewport(ref, { min = 320, enabled = true } = {}) {
+  const [height, setHeight] = useState(null)
+
+  useLayoutEffect(() => {
+    if (!enabled) {
+      setHeight(null)
+      return
+    }
+    const measure = () => {
+      const el = ref.current
+      if (!el) return
+      // Measure against the element's own top edge. Reading it while a height is
+      // already applied is safe: the top doesn't depend on our own height, since
+      // the element is laid out top-down from content above it.
+      const top = el.getBoundingClientRect().top
+      const avail = window.innerHeight - top - BOTTOM_GAP
+      const next = avail >= min ? avail : null
+      // Keep the identical value so an observer firing on our own resize (we
+      // observe the element we size) can't loop or land a stray re-render on
+      // top of the editor's caret bookkeeping.
+      setHeight((prev) => (prev === next ? prev : next))
+    }
+    measure()
+    window.addEventListener('resize', measure)
+    // Content above the editor (a wrapping toolbar, a header that hides on
+    // mobile) can reflow without a resize event, which moves our top edge.
+    // Only the document is observed, never the element we size — watching our
+    // own target would feed each height we set straight back in as a resize.
+    const ro = typeof ResizeObserver === 'function' ? new ResizeObserver(measure) : null
+    ro?.observe(document.documentElement)
+    return () => {
+      window.removeEventListener('resize', measure)
+      ro?.disconnect()
+    }
+  }, [ref, min, enabled])
+
+  return height
+}

--- a/frontend/src/components/campaigns/useFillViewport.test.js
+++ b/frontend/src/components/campaigns/useFillViewport.test.js
@@ -1,0 +1,130 @@
+import { describe, it, expect, afterEach, beforeEach, vi } from 'vitest'
+import { renderHook, act } from '@testing-library/react'
+import useFillViewport from './useFillViewport'
+
+// jsdom gives every element a zero-sized rect, so tests stub the one value the
+// hook reads (the element's distance from the top of the viewport).
+function elementAt(top) {
+  const el = document.createElement('div')
+  el.getBoundingClientRect = () => ({ top, left: 0, right: 0, bottom: 0, width: 0, height: 0 })
+  return el
+}
+
+const originalHeight = window.innerHeight
+const originalRO = globalThis.ResizeObserver
+
+function setViewportHeight(h) {
+  Object.defineProperty(window, 'innerHeight', { value: h, configurable: true, writable: true })
+}
+
+beforeEach(() => {
+  setViewportHeight(900)
+})
+
+afterEach(() => {
+  setViewportHeight(originalHeight)
+  globalThis.ResizeObserver = originalRO
+  vi.restoreAllMocks()
+})
+
+describe('useFillViewport', () => {
+  it('returns the space between the element top and the bottom of the viewport', () => {
+    const ref = { current: elementAt(100) }
+    const { result } = renderHook(() => useFillViewport(ref))
+    // 900 viewport - 100 top - 24 bottom gap
+    expect(result.current).toBe(776)
+  })
+
+  it('returns null when the leftover space is below the minimum', () => {
+    const ref = { current: elementAt(700) }
+    // 900 - 700 - 24 = 176, under the 320 default minimum.
+    const { result } = renderHook(() => useFillViewport(ref))
+    expect(result.current).toBeNull()
+  })
+
+  it('honours a custom minimum', () => {
+    const ref = { current: elementAt(700) }
+    const { result } = renderHook(() => useFillViewport(ref, { min: 100 }))
+    expect(result.current).toBe(176)
+  })
+
+  it('returns null while disabled', () => {
+    const ref = { current: elementAt(100) }
+    const { result } = renderHook(() => useFillViewport(ref, { enabled: false }))
+    expect(result.current).toBeNull()
+  })
+
+  it('recomputes when the window resizes', () => {
+    const ref = { current: elementAt(100) }
+    const { result } = renderHook(() => useFillViewport(ref))
+    expect(result.current).toBe(776)
+    act(() => {
+      setViewportHeight(600)
+      window.dispatchEvent(new Event('resize'))
+    })
+    expect(result.current).toBe(476)
+  })
+
+  it('drops to null when a resize leaves too little room', () => {
+    const ref = { current: elementAt(100) }
+    const { result } = renderHook(() => useFillViewport(ref))
+    expect(result.current).toBe(776)
+    act(() => {
+      setViewportHeight(300)
+      window.dispatchEvent(new Event('resize'))
+    })
+    expect(result.current).toBeNull()
+  })
+
+  it('recomputes when an observed element reflows', () => {
+    let notify
+    globalThis.ResizeObserver = class {
+      constructor(cb) {
+        notify = cb
+      }
+      observe() {}
+      disconnect() {}
+    }
+    const el = elementAt(100)
+    const ref = { current: el }
+    const { result } = renderHook(() => useFillViewport(ref))
+    expect(result.current).toBe(776)
+    // Content above the editor grew, pushing it down without a window resize.
+    el.getBoundingClientRect = () => ({ top: 200 })
+    act(() => notify())
+    expect(result.current).toBe(676)
+  })
+
+  it('works when ResizeObserver is unavailable', () => {
+    globalThis.ResizeObserver = undefined
+    const ref = { current: elementAt(100) }
+    const { result } = renderHook(() => useFillViewport(ref))
+    expect(result.current).toBe(776)
+  })
+
+  it('leaves the height untouched when the ref is empty', () => {
+    const ref = { current: null }
+    const { result } = renderHook(() => useFillViewport(ref))
+    expect(result.current).toBeNull()
+  })
+
+  it('removes its resize listener on unmount', () => {
+    const remove = vi.spyOn(window, 'removeEventListener')
+    const ref = { current: elementAt(100) }
+    const { unmount } = renderHook(() => useFillViewport(ref))
+    unmount()
+    expect(remove).toHaveBeenCalledWith('resize', expect.any(Function))
+  })
+
+  it('disconnects its observer on unmount', () => {
+    const disconnect = vi.fn()
+    globalThis.ResizeObserver = class {
+      observe() {}
+      disconnect = disconnect
+    }
+    const ref = { current: elementAt(100) }
+    const { unmount } = renderHook(() => useFillViewport(ref))
+    unmount()
+    expect(disconnect).toHaveBeenCalled()
+  })
+})


### PR DESCRIPTION
## Summary

<!-- What does this PR do? A few sentences is fine. -->

## Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / cleanup
- [ ] Docs / configuration only

## Testing

<!-- How did you verify this works? Check all that apply. -->

- [x] Backend tests pass (`pytest -q`)
- [x] Frontend tests pass (`npm test`)
- [x] Tested manually in the browser

## Notes for reviewer

<!-- Anything that needs extra context, known limitations, or follow-up work. Delete if not needed. -->
