### PR TITLE
Fix: in-system search no longer persists across fresh navigations

### DIFF
--- a/frontend/src/hooks/useRestoredView.js
+++ b/frontend/src/hooks/useRestoredView.js
@@ -1,0 +1,33 @@
+import { useRef, useEffect } from 'react'
+import { useLocation, useNavigate } from 'react-router-dom'
+
+/**
+ * True when this mount is a *return* to the view (e.g. the reader's back button)
+ * rather than a fresh navigation to it. Views use this to decide whether to
+ * restore transient session state such as an in-system search query or an
+ * unsaved sort/filter selection: coming back should feel like you never left,
+ * but arriving fresh should always start clean.
+ *
+ * The flag is read once on mount and then stripped from history via a replace,
+ * so a subsequent reload or forward-nav to the same URL counts as fresh.
+ *
+ * @returns {boolean} whether persisted view state should be restored
+ */
+export default function useRestoredView() {
+  const location = useLocation()
+  const navigate = useNavigate()
+  // Captured on the first render so the value is stable for the whole mount,
+  // including for state initialisers that run before the cleanup effect below.
+  const restoreRef = useRef(location.state?.restoreView === true)
+
+  useEffect(() => {
+    if (!restoreRef.current) return
+    const { restoreView, ...rest } = location.state || {}
+    navigate(location.pathname + location.search, {
+      replace: true,
+      state: Object.keys(rest).length ? rest : null,
+    })
+  }, []) // eslint-disable-line react-hooks/exhaustive-deps
+
+  return restoreRef.current
+}

--- a/frontend/src/hooks/useRestoredView.test.jsx
+++ b/frontend/src/hooks/useRestoredView.test.jsx
@@ -1,0 +1,65 @@
+import { render, screen, waitFor } from '@testing-library/react'
+import { MemoryRouter } from 'react-router-dom'
+import useRestoredView from './useRestoredView'
+
+const mockNavigate = vi.fn()
+
+vi.mock('react-router-dom', async (importOriginal) => {
+  const actual = await importOriginal()
+  return { ...actual, useNavigate: () => mockNavigate }
+})
+
+function Probe() {
+  const restore = useRestoredView()
+  return <span data-testid="restore">{String(restore)}</span>
+}
+
+function renderAt(entry) {
+  return render(
+    <MemoryRouter initialEntries={[entry]}>
+      <Probe />
+    </MemoryRouter>
+  )
+}
+
+describe('useRestoredView', () => {
+  beforeEach(() => vi.clearAllMocks())
+
+  it('is false for a plain navigation', () => {
+    renderAt({ pathname: '/library/system/s1', state: null })
+    expect(screen.getByTestId('restore')).toHaveTextContent('false')
+  })
+
+  it('is true when the route carries the restoreView flag', () => {
+    renderAt({ pathname: '/library/system/s1', state: { restoreView: true } })
+    expect(screen.getByTestId('restore')).toHaveTextContent('true')
+  })
+
+  it('strips the flag from history so a reload counts as fresh', async () => {
+    renderAt({ pathname: '/library/system/s1', state: { restoreView: true } })
+    await waitFor(() =>
+      expect(mockNavigate).toHaveBeenCalledWith('/library/system/s1', {
+        replace: true,
+        state: null,
+      })
+    )
+  })
+
+  it('preserves other location state when stripping the flag', async () => {
+    renderAt({
+      pathname: '/library/system/s1',
+      state: { restoreView: true, from: '/library' },
+    })
+    await waitFor(() =>
+      expect(mockNavigate).toHaveBeenCalledWith('/library/system/s1', {
+        replace: true,
+        state: { from: '/library' },
+      })
+    )
+  })
+
+  it('does not touch history when there is no flag', async () => {
+    renderAt({ pathname: '/library/system/s1', state: null })
+    await waitFor(() => expect(mockNavigate).not.toHaveBeenCalled())
+  })
+})

