### PR TITLE
Fix: reclaim PDF render memory and bound the reader/Valkey page caches

### DIFF
--- a/backend/config.py
+++ b/backend/config.py
@@ -77,6 +77,42 @@ def _read_ocr_dpi() -> float:
 
 
 OCR_DPI = _read_ocr_dpi()
+
+
+#   PAGE_RECLAIM_INTERVAL — how many page rasterizations to run between memory
+#             reclaims. MuPDF is a C library: pixmaps and the images it decodes
+#             to build them are allocated outside Python's heap, so gc.collect()
+#             and even doc.close() free none of it. A single illustrated page can
+#             decode >190MB of raw RGB (a 1.8MB JPEG becomes 32MB), and MuPDF's
+#             store is process-global, so RSS climbs and then never falls back.
+#             Reclaiming needs both halves: TOOLS.store_shrink() to release
+#             MuPDF's C-side store, then malloc_trim() to hand the freed glibc
+#             arenas back to the OS. Measured on a 300MB illustrated rulebook,
+#             reclaiming every 10 renders cut peak RSS 396->264MB and the
+#             settled floor 377->66MB for ~4% render time. 0 disables it.
+def _read_page_reclaim_interval() -> int:
+    try:
+        return max(0, int(os.environ.get("PAGE_RECLAIM_INTERVAL", "10")))
+    except ValueError:
+        return 10
+
+
+PAGE_RECLAIM_INTERVAL = _read_page_reclaim_interval()
+
+
+#   PAGE_CACHE_TTL — seconds a rendered page stays in Valkey. Rendered pages are
+#             a regenerable cache, not durable data: without an expiry they
+#             accumulate until Valkey hits maxmemory and starts evicting under
+#             pressure (or OOMs, if no eviction policy is set). Defaults to 7
+#             days; 0 means no expiry (the old behaviour).
+def _read_page_cache_ttl() -> int:
+    try:
+        return max(0, int(os.environ.get("PAGE_CACHE_TTL", str(7 * 24 * 3600))))
+    except ValueError:
+        return 7 * 24 * 3600
+
+
+PAGE_CACHE_TTL = _read_page_cache_ttl()
 _PAGE_CACHE_HEADERS = {"Cache-Control": "max-age=31536000, immutable"}
 
 # Optional override for password authentication. When the env var is set,
@@ -361,3 +397,69 @@ if VALKEY_URL:
     except Exception as e:
         logger.warning(f"Valkey connection failed, falling back to disk cache: {e}")
         _valkey = None
+
+
+# Key prefixes for regenerable render caches. Scan state lives under "grimoire:"
+# and is deliberately excluded — purging it would wipe a running scan's status.
+_CACHE_KEY_PREFIXES = ("page:", "mappage:")
+
+
+def valkey_cache_set(key: str, value: bytes) -> bool:
+    """Store a rendered page in Valkey under the configured TTL.
+
+    Returns whether the write succeeded, so callers can fall back to the disk
+    cache. Errors are logged rather than raised: the cache is an optimisation
+    and a Valkey blip must never fail the request populating it.
+    """
+    if _valkey is None:
+        return False
+    try:
+        if PAGE_CACHE_TTL > 0:
+            _valkey.set(key, value, ex=PAGE_CACHE_TTL)  # type: ignore[attr-defined]
+        else:
+            _valkey.set(key, value)  # type: ignore[attr-defined]
+        return True
+    except Exception as e:
+        logger.warning(f"Valkey set error: {e}")
+        return False
+
+
+def purge_valkey_page_cache() -> int:
+    """Drop every cached render from Valkey. Returns the number of keys removed.
+
+    Runs once at startup. Cached pages key off the book id and render width but
+    carry no content hash, so a page edited/replaced on disk while the server was
+    down would otherwise be served stale forever — the entries never expired
+    before this and the HTTP response is marked immutable. Clearing on boot makes
+    a restart the reliable way to invalidate them.
+
+    Uses SCAN rather than KEYS so a large cache doesn't block the Valkey server,
+    and UNLINK (falling back to DEL) so reclaim happens off the main thread.
+    """
+    if _valkey is None:
+        return 0
+    removed = 0
+    try:
+        for prefix in _CACHE_KEY_PREFIXES:
+            batch: list = []
+            for key in _valkey.scan_iter(match=f"{prefix}*", count=500):  # type: ignore[attr-defined]
+                batch.append(key)
+                if len(batch) >= 500:
+                    removed += _valkey_unlink(batch)
+                    batch = []
+            if batch:
+                removed += _valkey_unlink(batch)
+    except Exception as e:
+        logger.warning(f"Valkey page-cache purge failed: {e}")
+        return removed
+    if removed:
+        logger.info(f"Cleared {removed} cached page render(s) from Valkey")
+    return removed
+
+
+def _valkey_unlink(keys: list) -> int:
+    """UNLINK a batch of keys, falling back to DEL on older servers."""
+    try:
+        return int(_valkey.unlink(*keys))  # type: ignore[attr-defined]
+    except Exception:
+        return int(_valkey.delete(*keys))  # type: ignore[attr-defined]

