### PR TITLE
Fix: child-system grids use the system view mode, not the book one

### DIFF
--- a/frontend/src/views/SystemDetailView.jsx
+++ b/frontend/src/views/SystemDetailView.jsx
@@ -91,7 +91,12 @@ export default function SystemDetailView() {
     { restore: restoreView }
   )
   const [defaultApplied, setDefaultApplied] = useState(restoreView)
+  // Two independent view modes: the book list below uses the "book" preference,
+  // while a container system's child-system grid uses the "system" one — the same
+  // setting the main library grid uses (issue #296). Sharing one mode made
+  // changing the system layout silently restyle every book list.
   const [viewMode, cycleViewMode] = useViewMode('book')
+  const [systemViewMode, cycleSystemViewMode] = useViewMode('system')
   const [searchQuery, setSearchQuery] = useSessionState(
     `grimoire:system:${systemId}:search-query`,
     '',
@@ -197,12 +202,12 @@ export default function SystemDetailView() {
       <div style={{ padding: '24px 32px', maxWidth: 1400, margin: '0 auto' }}>
         <SystemContainerView
           system={system}
-          viewMode={viewMode}
+          viewMode={systemViewMode}
           canEdit={isEditor}
           onBack={() => navigate('/library')}
           onOpenChild={(child) => navigate(`/library/system/${child.id}`)}
           onCoverChange={(cover) => setSystem((s) => ({ ...s, ...cover }))}
-          headerExtra={<ViewModeToggle mode={viewMode} onCycle={cycleViewMode} />}
+          headerExtra={<ViewModeToggle mode={systemViewMode} onCycle={cycleSystemViewMode} />}
         />
       </div>
     )

--- a/frontend/src/views/SystemDetailView.test.jsx
+++ b/frontend/src/views/SystemDetailView.test.jsx
@@ -980,6 +980,34 @@ describe('SystemDetailView — system containers (issues #261, #262)', () => {
     renderView()
     await waitFor(() => expect(screen.getByText('PHB')).toBeInTheDocument())
   })
+  // Issue #296: the child-systems grid is driven by the "system" view-mode
+  // preference, not the "book" one, so the two settings stay independent.
+  it('cycles the container grid through the system view mode, not the book one', async () => {
+    api.get.mockResolvedValue(makeContainer())
+    renderView()
+    await waitFor(() => expect(screen.getByText('Honey Heist')).toBeInTheDocument())
+
+    // Systems default to card view (books default to list).
+    const toggle = screen.getByRole('button', { name: /change view/i })
+    expect(toggle).toHaveAccessibleName(/cards/i)
+
+    await userEvent.click(toggle)
+    expect(toggle).toHaveAccessibleName(/compact/i)
+    expect(sessionStorage.getItem('grimoire:view-mode:system')).toBe('compact')
+    // The book preference is untouched by cycling the system grid.
+    expect(sessionStorage.getItem('grimoire:view-mode:book')).toBeNull()
+  })
+
+  it('leaves the book view mode alone when the system view mode is set', async () => {
+    sessionStorage.setItem('grimoire:view-mode:system', 'compact')
+    api.get.mockResolvedValue(makeSystem([makeBook({ title: 'PHB' })]))
+    renderView()
+    await waitFor(() => expect(screen.getByText('PHB')).toBeInTheDocument())
+
+    // Books still use their own default (list), not the system setting.
+    expect(screen.getByRole('button', { name: /change view/i })).toHaveAccessibleName(/list/i)
+  })
+
   it('reflects a container cover upload without leaving the view', async () => {
     api.get.mockResolvedValue(makeContainer())
     api.upload.mockResolvedValue({ cover_image: 'system-1.png' })


### PR DESCRIPTION
## Summary

<!-- What does this PR do? A few sentences is fine. -->

## Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / cleanup
- [ ] Docs / configuration only

## Testing

<!-- How did you verify this works? Check all that apply. -->

- [x] Backend tests pass (`pytest -q`)
- [x] Frontend tests pass (`npm test`)
- [x] Tested manually in the browser

## Notes for reviewer

<!-- Anything that needs extra context, known limitations, or follow-up work. Delete if not needed. -->