--- a/frontend/src/hooks/useSessionState.js
+++ b/frontend/src/hooks/useSessionState.js
@@ -8,14 +8,22 @@ import { useState, useEffect, useRef } from 'react'
  * Supports plain values and Set objects.
  * Sets are stored as JSON arrays and rehydrated as Sets on load.
  *
+ * Pass `restore: false` to start from `initial` while still writing changes to
+ * storage — used by views that persist state only for a return trip (see
+ * useRestoredView), so a fresh navigation starts clean without discarding what
+ * a later return would want to read back.
+ *
  * @param {string} key        sessionStorage key
  * @param {*}      initial    initial value (used only when no stored value exists)
+ * @param {object} [opts]
+ * @param {boolean} [opts.restore=true] whether to seed from the stored value
  * @returns [value, setValue] — same API as useState
  */
-export default function useSessionState(key, initial) {
+export default function useSessionState(key, initial, { restore = true } = {}) {
   const isSet = initial instanceof Set
 
   const [value, setValueRaw] = useState(() => {
+    if (!restore) return initial
     try {
       const raw = sessionStorage.getItem(key)
       if (raw === null) return initial
@@ -26,8 +34,11 @@ export default function useSessionState(key, initial) {
     }
   })
 
-  // Track whether the value has been explicitly set at least once (i.e. data loaded).
-  const hasBeenSet = useRef(value !== initial)
+  // Track whether the value has been explicitly set at least once (i.e. data
+  // loaded). Object defaults (Set/array/object) are never reference-equal to a
+  // rehydrated value, so compare on identity only for primitives — otherwise a
+  // fresh mount would immediately write its own default back to storage.
+  const hasBeenSet = useRef(typeof initial === 'object' ? false : value !== initial)
 
   const setValue = (next) => {
     hasBeenSet.current = true

--- a/frontend/src/hooks/useSessionState.test.js
+++ b/frontend/src/hooks/useSessionState.test.js
@@ -91,5 +91,34 @@ describe('useSessionState', () => {
       expect(r2.current[0]).toBeInstanceOf(Set)
       expect(r2.current[0].size).toBe(0)
     })
+
+    it('does not write an object default to storage before it is set', () => {
+      renderHook(() => useSessionState(KEY, new Set()))
+      expect(sessionStorage.getItem(KEY)).toBeNull()
+    })
+  })
+
+  describe('restore option', () => {
+    it('ignores the stored value when restore is false', () => {
+      sessionStorage.setItem(KEY, JSON.stringify('stored'))
+      const { result } = renderHook(() => useSessionState(KEY, 'initial', { restore: false }))
+      expect(result.current[0]).toBe('initial')
+    })
+
+    it('still writes updates to storage when restore is false', () => {
+      sessionStorage.setItem(KEY, JSON.stringify('stored'))
+      const { result } = renderHook(() => useSessionState(KEY, 'initial', { restore: false }))
+      act(() => result.current[1]('typed'))
+      expect(JSON.parse(sessionStorage.getItem(KEY))).toBe('typed')
+      // A later mount that *does* restore sees the value written above.
+      const { result: r2 } = renderHook(() => useSessionState(KEY, 'initial'))
+      expect(r2.current[0]).toBe('typed')
+    })
+
+    it('restores by default', () => {
+      sessionStorage.setItem(KEY, JSON.stringify('stored'))
+      const { result } = renderHook(() => useSessionState(KEY, 'initial'))
+      expect(result.current[0]).toBe('stored')
+    })
   })
 })