--- a/backend/main.py
+++ b/backend/main.py
@@ -22,6 +22,7 @@ from .config import (
     VERSION,
     _valkey,
     logger,
+    purge_valkey_page_cache,
 )
 from .routers import (
     addons as addons_router,
@@ -103,6 +104,12 @@ async def lifespan(app: FastAPI):
         lock_file.close()
         yield
         return
+
+    # Drop cached renders from a previous run. Page keys carry no content hash,
+    # so a file replaced while the server was down would otherwise be served
+    # stale indefinitely — the responses are marked immutable. Only this worker
+    # holds the lock, so the purge runs once per startup rather than per worker.
+    purge_valkey_page_cache()
 
     def do_scan():
         from .routers.library._helpers import clear_stop, _set_status, _DEFAULT_STATUS

--- a/backend/routers/books/_helpers.py
+++ b/backend/routers/books/_helpers.py
@@ -1,5 +1,7 @@
 """In-process caches and shared helpers for book endpoints."""
+import ctypes
 import functools
+import platform
 import threading
 from collections import OrderedDict
 from typing import Optional
@@ -7,7 +9,7 @@ from typing import Optional
 import fitz  # type: ignore[import-untyped]
 from fastapi import HTTPException
 
-from ...config import SessionLocal, logger
+from ...config import PAGE_RECLAIM_INTERVAL, SessionLocal, logger
 from ...models import Book, User
 
 
@@ -16,6 +18,69 @@ from ...models import Book, User
 _PDF_CACHE_MAX = 10
 _pdf_cache: OrderedDict = OrderedDict()
 _pdf_cache_lock = threading.Lock()
+
+
+# glibc's malloc_trim() is what actually returns freed arenas to the OS. It does
+# not exist on musl (Alpine), so resolve it once and treat absence as "no trim"
+# rather than assuming the symbol is there.
+def _resolve_malloc_trim():
+    if platform.system() != "Linux":
+        return None
+    try:
+        libc = ctypes.CDLL("libc.so.6")
+    except OSError:
+        return None  # musl / non-glibc: nothing to call
+    return getattr(libc, "malloc_trim", None)
+
+
+_malloc_trim = _resolve_malloc_trim()
+
+# Renders since the last reclaim. PDF page handlers are sync defs run across the
+# threadpool, so this counter is shared and guarded by its own lock.
+_render_count = 0
+_render_count_lock = threading.Lock()
+
+
+def _reclaim_render_memory() -> None:
+    """Release MuPDF's C-side store and hand the freed arenas back to the OS.
+
+    Both halves are required and neither is Python-level. MuPDF decodes every
+    embedded image on a page to raw RGB to rasterize it, and caches that in a
+    process-global store, so ``gc.collect()`` and ``doc.close()`` reclaim
+    nothing — the allocations were never on Python's heap and aren't owned by
+    the document. ``store_shrink`` frees them inside MuPDF; ``malloc_trim`` then
+    releases the now-empty glibc arenas, which is the step that actually moves
+    RSS back down.
+    """
+    try:
+        fitz.TOOLS.store_shrink(100)
+    except Exception as e:  # pragma: no cover - defensive; API varies by build
+        logger.debug("MuPDF store_shrink failed: %s", e)
+    if _malloc_trim is not None:
+        try:
+            _malloc_trim(0)
+        except Exception as e:  # pragma: no cover - defensive
+            logger.debug("malloc_trim failed: %s", e)
+
+
+def note_page_render() -> bool:
+    """Count one rasterization, reclaiming memory every PAGE_RECLAIM_INTERVAL.
+
+    Returns whether a reclaim ran (for tests). Callers should invoke this after
+    a render completes and its pixmap has been released, never on a cache hit.
+    """
+    global _render_count
+    if PAGE_RECLAIM_INTERVAL <= 0:
+        return False
+    with _render_count_lock:
+        _render_count += 1
+        if _render_count < PAGE_RECLAIM_INTERVAL:
+            return False
+        _render_count = 0
+    # Reclaim outside the lock: it's slow-ish and other threads only need the
+    # counter, not to be serialised behind the trim.
+    _reclaim_render_memory()
+    return True
 
 
 def _get_pdf_doc(filepath: str) -> fitz.Document:

--- a/backend/routers/books/pages.py
+++ b/backend/routers/books/pages.py
@@ -13,9 +13,21 @@ import fitz  # type: ignore[import-untyped]
 from PIL import Image  # type: ignore[import-untyped]
 
 from ...auth import CurrentUser, get_current_user
-from ...config import _PAGE_CACHE_HEADERS, PAGE_CACHE_DIR, _valkey, logger, get_db
+from ...config import (
+    _PAGE_CACHE_HEADERS,
+    PAGE_CACHE_DIR,
+    _valkey,
+    get_db,
+    logger,
+    valkey_cache_set,
+)
 from ...models import Book
-from ._helpers import _assert_book_access, _cached_book_info, _get_pdf_doc
+from ._helpers import (
+    _assert_book_access,
+    _cached_book_info,
+    _get_pdf_doc,
+    note_page_render,
+)
 
 
 def _authorize_book(db: Session, book_id: str, user) -> None:
@@ -116,9 +128,9 @@ def serve_book_page(
         if _valkey is not None:
             try:
                 with open(cache_path, "rb") as f:
-                    _valkey.set(valkey_key, f.read())
-            except Exception as e:
-                logger.warning(f"Valkey set error: {e}")
+                    valkey_cache_set(valkey_key, f.read())
+            except OSError as e:
+                logger.warning(f"Page cache read error: {e}")
         return FileResponse(cache_path, media_type="image/webp", headers=_PAGE_CACHE_HEADERS)
 
     if not os.path.exists(filepath):
@@ -138,15 +150,13 @@ def serve_book_page(
         buf, format="webp", quality=85, method=0
     )
     img_bytes = buf.getvalue()
+    # Drop the pixmap before reclaiming so its buffer is part of what's freed.
+    del pix
+    note_page_render()
 
-    if _valkey is not None:
-        try:
-            _valkey.set(valkey_key, img_bytes)
-        except Exception as e:
-            logger.warning(f"Valkey set error: {e}")
-            with open(cache_path, "wb") as f:
-                f.write(img_bytes)
-    else:
+    # Fall back to the disk cache when Valkey is absent or the write failed, so
+    # a Valkey outage degrades to the on-disk path instead of losing the render.
+    if not valkey_cache_set(valkey_key, img_bytes):
         with open(cache_path, "wb") as f:
             f.write(img_bytes)
 

--- a/backend/routers/maps/_helpers.py
+++ b/backend/routers/maps/_helpers.py
@@ -9,9 +9,9 @@ from typing import Optional
 import fitz  # type: ignore[import-untyped]
 from PIL import Image as PILImage  # type: ignore[import-untyped]
 
-from ...config import PAGE_CACHE_DIR, _valkey, logger
+from ...config import PAGE_CACHE_DIR, _valkey, logger, valkey_cache_set
 from ...indexer import archive_ext
-from ..books._helpers import _get_pdf_doc
+from ..books._helpers import _get_pdf_doc, note_page_render
 
 
 def _is_pdf(filepath: str) -> bool:
@@ -40,11 +40,7 @@ def render_map_pdf_page(filepath: str, page_num: int, width: int) -> bytes:
     if os.path.exists(cache_path):
         with open(cache_path, "rb") as f:
             data = f.read()
-        if _valkey is not None:
-            try:
-                _valkey.set(valkey_key, data)
-            except Exception as e:
-                logger.warning(f"Valkey set error: {e}")
+        valkey_cache_set(valkey_key, data)
         return data
 
     doc = _get_pdf_doc(filepath)
@@ -58,15 +54,12 @@ def render_map_pdf_page(filepath: str, page_num: int, width: int) -> bytes:
         buf, format="webp", quality=85, method=0
     )
     img_bytes = buf.getvalue()
+    # Shares the books' reclaim counter: both paths rasterize through the same
+    # process-global MuPDF store, so they must be accounted for together.
+    del pix
+    note_page_render()
 
-    if _valkey is not None:
-        try:
-            _valkey.set(valkey_key, img_bytes)
-        except Exception as e:
-            logger.warning(f"Valkey set error: {e}")
-            with open(cache_path, "wb") as f:
-                f.write(img_bytes)
-    else:
+    if not valkey_cache_set(valkey_key, img_bytes):
         with open(cache_path, "wb") as f:
             f.write(img_bytes)
 

--- a/backend/tests/test_books_helpers.py
+++ b/backend/tests/test_books_helpers.py
@@ -5,6 +5,7 @@ best-effort close of an evicted document), the book-info memo cache, and the
 explicit-content permission lookup.
 """
 import os
+import threading
 import uuid
 from unittest.mock import MagicMock
 
@@ -117,3 +118,101 @@ class TestAllowExplicit:
             assert _helpers._allow_explicit(db, blocked) is False
         finally:
             db.close()
+
+
+class TestPageRenderReclaim:
+    """The render-memory reclaim counter (issue: reader memory growth).
+
+    MuPDF is a C library, so the memory a render leaves behind is invisible to
+    Python's GC and isn't freed by closing the document. These tests cover the
+    interval bookkeeping and the guards around the two native calls; the actual
+    RSS reduction is a property of MuPDF/glibc and isn't asserted here.
+    """
+
+    def setup_method(self):
+        _helpers._render_count = 0
+
+    def test_reclaims_on_the_configured_interval(self, monkeypatch):
+        monkeypatch.setattr(_helpers, "PAGE_RECLAIM_INTERVAL", 3)
+        calls = []
+        monkeypatch.setattr(_helpers, "_reclaim_render_memory", lambda: calls.append(1))
+        results = [_helpers.note_page_render() for _ in range(3)]
+        assert results == [False, False, True]
+        assert len(calls) == 1
+
+    def test_counter_resets_after_each_reclaim(self, monkeypatch):
+        monkeypatch.setattr(_helpers, "PAGE_RECLAIM_INTERVAL", 2)
+        calls = []
+        monkeypatch.setattr(_helpers, "_reclaim_render_memory", lambda: calls.append(1))
+        for _ in range(6):
+            _helpers.note_page_render()
+        assert len(calls) == 3
+
+    def test_zero_interval_disables_reclaim(self, monkeypatch):
+        monkeypatch.setattr(_helpers, "PAGE_RECLAIM_INTERVAL", 0)
+        calls = []
+        monkeypatch.setattr(_helpers, "_reclaim_render_memory", lambda: calls.append(1))
+        assert _helpers.note_page_render() is False
+        assert calls == []
+
+    def test_counter_is_threadsafe(self, monkeypatch):
+        # Page handlers are sync defs run across the threadpool, so the counter
+        # is shared. Every render must be accounted for exactly once.
+        monkeypatch.setattr(_helpers, "PAGE_RECLAIM_INTERVAL", 10)
+        calls = []
+        lock = threading.Lock()
+
+        def _record():
+            with lock:
+                calls.append(1)
+
+        monkeypatch.setattr(_helpers, "_reclaim_render_memory", _record)
+        threads = [
+            threading.Thread(target=lambda: [_helpers.note_page_render() for _ in range(20)])
+            for _ in range(5)
+        ]
+        for t in threads:
+            t.start()
+        for t in threads:
+            t.join()
+        # 5 threads x 20 renders = 100 renders / interval 10 = exactly 10 reclaims.
+        assert len(calls) == 10
+
+    def test_reclaim_survives_missing_store_shrink(self, monkeypatch):
+        # store_shrink availability varies by PyMuPDF build; a failure must not
+        # propagate into the request that triggered it.
+        def _boom(_):
+            raise RuntimeError("no store_shrink in this build")
+
+        monkeypatch.setattr(fitz.TOOLS, "store_shrink", _boom)
+        monkeypatch.setattr(_helpers, "_malloc_trim", None)
+        _helpers._reclaim_render_memory()  # must not raise
+
+    def test_reclaim_survives_malloc_trim_failure(self, monkeypatch):
+        def _boom(_):
+            raise OSError("trim failed")
+
+        monkeypatch.setattr(_helpers, "_malloc_trim", _boom)
+        _helpers._reclaim_render_memory()  # must not raise
+
+    def test_calls_both_native_reclaims_when_available(self, monkeypatch):
+        seen = []
+        monkeypatch.setattr(fitz.TOOLS, "store_shrink", lambda pct: seen.append(("shrink", pct)))
+        monkeypatch.setattr(_helpers, "_malloc_trim", lambda n: seen.append(("trim", n)))
+        _helpers._reclaim_render_memory()
+        # Order matters: free MuPDF's store first, then return the arenas.
+        assert seen == [("shrink", 100), ("trim", 0)]
+
+    def test_malloc_trim_absent_off_linux(self, monkeypatch):
+        monkeypatch.setattr(_helpers.platform, "system", lambda: "Darwin")
+        assert _helpers._resolve_malloc_trim() is None
+
+    def test_malloc_trim_absent_without_glibc(self, monkeypatch):
+        # musl (Alpine) has no libc.so.6 to load.
+        monkeypatch.setattr(_helpers.platform, "system", lambda: "Linux")
+
+        def _no_libc(_name):
+            raise OSError("not found")
+
+        monkeypatch.setattr(_helpers.ctypes, "CDLL", _no_libc)
+        assert _helpers._resolve_malloc_trim() is None

--- a/backend/tests/test_valkey_page_cache.py
+++ b/backend/tests/test_valkey_page_cache.py
@@ -1,0 +1,118 @@
+"""Tests for the Valkey page-cache TTL and the startup purge.
+
+Rendered pages are a regenerable cache, so they expire (they used to be written
+with no TTL and accumulated forever) and are dropped on startup — their keys
+carry no content hash, so a file replaced while the server was down would
+otherwise be served stale behind an immutable Cache-Control header.
+"""
+from unittest.mock import MagicMock
+
+from backend import config
+
+
+class _FakeValkey:
+    """Minimal stand-in recording set/scan/unlink calls."""
+
+    def __init__(self, keys=None, unlink_raises=False):
+        self.store = dict.fromkeys(keys or [], b"x")
+        self.sets: list = []
+        self.unlinked: list = []
+        self.deleted: list = []
+        self._unlink_raises = unlink_raises
+
+    def set(self, key, value, ex=None):
+        self.sets.append((key, value, ex))
+        self.store[key] = value
+
+    def scan_iter(self, match=None, count=None):
+        prefix = (match or "*").rstrip("*")
+        # Snapshot: deleting while iterating the live dict would raise.
+        return list(k for k in list(self.store) if k.startswith(prefix))
+
+    def unlink(self, *keys):
+        if self._unlink_raises:
+            raise RuntimeError("UNLINK unsupported")
+        self.unlinked.extend(keys)
+        for k in keys:
+            self.store.pop(k, None)
+        return len(keys)
+
+    def delete(self, *keys):
+        self.deleted.extend(keys)
+        for k in keys:
+            self.store.pop(k, None)
+        return len(keys)
+
+
+class TestValkeyCacheSet:
+    def test_applies_the_configured_ttl(self, monkeypatch):
+        fake = _FakeValkey()
+        monkeypatch.setattr(config, "_valkey", fake)
+        monkeypatch.setattr(config, "PAGE_CACHE_TTL", 3600)
+        assert config.valkey_cache_set("page:b:1:1200", b"webp") is True
+        assert fake.sets == [("page:b:1:1200", b"webp", 3600)]
+
+    def test_zero_ttl_writes_without_expiry(self, monkeypatch):
+        fake = _FakeValkey()
+        monkeypatch.setattr(config, "_valkey", fake)
+        monkeypatch.setattr(config, "PAGE_CACHE_TTL", 0)
+        config.valkey_cache_set("page:b:1:1200", b"webp")
+        assert fake.sets == [("page:b:1:1200", b"webp", None)]
+
+    def test_returns_false_without_valkey(self, monkeypatch):
+        monkeypatch.setattr(config, "_valkey", None)
+        assert config.valkey_cache_set("page:b:1:1200", b"webp") is False
+
+    def test_returns_false_and_swallows_errors(self, monkeypatch):
+        fake = MagicMock()
+        fake.set.side_effect = RuntimeError("connection reset")
+        monkeypatch.setattr(config, "_valkey", fake)
+        monkeypatch.setattr(config, "PAGE_CACHE_TTL", 60)
+        # Caller falls back to the disk cache rather than losing the render.
+        assert config.valkey_cache_set("page:b:1:1200", b"webp") is False
+
+
+class TestPurgeValkeyPageCache:
+    def test_removes_book_and_map_page_keys(self, monkeypatch):
+        fake = _FakeValkey(["page:b1:1:1200", "page:b1:2:1200", "mappage:/m.pdf:1:900"])
+        monkeypatch.setattr(config, "_valkey", fake)
+        assert config.purge_valkey_page_cache() == 3
+        assert fake.store == {}
+
+    def test_preserves_scan_state_keys(self, monkeypatch):
+        # Scan status/stop flags live under "grimoire:" and must survive — a
+        # purge that wiped them would clobber a running scan's state.
+        fake = _FakeValkey(
+            ["page:b1:1:1200", "grimoire:scan_status", "grimoire:scan_stop"]
+        )
+        monkeypatch.setattr(config, "_valkey", fake)
+        assert config.purge_valkey_page_cache() == 1
+        assert set(fake.store) == {"grimoire:scan_status", "grimoire:scan_stop"}
+
+    def test_noop_without_valkey(self, monkeypatch):
+        monkeypatch.setattr(config, "_valkey", None)
+        assert config.purge_valkey_page_cache() == 0
+
+    def test_returns_zero_when_cache_empty(self, monkeypatch):
+        fake = _FakeValkey([])
+        monkeypatch.setattr(config, "_valkey", fake)
+        assert config.purge_valkey_page_cache() == 0
+
+    def test_falls_back_to_del_when_unlink_unsupported(self, monkeypatch):
+        fake = _FakeValkey(["page:b1:1:1200"], unlink_raises=True)
+        monkeypatch.setattr(config, "_valkey", fake)
+        assert config.purge_valkey_page_cache() == 1
+        assert fake.deleted == ["page:b1:1:1200"]
+
+    def test_survives_a_scan_failure(self, monkeypatch):
+        fake = MagicMock()
+        fake.scan_iter.side_effect = RuntimeError("connection lost")
+        monkeypatch.setattr(config, "_valkey", fake)
+        # Startup must not be blocked by an unreachable cache.
+        assert config.purge_valkey_page_cache() == 0
+
+    def test_batches_large_key_sets(self, monkeypatch):
+        fake = _FakeValkey([f"page:b:{i}:1200" for i in range(1200)])
+        monkeypatch.setattr(config, "_valkey", fake)
+        assert config.purge_valkey_page_cache() == 1200
+        assert fake.store == {}

--- a/frontend/src/components/reader/pageRender.js
+++ b/frontend/src/components/reader/pageRender.js
@@ -5,6 +5,30 @@
 export const PAGE_WIDTH = 1600
 export const SPREAD_WIDTH = 1000
 
+// Caps for the reader's in-memory page caches. The image cache is the one that
+// matters: a decoded PAGE_WIDTH bitmap costs ~12MB of RAM regardless of how
+// small the WebP payload was, so an unbounded cache reached multiple GB after a
+// few hundred pages. The cap comfortably covers the largest prefetch window
+// (±12 in spread mode) plus recent history, so scrolling back a few pages still
+// hits the cache and the browser's own HTTP cache absorbs anything older.
+export const PRELOAD_CACHE_MAX = 40
+// Text/words entries are kilobytes each, but bounding them keeps a long reading
+// session from growing without limit too.
+export const TEXT_CACHE_MAX = 200
+
+/**
+ * Evict oldest entries from a plain-object cache held in a ref, keeping at most
+ * `max`. Relies on JS objects preserving string-key insertion order; callers
+ * must delete-then-reinsert if they want to mark an entry as recently used.
+ */
+export function pruneCache(cacheRef, max) {
+  const keys = Object.keys(cacheRef.current)
+  if (keys.length <= max) return
+  for (const key of keys.slice(0, keys.length - max)) {
+    delete cacheRef.current[key]
+  }
+}
+
 /** Page-turn entrance animation + zoom/pan transform for a page container. */
 export function animStyle(axisRef, directionRef, zoom, pan) {
   const axis = axisRef.current

--- a/frontend/src/components/reader/pageRender.test.js
+++ b/frontend/src/components/reader/pageRender.test.js
@@ -1,0 +1,67 @@
+import { describe, it, expect } from 'vitest'
+import {
+  PAGE_WIDTH,
+  PRELOAD_CACHE_MAX,
+  SPREAD_WIDTH,
+  TEXT_CACHE_MAX,
+  pruneCache,
+} from './pageRender'
+
+describe('page render constants', () => {
+  it('exposes the widths the preloader and page components share', () => {
+    expect(PAGE_WIDTH).toBe(1600)
+    expect(SPREAD_WIDTH).toBe(1000)
+  })
+
+  it('caps the preload cache above the widest prefetch window', () => {
+    // Spread mode prefetches ahead 12 + behind 4 + 2 visible; the cap must
+    // exceed that or the preloader would evict pages it just requested.
+    expect(PRELOAD_CACHE_MAX).toBeGreaterThan(12 + 4 + 2)
+  })
+})
+
+describe('pruneCache', () => {
+  const refOf = (obj) => ({ current: obj })
+
+  it('leaves a cache under the cap untouched', () => {
+    const ref = refOf({ a: 1, b: 2 })
+    pruneCache(ref, 5)
+    expect(ref.current).toEqual({ a: 1, b: 2 })
+  })
+
+  it('leaves a cache exactly at the cap untouched', () => {
+    const ref = refOf({ a: 1, b: 2 })
+    pruneCache(ref, 2)
+    expect(Object.keys(ref.current)).toEqual(['a', 'b'])
+  })
+
+  it('evicts the oldest entries when over the cap', () => {
+    const ref = refOf({ a: 1, b: 2, c: 3, d: 4 })
+    pruneCache(ref, 2)
+    expect(Object.keys(ref.current)).toEqual(['c', 'd'])
+  })
+
+  it('keeps the most recently inserted entry, which is the visible page', () => {
+    const ref = refOf({})
+    for (let p = 1; p <= 50; p++) ref.current[`${p}`] = p
+    pruneCache(ref, 10)
+    expect(ref.current['50']).toBe(50)
+    expect(ref.current['1']).toBeUndefined()
+  })
+
+  it('bounds a cache across repeated inserts rather than growing', () => {
+    const ref = refOf({})
+    for (let p = 1; p <= 500; p++) {
+      ref.current[`${p}`] = p
+      pruneCache(ref, TEXT_CACHE_MAX)
+      expect(Object.keys(ref.current).length).toBeLessThanOrEqual(TEXT_CACHE_MAX)
+    }
+    expect(Object.keys(ref.current).length).toBe(TEXT_CACHE_MAX)
+  })
+
+  it('handles an empty cache', () => {
+    const ref = refOf({})
+    pruneCache(ref, 10)
+    expect(ref.current).toEqual({})
+  })
+})

--- a/frontend/src/views/ReaderView.jsx
+++ b/frontend/src/views/ReaderView.jsx
@@ -20,7 +20,13 @@ import ReaderToolbar from '../components/reader/ReaderToolbar'
 import SpreadPage from '../components/reader/SpreadPage'
 import SinglePage from '../components/reader/SinglePage'
 import ImageBookViewer from '../components/reader/ImageBookViewer'
-import { PAGE_WIDTH, SPREAD_WIDTH } from '../components/reader/pageRender'
+import {
+  PAGE_WIDTH,
+  PRELOAD_CACHE_MAX,
+  SPREAD_WIDTH,
+  TEXT_CACHE_MAX,
+  pruneCache,
+} from '../components/reader/pageRender'
 
 // Inject page-turn keyframes once at module load
 if (typeof document !== 'undefined' && !document.getElementById('reader-anim')) {
@@ -163,10 +169,12 @@ export default function ReaderView() {
         .get(`/books/${bookId}/page/${p}/text`)
         .then((data) => {
           pageTextCacheRef.current[p] = data.text || ''
+          pruneCache(pageTextCacheRef, TEXT_CACHE_MAX)
           setPageTextVersion((v) => v + 1)
         })
         .catch(() => {
           pageTextCacheRef.current[p] = ''
+          pruneCache(pageTextCacheRef, TEXT_CACHE_MAX)
         })
     })
   }, [currentPage, mode, spreadOffset, book, bookId, totalPages])
@@ -187,10 +195,12 @@ export default function ReaderView() {
         .get(`/books/${bookId}/page/${p}/words`)
         .then((data) => {
           wordsCacheRef.current[p] = data
+          pruneCache(wordsCacheRef, TEXT_CACHE_MAX)
           setWordsVersion((v) => v + 1)
         })
         .catch(() => {
           wordsCacheRef.current[p] = null
+          pruneCache(wordsCacheRef, TEXT_CACHE_MAX)
         })
     })
   }, [currentPage, mode, spreadOffset, book, bookId, totalPages])
@@ -259,6 +269,9 @@ export default function ReaderView() {
         preloadCacheRef.current[key] = img
       }
     }
+    // Drop the oldest decoded bitmaps so a long flip-through doesn't pin every
+    // page it passed in memory (each is ~12MB decoded, WebP size notwithstanding).
+    pruneCache(preloadCacheRef, PRELOAD_CACHE_MAX)
   }, [currentPage, mode, book, bookId, totalPages])
 
   useEffect(() => {


### PR DESCRIPTION
## Summary

<!-- What does this PR do? A few sentences is fine. -->

## Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / cleanup
- [ ] Docs / configuration only

## Testing

<!-- How did you verify this works? Check all that apply. -->

- [x] Backend tests pass (`pytest -q`)
- [x] Frontend tests pass (`npm test`)
- [x] Tested manually in the browser

## Notes for reviewer

<!-- Anything that needs extra context, known limitations, or follow-up work. Delete if not needed. -->
