### PR TITLE
Fix: Wiki book embeds show the book title instead of "Book" 

### DIFF
--- a/frontend/src/components/campaigns/EmbedCard.jsx
+++ b/frontend/src/components/campaigns/EmbedCard.jsx
@@ -1,6 +1,7 @@
+import { useState, useEffect } from 'react'
 import { useTranslation } from 'react-i18next'
 import { LuBookOpen, LuMap, LuUser, LuMusic, LuFile } from 'react-icons/lu'
-import { campaigns } from '../../api'
+import api, { campaigns } from '../../api'
 import AudioPlayer from '../audio/AudioPlayer'
 import LazyImg from '../LazyImg'
 
@@ -25,6 +26,25 @@ const embedCardStyle = {
 export default function EmbedCard({ spec, campaignId, onNavigate }) {
   const { t } = useTranslation()
   const [type, id, page] = spec.split(':')
+
+  // A book embed names the book, so its title is fetched here. It stays null if
+  // the book can't be resolved (deleted or unreadable), and the card falls back
+  // to the generic "Book" label. Rules-of-hooks keeps this above the early
+  // returns below, hence the type guard rather than a conditional hook.
+  const [bookTitle, setBookTitle] = useState(null)
+  useEffect(() => {
+    if (type !== 'book') return
+    let active = true
+    api
+      .get(`/books/${id}`)
+      .then((b) => {
+        if (active) setBookTitle(b.title || null)
+      })
+      .catch(() => {})
+    return () => {
+      active = false
+    }
+  }, [type, id])
 
   // An embedded audio track plays in the global player (play / play next), with a
   // click-through to its detail page.
@@ -96,8 +116,10 @@ export default function EmbedCard({ spec, campaignId, onNavigate }) {
   if (!meta) return null
   const { Icon, color } = meta
   const to = type === 'book' && page ? `${meta.to}?page=${page}` : meta.to
-  const label =
-    type === 'book' && page ? t('wiki.embedBookPage', { page }) : t(`wiki.embed_${type}`)
+  // A resolved title replaces the generic type label; the page suffix is added
+  // on top of whichever of the two we ended up with.
+  const name = type === 'book' && bookTitle ? bookTitle : t(`wiki.embed_${type}`)
+  const label = type === 'book' && page ? t('wiki.embedBookPage', { title: name, page }) : name
   return (
     <button type="button" onClick={() => onNavigate(to)} style={embedCardStyle}>
       <Icon size={15} color={color} />

--- a/frontend/src/components/campaigns/EmbedCard.test.jsx
+++ b/frontend/src/components/campaigns/EmbedCard.test.jsx
@@ -1,9 +1,11 @@
-import { describe, it, expect, vi } from 'vitest'
+import { describe, it, expect, vi, beforeEach } from 'vitest'
 import { render, screen } from '@testing-library/react'
 import userEvent from '@testing-library/user-event'
 import EmbedCard from './EmbedCard'
 
+const get = vi.fn()
 vi.mock('../../api', () => ({
+  default: { get: (...args) => get(...args) },
   campaigns: { fileUrl: (cid, id) => `http://localhost/campaigns/${cid}/files/${id}` },
   mediaUrl: (path) => `http://localhost${path}`,
 }))
@@ -20,6 +22,11 @@ vi.mock('../../context/AudioPlayerContext', () => ({
 }))
 
 describe('EmbedCard', () => {
+  beforeEach(() => {
+    get.mockReset()
+    get.mockResolvedValue({ title: "Player's Handbook" })
+  })
+
   it('renders a play control for audio embeds', () => {
     render(<EmbedCard spec="audio:track123" campaignId="c1" onNavigate={vi.fn()} />)
     expect(screen.getByRole('button', { name: 'Play' })).toBeInTheDocument()
@@ -44,5 +51,37 @@ describe('EmbedCard', () => {
     render(<EmbedCard spec="map:m1" campaignId="c1" onNavigate={onNavigate} />)
     await userEvent.click(screen.getByText('Map'))
     expect(onNavigate).toHaveBeenCalledWith('/maps/m1')
+    // Only book embeds resolve a title.
+    expect(get).not.toHaveBeenCalled()
+  })
+
+  it('names the book alongside the page for a page-anchored book embed', async () => {
+    render(<EmbedCard spec="book:b1:42" campaignId="c1" onNavigate={vi.fn()} />)
+    expect(await screen.findByText("Player's Handbook — p. 42")).toBeInTheDocument()
+    expect(get).toHaveBeenCalledWith('/books/b1')
+  })
+
+  it('names the book for an embed without a page', async () => {
+    render(<EmbedCard spec="book:b1" campaignId="c1" onNavigate={vi.fn()} />)
+    expect(await screen.findByText("Player's Handbook")).toBeInTheDocument()
+  })
+
+  it('navigates to the book page anchor when clicked', async () => {
+    const onNavigate = vi.fn()
+    render(<EmbedCard spec="book:b1:42" campaignId="c1" onNavigate={onNavigate} />)
+    await userEvent.click(await screen.findByText("Player's Handbook — p. 42"))
+    expect(onNavigate).toHaveBeenCalledWith('/library/book/b1?page=42')
+  })
+
+  it('falls back to the generic label when the book cannot be resolved', async () => {
+    get.mockRejectedValue(new Error('404'))
+    render(<EmbedCard spec="book:gone:42" campaignId="c1" onNavigate={vi.fn()} />)
+    expect(await screen.findByText('Book — p. 42')).toBeInTheDocument()
+  })
+
+  it('falls back to the generic label when the book has no title', async () => {
+    get.mockResolvedValue({ title: '' })
+    render(<EmbedCard spec="book:b1" campaignId="c1" onNavigate={vi.fn()} />)
+    expect(await screen.findByText('Book')).toBeInTheDocument()
   })
 })

--- a/frontend/src/locales/de-DE.json
+++ b/frontend/src/locales/de-DE.json
@@ -1319,7 +1319,7 @@
     "embed_map": "Karte",
     "embed_token": "Token",
     "embed_audio": "Audio",
-    "embedBookPage": "Buch — S. {{page}}",
+    "embedBookPage": "{{title}} — S. {{page}}",
     "parentLabel": "Übergeordnete Seite",
     "noParent": "Oberste Ebene",
     "addSubpage": "Unterseite hinzufügen",

--- a/frontend/src/locales/en-CA.json
+++ b/frontend/src/locales/en-CA.json
@@ -1319,7 +1319,7 @@
     "embed_map": "Map",
     "embed_token": "Token",
     "embed_audio": "Audio",
-    "embedBookPage": "Book — p. {{page}}",
+    "embedBookPage": "{{title}} — p. {{page}}",
     "parentLabel": "Parent page",
     "noParent": "Top level",
     "addSubpage": "Add subpage",

--- a/frontend/src/locales/en-US.json
+++ b/frontend/src/locales/en-US.json
@@ -1319,7 +1319,7 @@
     "embed_map": "Map",
     "embed_token": "Token",
     "embed_audio": "Audio",
-    "embedBookPage": "Book — p. {{page}}",
+    "embedBookPage": "{{title}} — p. {{page}}",
     "parentLabel": "Parent page",
     "noParent": "Top level",
     "addSubpage": "Add subpage",

--- a/frontend/src/locales/es-ES.json
+++ b/frontend/src/locales/es-ES.json
@@ -1319,7 +1319,7 @@
     "embed_map": "Mapa",
     "embed_token": "Ficha",
     "embed_audio": "Audio",
-    "embedBookPage": "Libro — p. {{page}}",
+    "embedBookPage": "{{title}} — p. {{page}}",
     "parentLabel": "Página principal",
     "noParent": "Nivel superior",
     "addSubpage": "Añadir subpágina",

--- a/frontend/src/locales/es-MX.json
+++ b/frontend/src/locales/es-MX.json
@@ -1319,7 +1319,7 @@
     "embed_map": "Mapa",
     "embed_token": "Ficha",
     "embed_audio": "Audio",
-    "embedBookPage": "Libro — p. {{page}}",
+    "embedBookPage": "{{title}} — p. {{page}}",
     "parentLabel": "Página principal",
     "noParent": "Nivel superior",
     "addSubpage": "Añadir subpágina",

--- a/frontend/src/locales/fr-CA.json
+++ b/frontend/src/locales/fr-CA.json
@@ -1319,7 +1319,7 @@
     "embed_map": "Carte",
     "embed_token": "Jeton",
     "embed_audio": "Audio",
-    "embedBookPage": "Livre — p. {{page}}",
+    "embedBookPage": "{{title}} — p. {{page}}",
     "parentLabel": "Page parente",
     "noParent": "Niveau supérieur",
     "addSubpage": "Ajouter une sous-page",

--- a/frontend/src/locales/fr-FR.json
+++ b/frontend/src/locales/fr-FR.json
@@ -1319,7 +1319,7 @@
     "embed_map": "Carte",
     "embed_token": "Jeton",
     "embed_audio": "Audio",
-    "embedBookPage": "Livre — p. {{page}}",
+    "embedBookPage": "{{title}} — p. {{page}}",
     "parentLabel": "Page parente",
     "noParent": "Niveau supérieur",
     "addSubpage": "Ajouter une sous-page",

--- a/frontend/src/locales/nl-NL.json
+++ b/frontend/src/locales/nl-NL.json
@@ -1319,7 +1319,7 @@
     "embed_map": "Kaart",
     "embed_token": "Token",
     "embed_audio": "Audio",
-    "embedBookPage": "Boek — p. {{page}}",
+    "embedBookPage": "{{title}} — p. {{page}}",
     "parentLabel": "Bovenliggende pagina",
     "noParent": "Hoogste niveau",
     "addSubpage": "Subpagina toevoegen",

--- a/frontend/src/locales/pt-BR.json
+++ b/frontend/src/locales/pt-BR.json
@@ -1319,7 +1319,7 @@
     "embed_map": "Mapa",
     "embed_token": "Token",
     "embed_audio": "Áudio",
-    "embedBookPage": "Livro — p. {{page}}",
+    "embedBookPage": "{{title}} — p. {{page}}",
     "parentLabel": "Página principal",
     "noParent": "Nível superior",
     "addSubpage": "Adicionar subpágina",

--- a/frontend/src/locales/pt-PT.json
+++ b/frontend/src/locales/pt-PT.json
@@ -1319,7 +1319,7 @@
     "embed_map": "Mapa",
     "embed_token": "Token",
     "embed_audio": "Áudio",
-    "embedBookPage": "Livro — p. {{page}}",
+    "embedBookPage": "{{title}} — p. {{page}}",
     "parentLabel": "Página principal",
     "noParent": "Nível superior",
     "addSubpage": "Adicionar subpágina",


### PR DESCRIPTION
## Summary

An embedded book rendered as "Book - pg. 42" because the card only interpolated the page number into `wiki.embedBookPage`. The card's `meta` lookup is just a local icon/color table, so the title was never actually available — it now comes from `GET /books/{id}`.

## Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / cleanup
- [ ] Docs / configuration only

## Testing

<!-- How did you verify this works? Check all that apply. -->

- [x] Backend tests pass (`pytest -q`)
- [x] Frontend tests pass (`npm test`)
- [x] Tested manually in the browser

## Notes for reviewer

<!-- Anything that needs extra context, known limitations, or follow-up work. Delete if not needed. -->