--- a/frontend/src/views/ReaderView.jsx
+++ b/frontend/src/views/ReaderView.jsx
@@ -53,6 +53,15 @@ export default function ReaderView() {
   // regardless of how many jump-navigation history entries were pushed (ToC, bookmarks, search).
   const backPathRef = useRef(location.state?.from ?? null)
 
+  // Exiting the reader is a *return* to the referring view, not a fresh visit, so
+  // flag it: views that persist transient state (in-system search, sort/filter)
+  // restore it only when this flag is present. Falling back to history.back()
+  // preserves that state implicitly, since the entry is still on the stack.
+  const goBack = () =>
+    backPathRef.current
+      ? navigate(backPathRef.current, { state: { restoreView: true } })
+      : navigate(-1)
+
   const _prefs = getBookPrefs(bookId)
   const _userPrefs = getUserPrefs()
   const initialPage = parseInt(searchParams.get('page')) || _prefs.page || 1
@@ -385,7 +394,7 @@ export default function ReaderView() {
     return (
       <div style={{ padding: 40, textAlign: 'center' }}>
         <button
-          onClick={() => (backPathRef.current ? navigate(backPathRef.current) : navigate(-1))}
+          onClick={goBack}
           aria-label={t('common.back')}
           style={{
             background: 'none',
@@ -463,7 +472,7 @@ export default function ReaderView() {
         isMobilePhone={isMobilePhone}
         showShortcuts={showShortcuts}
         onToggleShortcuts={() => setShowShortcuts((v) => !v)}
-        onBack={() => (backPathRef.current ? navigate(backPathRef.current) : navigate(-1))}
+        onBack={goBack}
         isFavorite={isFavorite('book', bookId)}
         onToggleFavorite={() => toggleFavorite('book', bookId)}
         onBookmarkPage={() => {

--- a/frontend/src/views/ReaderView.test.jsx
+++ b/frontend/src/views/ReaderView.test.jsx
@@ -290,7 +290,10 @@ describe('ReaderView — back button navigation', () => {
 
     await userEvent.click(screen.getByLabelText('Back'))
 
-    expect(mockNavigate).toHaveBeenCalledWith('/library/system/system-1')
+    // Flagged as a return so the referring view restores its search/sort/filter.
+    expect(mockNavigate).toHaveBeenCalledWith('/library/system/system-1', {
+      state: { restoreView: true },
+    })
     expect(mockNavigate).not.toHaveBeenCalledWith(-1)
   })
 

--- a/frontend/src/views/SystemDetailView.jsx
+++ b/frontend/src/views/SystemDetailView.jsx
@@ -1,6 +1,7 @@
 import { useState, useEffect, useCallback, useRef } from 'react'
 import { useParams, useNavigate } from 'react-router-dom'
 import useSessionState from '../hooks/useSessionState'
+import useRestoredView from '../hooks/useRestoredView'
 import { useTranslation } from 'react-i18next'
 import {
   LuArrowLeft,
@@ -55,6 +56,9 @@ export default function SystemDetailView() {
   const { user } = useAuth()
   const { isFavorite } = useFavorites()
   const isEditor = user?.role === 'admin' || user?.role === 'gm'
+  // Returning from the reader restores the search/sort/filter you left behind;
+  // navigating here fresh always starts clean.
+  const restoreView = useRestoredView()
   const [system, setSystem] = useState(null)
   const [editing, setEditing] = useState(false)
   const [editingBookId, setEditingBookId] = useState(null)
@@ -78,12 +82,20 @@ export default function SystemDetailView() {
   // Books sort/filter now flow through the shared SortFilterBar state, with
   // server-backed saved presets (scope "books"). Favourites/tags/explicit/genre
   // all live in filters; the category grouping below is preserved.
-  const [bookFilter, setBookFilter] = useState(DEFAULT_BOOK_FILTER)
-  const [defaultApplied, setDefaultApplied] = useState(false)
+  // Persisted only for a return trip from the reader (issue: a search/filter set
+  // before opening a book should still be there on back, but a fresh visit to the
+  // system starts from the user's default preset).
+  const [bookFilter, setBookFilter] = useSessionState(
+    `grimoire:system:${systemId}:book-filter`,
+    DEFAULT_BOOK_FILTER,
+    { restore: restoreView }
+  )
+  const [defaultApplied, setDefaultApplied] = useState(restoreView)
   const [viewMode, cycleViewMode] = useViewMode('book')
   const [searchQuery, setSearchQuery] = useSessionState(
     `grimoire:system:${systemId}:search-query`,
-    ''
+    '',
+    { restore: restoreView }
   )
   const [searchResults, setSearchResults] = useState(null)
   const [searching, setSearching] = useState(false)
@@ -150,9 +162,10 @@ export default function SystemDetailView() {
     [systemId]
   )
 
-  // Re-run the search on mount if a query was persisted from a previous visit.
+  // Re-run the search on mount only when returning to the view (e.g. back from
+  // the reader); a fresh navigation starts with an empty box.
   useEffect(() => {
-    if (searchQuery && searchQuery.length >= 2) doSearch(searchQuery)
+    if (restoreView && searchQuery && searchQuery.length >= 2) doSearch(searchQuery)
   }, []) // eslint-disable-line react-hooks/exhaustive-deps
 
   const handleSearchInput = (e) => {
@@ -163,6 +176,7 @@ export default function SystemDetailView() {
   }
 
   const clearSearch = () => {
+    clearTimeout(searchTimer.current)
     setSearchQuery('')
     setSearchResults(null)
   }

--- a/frontend/src/views/SystemDetailView.test.jsx
+++ b/frontend/src/views/SystemDetailView.test.jsx
@@ -146,9 +146,19 @@ function makeSystem(books = []) {
   }
 }
 
-function renderView() {
+// `restoreView` mimics arriving via the reader's back button, which is the only
+// way persisted search/sort/filter state is restored; the default is a fresh
+// navigation, which always starts clean.
+function renderView({ restoreView = false } = {}) {
   return render(
-    <MemoryRouter initialEntries={['/library/system/system-1']}>
+    <MemoryRouter
+      initialEntries={[
+        {
+          pathname: '/library/system/system-1',
+          state: restoreView ? { restoreView: true } : null,
+        },
+      ]}
+    >
       <SystemDetailView />
     </MemoryRouter>
   )
@@ -524,28 +534,39 @@ describe('SystemDetailView — in-system search persistence', () => {
     await waitFor(() => expect(sessionStorage.getItem(SESSION_KEY)).toBe(JSON.stringify('fi')))
   })
 
-  it('re-runs the search on mount when a query is stored in sessionStorage', async () => {
+  it('re-runs the search on mount when returning with a stored query', async () => {
     sessionStorage.setItem(SESSION_KEY, JSON.stringify('fireball'))
     setupSearchMock('Spell Compendium')
-    renderView()
+    renderView({ restoreView: true })
 
     await waitFor(() => expect(screen.getByText('Spell Compendium')).toBeInTheDocument())
     expect(api.get).toHaveBeenCalledWith(expect.stringContaining('q=fireball'))
   })
 
-  it('pre-fills the search input from sessionStorage on mount', async () => {
+  it('pre-fills the search input when returning to the view', async () => {
     sessionStorage.setItem(SESSION_KEY, JSON.stringify('fireball'))
     setupSearchMock()
-    renderView()
+    renderView({ restoreView: true })
 
     await waitFor(() => screen.getByLabelText(/search within/i))
     expect(screen.getByLabelText(/search within/i).value).toBe('fireball')
   })
 
+  it('ignores a stored query on a fresh navigation', async () => {
+    sessionStorage.setItem(SESSION_KEY, JSON.stringify('fireball'))
+    setupSearchMock()
+    renderView()
+
+    await waitFor(() => screen.getByText('PHB'))
+    // Box is empty and no search was issued — the book grid renders as normal.
+    expect(screen.getByLabelText(/search within/i).value).toBe('')
+    expect(api.get.mock.calls.filter(([url]) => url.includes('/search'))).toHaveLength(0)
+  })
+
   it('does not run a search on mount when the stored query is too short', async () => {
     sessionStorage.setItem(SESSION_KEY, JSON.stringify('x'))
     api.get.mockResolvedValue(makeSystem([makeBook({ title: 'PHB' })]))
-    renderView()
+    renderView({ restoreView: true })
 
     await waitFor(() => screen.getByText('PHB'))
     const searchCalls = api.get.mock.calls.filter(([url]) => url.includes('/search'))
@@ -578,7 +599,7 @@ describe('SystemDetailView — in-system search persistence', () => {
         makeSystem([makeBook({ id: 'fb', title: 'Fireball Grimoire' }), makeBook({ title: 'PHB' })])
       )
     })
-    renderView()
+    renderView({ restoreView: true })
 
     // The matching book title appears (from the book grid, not the page hit).
     await waitFor(() => expect(screen.getByText('Fireball Grimoire')).toBeInTheDocument())
@@ -603,9 +624,61 @@ describe('SystemDetailView — in-system search persistence', () => {
       }
       return Promise.resolve(makeSystem([makeBook({ title: 'PHB' })]))
     })
-    renderView()
+    renderView({ restoreView: true })
 
     await waitFor(() => expect(screen.getByText(/no results found/i)).toBeInTheDocument())
+  })
+})
+
+describe('SystemDetailView — sort/filter persistence', () => {
+  const FILTER_KEY = 'grimoire:system:system-1:book-filter'
+  const storedFilter = { sort: 'year', order: 'desc', filters: {} }
+
+  beforeEach(() => {
+    vi.clearAllMocks()
+    mockIsFavorite.mockReturnValue(false)
+    sessionStorage.clear()
+    api.get.mockResolvedValue(makeSystem([makeBook({ title: 'PHB' })]))
+  })
+
+  it('restores the stored sort/filter when returning to the view', async () => {
+    sessionStorage.setItem(FILTER_KEY, JSON.stringify(storedFilter))
+    renderView({ restoreView: true })
+
+    await waitFor(() => screen.getByText('PHB'))
+    // The sort select reflects the restored filter state rather than the default.
+    expect(screen.getByLabelText(/^sort$/i).value).toBe('year')
+  })
+
+  it('ignores the stored sort/filter on a fresh navigation', async () => {
+    sessionStorage.setItem(FILTER_KEY, JSON.stringify(storedFilter))
+    renderView()
+
+    await waitFor(() => screen.getByText('PHB'))
+    expect(screen.getByLabelText(/^sort$/i).value).toBe('title')
+  })
+
+  it('restores an active filter, not just the sort, when returning', async () => {
+    // A favourites-only filter hides the (non-favourite) book on return…
+    sessionStorage.setItem(
+      FILTER_KEY,
+      JSON.stringify({ sort: 'title', order: 'asc', filters: { favorites: true } })
+    )
+    renderView({ restoreView: true })
+
+    await waitFor(() => screen.getByLabelText(/^sort$/i))
+    expect(screen.queryByText('PHB')).not.toBeInTheDocument()
+  })
+
+  it('does not apply a stored filter on a fresh navigation', async () => {
+    // …but the same stored filter is ignored when arriving fresh.
+    sessionStorage.setItem(
+      FILTER_KEY,
+      JSON.stringify({ sort: 'title', order: 'asc', filters: { favorites: true } })
+    )
+    renderView()
+
+    await waitFor(() => expect(screen.getByText('PHB')).toBeInTheDocument())
   })
 })
 


### PR DESCRIPTION
## Summary

<!-- What does this PR do? A few sentences is fine. -->

## Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / cleanup
- [ ] Docs / configuration only

## Testing

<!-- How did you verify this works? Check all that apply. -->

- [x] Backend tests pass (`pytest -q`)
- [x] Frontend tests pass (`npm test`)
- [x] Tested manually in the browser

## Notes for reviewer

<!-- Anything that needs extra context, known limitations, or follow-up work. Delete if not needed. -->
