### PR TITLE
Fix: middle click opens cards and chips in a new tab

### DIFF
--- a/frontend/src/components/LinkableTag.jsx
+++ b/frontend/src/components/LinkableTag.jsx
@@ -1,21 +1,28 @@
 import { useNavigate } from 'react-router-dom'
+import useLinkProps from '../hooks/useLinkProps'
 import { tagStyle, displayLabel } from './tagStyle'
 
 /**
  * The clickable tag chip: navigates to the tags page filtered to this tag by its
  * internal key (lowercased label). Kept in its own file so `useNavigate` is only
  * ever invoked for a linkable tag — plain chips never need a Router context.
+ *
+ * Tags usually sit inside a clickable card, so the chip stops propagation on
+ * every button — including the middle click that opens it in a new tab (issue
+ * #313) — to keep the surrounding card from also reacting.
  */
 export default function LinkableTag({ label, color }) {
   const navigate = useNavigate()
   const internal = String(label).trim().toLowerCase()
+  const to = `/tags?tag=${encodeURIComponent(internal)}`
+  const linkProps = useLinkProps(to, (e) => {
+    e.stopPropagation()
+    navigate(to)
+  })
   return (
     <button
       type="button"
-      onClick={(e) => {
-        e.stopPropagation()
-        navigate(`/tags?tag=${encodeURIComponent(internal)}`)
-      }}
+      {...linkProps}
       style={{ ...tagStyle(color), cursor: 'pointer', fontFamily: 'inherit' }}
     >
       {displayLabel(label)}

--- a/frontend/src/components/Tag.test.jsx
+++ b/frontend/src/components/Tag.test.jsx
@@ -1,4 +1,4 @@
-import { describe, it, expect, vi } from 'vitest'
+import { describe, it, expect, vi, beforeEach } from 'vitest'
 import { render, screen } from '@testing-library/react'
 import userEvent from '@testing-library/user-event'
 import { MemoryRouter } from 'react-router-dom'
@@ -18,6 +18,8 @@ const renderTag = (props) =>
   )
 
 describe('Tag', () => {
+  beforeEach(() => mockNavigate.mockClear())
+
   it('renders the label text', () => {
     renderTag({ label: 'fantasy' })
     expect(screen.getByText('Fantasy')).toBeInTheDocument()
@@ -57,5 +59,17 @@ describe('Tag', () => {
     renderTag({ label: 'fantasy', linkable: false })
     const el = screen.getByText('Fantasy')
     expect(el.tagName).toBe('SPAN')
+  })
+
+  // Issue #313 — tag chips are <button>s, so new-tab behaviour is wired by hand.
+  it('opens the tags page in a new tab on middle click', async () => {
+    const open = vi.spyOn(window, 'open').mockImplementation(() => null)
+    renderTag({ label: 'Draw Steel' })
+
+    await userEvent.pointer({ target: screen.getByText('Draw Steel'), keys: '[MouseMiddle]' })
+
+    expect(open).toHaveBeenCalledWith('/tags?tag=draw%20steel', '_blank', 'noopener,noreferrer')
+    expect(mockNavigate).not.toHaveBeenCalled()
+    open.mockRestore()
   })
 })

--- a/frontend/src/components/campaigns/CampaignCard.jsx
+++ b/frontend/src/components/campaigns/CampaignCard.jsx
@@ -13,6 +13,7 @@ import { campaigns } from '../../api'
 import WikiMarkdown from './WikiMarkdown'
 import CampaignRoleBadge from './CampaignRoleBadge'
 import LazyImg from '../LazyImg'
+import useLinkProps, { useNewTabHandler } from '../../hooks/useLinkProps'
 
 function formatSessionDate(dateStr) {
   if (!dateStr) return ''
@@ -42,9 +43,14 @@ export default function CampaignCard({
     ? campaigns.bannerUrl(campaign.id, campaign.updated_at)
     : null
 
+  // The card body and the Open Notes button lead to different pages, so each
+  // gets its own new-tab target (issue #313).
+  const linkProps = useLinkProps(`/campaigns/${campaign.id}/overview`, onClick)
+  const notesNewTab = useNewTabHandler(`/campaigns/${campaign.id}/notes`)
+
   return (
     <div
-      onClick={onClick}
+      {...linkProps}
       onKeyDown={(e) => {
         if (e.key === 'Enter' || e.key === ' ') {
           e.preventDefault()
@@ -213,8 +219,15 @@ export default function CampaignCard({
             type="button"
             onClick={(e) => {
               e.stopPropagation()
+              // Ctrl/cmd-click opens the notes in a new tab instead; the handler
+              // no-ops on a plain click and leaves the normal path alone.
+              if (e.ctrlKey || e.metaKey || e.shiftKey) {
+                notesNewTab(e)
+                return
+              }
               onOpenNotes()
             }}
+            onAuxClick={notesNewTab}
             style={{
               display: 'inline-flex',
               alignItems: 'center',

--- a/frontend/src/components/campaigns/CampaignCard.test.jsx
+++ b/frontend/src/components/campaigns/CampaignCard.test.jsx
@@ -1,4 +1,4 @@
-import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
 import { render, screen } from '@testing-library/react'
 import userEvent from '@testing-library/user-event'
 import CampaignCard from './CampaignCard'
@@ -132,5 +132,56 @@ describe('CampaignCard', () => {
   it('shows no archived badge on an active campaign', () => {
     render(<CampaignCard campaign={campaign()} onClick={vi.fn()} onOpenNotes={vi.fn()} />)
     expect(screen.queryByText(/archived/i)).toBeNull()
+  })
+
+  // Issue #313 — the card and its Open Notes button lead to different pages.
+  describe('opening in a new tab', () => {
+    let open
+
+    beforeEach(() => {
+      open = vi.spyOn(window, 'open').mockImplementation(() => null)
+    })
+
+    afterEach(() => open.mockRestore())
+
+    it('middle click on the card opens the campaign overview in a new tab', async () => {
+      const onClick = vi.fn()
+      render(<CampaignCard campaign={campaign()} onClick={onClick} onOpenNotes={vi.fn()} />)
+
+      await userEvent.pointer({
+        target: screen.getByRole('button', { name: /open campaign curse of strahd/i }),
+        keys: '[MouseMiddle]',
+      })
+
+      expect(open).toHaveBeenCalledWith('/campaigns/c1/overview', '_blank', 'noopener,noreferrer')
+      expect(onClick).not.toHaveBeenCalled()
+    })
+
+    it('middle click on Open Notes opens the notes page, not the overview', async () => {
+      const onClick = vi.fn()
+      const onOpenNotes = vi.fn()
+      render(<CampaignCard campaign={campaign()} onClick={onClick} onOpenNotes={onOpenNotes} />)
+
+      await userEvent.pointer({
+        target: screen.getByRole('button', { name: /^notes$/i }),
+        keys: '[MouseMiddle]',
+      })
+
+      expect(open).toHaveBeenCalledWith('/campaigns/c1/notes', '_blank', 'noopener,noreferrer')
+      expect(onOpenNotes).not.toHaveBeenCalled()
+      expect(onClick).not.toHaveBeenCalled()
+    })
+
+    it('still opens notes in place on a plain click', async () => {
+      const onClick = vi.fn()
+      const onOpenNotes = vi.fn()
+      render(<CampaignCard campaign={campaign()} onClick={onClick} onOpenNotes={onOpenNotes} />)
+
+      await userEvent.click(screen.getByRole('button', { name: /^notes$/i }))
+
+      expect(onOpenNotes).toHaveBeenCalledTimes(1)
+      expect(onClick).not.toHaveBeenCalled()
+      expect(open).not.toHaveBeenCalled()
+    })
   })
 })

--- a/frontend/src/components/campaigns/EmbedCard.jsx
+++ b/frontend/src/components/campaigns/EmbedCard.jsx
@@ -4,6 +4,7 @@ import { LuBookOpen, LuMap, LuUser, LuMusic, LuFile } from 'react-icons/lu'
 import api, { campaigns } from '../../api'
 import AudioPlayer from '../audio/AudioPlayer'
 import LazyImg from '../LazyImg'
+import { useNewTabHandler, isNewTabClick } from '../../hooks/useLinkProps'
 
 const embedCardStyle = {
   display: 'inline-flex',
@@ -26,6 +27,19 @@ const embedCardStyle = {
 export default function EmbedCard({ spec, campaignId, onNavigate }) {
   const { t } = useTranslation()
   const [type, id, page] = spec.split(':')
+
+  // Route each linkable embed type points at. Computed up here (rather than
+  // beside the card that uses it) so the new-tab hooks below sit above the early
+  // returns, as rules-of-hooks requires. Images and files aren't app routes.
+  const routes = {
+    audio: `/audio/${id}`,
+    book: page ? `/library/book/${id}?page=${page}` : `/library/book/${id}`,
+    map: `/maps/${id}`,
+    token: `/tokens/${id}`,
+  }
+  // Middle click / ctrl-click opens the embedded resource in a new tab (#313).
+  const audioNewTab = useNewTabHandler(routes.audio)
+  const cardNewTab = useNewTabHandler(routes[type] ?? null)
 
   // A book embed names the book, so its title is fetched here. It stays null if
   // the book can't be resolved (deleted or unreadable), and the card falls back
@@ -60,7 +74,8 @@ export default function EmbedCard({ spec, campaignId, onNavigate }) {
         <AudioPlayer track={{ id }} showPlayNext size={34} />
         <button
           type="button"
-          onClick={() => onNavigate(`/audio/${id}`)}
+          onClick={(e) => (isNewTabClick(e) ? audioNewTab(e) : onNavigate(routes.audio))}
+          onAuxClick={audioNewTab}
           style={{
             background: 'none',
             border: 'none',
@@ -121,7 +136,12 @@ export default function EmbedCard({ spec, campaignId, onNavigate }) {
   const name = type === 'book' && bookTitle ? bookTitle : t(`wiki.embed_${type}`)
   const label = type === 'book' && page ? t('wiki.embedBookPage', { title: name, page }) : name
   return (
-    <button type="button" onClick={() => onNavigate(to)} style={embedCardStyle}>
+    <button
+      type="button"
+      onClick={(e) => (isNewTabClick(e) ? cardNewTab(e) : onNavigate(to))}
+      onAuxClick={cardNewTab}
+      style={embedCardStyle}
+    >
       <Icon size={15} color={color} />
       {label}
     </button>

--- a/frontend/src/components/campaigns/ResourceRow.jsx
+++ b/frontend/src/components/campaigns/ResourceRow.jsx
@@ -6,6 +6,7 @@ import { campaigns, mediaUrl } from '../../api'
 import { TYPE_ICONS, RESOURCE_NAV, VISIBILITY_OPTIONS, selectStyle } from './resourcesShared'
 import AudioPlayer from '../audio/AudioPlayer'
 import LazyImg from '../LazyImg'
+import useLinkProps from '../../hooks/useLinkProps'
 
 /** A single linked campaign resource with owner controls (visibility, category, share). */
 export default function ResourceRow({
@@ -51,6 +52,14 @@ export default function ResourceRow({
       state: { from: window.location.pathname },
     })
   }
+
+  // Middle click / ctrl-click opens the resource in a new tab (issue #313).
+  // Uploaded files already open in their own tab on any click, so they get no
+  // extra link target here.
+  const navLinkProps = useLinkProps(
+    isFile ? null : (RESOURCE_NAV[resource.resource_type]?.(resource.resource_id) ?? null),
+    handleNav
+  )
 
   const stop = (e) => e.stopPropagation()
 
@@ -100,7 +109,7 @@ export default function ResourceRow({
       <div style={{ flex: 1, minWidth: 0, display: 'flex', flexDirection: 'column', gap: 6 }}>
         {/* Row 1 — title (clickable) */}
         <div
-          onClick={handleNav}
+          {...navLinkProps}
           onKeyDown={(e) => {
             if (e.key === 'Enter' || e.key === ' ') {
               e.preventDefault()

--- a/frontend/src/components/campaigns/WikiMarkdown.jsx
+++ b/frontend/src/components/campaigns/WikiMarkdown.jsx
@@ -6,6 +6,7 @@ import remarkGfm from 'remark-gfm'
 import { LuFileQuestion } from 'react-icons/lu'
 import EmbedCard from './EmbedCard'
 import LazyImg from '../LazyImg'
+import { isNewTabClick } from '../../hooks/useLinkProps'
 import { isEmbed, parseTarget, resolvePage } from './wikiLinkTarget'
 import { buildHeadingComponents, headingDomId } from './wikiHeadings'
 
@@ -130,16 +131,29 @@ export default function WikiMarkdown({
   }, [])
 
   const openLink = useCallback(
-    (rawTarget) => {
+    (rawTarget, e) => {
       const link = parseTarget(rawTarget)
       const target = resolvePage(link, pages)
+      // Notes are URL-addressable (`?note=`), so a resolvable [[link]] can open
+      // in its own tab on middle click / ctrl-click like any other link (#313).
+      // An unresolved target has no URL to open, so it falls through.
+      if (target && campaignId && isNewTabClick(e)) {
+        e.preventDefault()
+        e.stopPropagation()
+        window.open(
+          `/campaigns/${campaignId}/notes?note=${encodeURIComponent(target.id)}`,
+          '_blank',
+          'noopener,noreferrer'
+        )
+        return
+      }
       if (target && target.id === currentPageId && link.heading) {
         scrollToHeading(link.heading)
         return
       }
       onOpenPage?.(target, link.heading, link)
     },
-    [pages, currentPageId, onOpenPage, scrollToHeading]
+    [pages, currentPageId, onOpenPage, scrollToHeading, campaignId]
   )
 
   const components = useMemo(
@@ -177,7 +191,8 @@ export default function WikiMarkdown({
           return (
             <button
               type="button"
-              onClick={() => openLink(rawTarget)}
+              onClick={(e) => openLink(rawTarget, e)}
+              onAuxClick={(e) => openLink(rawTarget, e)}
               title={
                 exists
                   ? link.heading

--- a/frontend/src/components/campaigns/WikiMarkdown.test.jsx
+++ b/frontend/src/components/campaigns/WikiMarkdown.test.jsx
@@ -1,5 +1,6 @@
 import { describe, it, expect, vi } from 'vitest'
 import { render, screen, fireEvent } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
 import { MemoryRouter } from 'react-router-dom'
 import WikiMarkdown from './WikiMarkdown'
 
@@ -32,6 +33,56 @@ describe('WikiMarkdown', () => {
     const link = screen.getByRole('button', { name: 'The Castle' })
     fireEvent.click(link)
     expect(onOpenPage).toHaveBeenCalledWith(CASTLE, null, expect.anything())
+  })
+
+  // Issue #313 — notes are addressable via ?note=, so a resolvable wiki link
+  // can open in its own tab.
+  describe('opening a [[wiki link]] in a new tab', () => {
+    it('middle click opens the linked note in a new tab', async () => {
+      const open = vi.spyOn(window, 'open').mockImplementation(() => null)
+      const onOpenPage = vi.fn()
+      renderMd({ body: 'Go to [[The Castle]].', pages: [CASTLE], campaignId: 'c1', onOpenPage })
+
+      await userEvent.pointer({
+        target: screen.getByRole('button', { name: 'The Castle' }),
+        keys: '[MouseMiddle]',
+      })
+
+      expect(open).toHaveBeenCalledWith(
+        '/campaigns/c1/notes?note=p-castle',
+        '_blank',
+        'noopener,noreferrer'
+      )
+      expect(onOpenPage).not.toHaveBeenCalled()
+      open.mockRestore()
+    })
+
+    it('falls back to in-place navigation for an unresolved link', async () => {
+      const open = vi.spyOn(window, 'open').mockImplementation(() => null)
+      const onOpenPage = vi.fn()
+      renderMd({ body: '[[Nowhere]]', pages: [], campaignId: 'c1', onOpenPage })
+
+      await userEvent.pointer({
+        target: screen.getByRole('button', { name: 'Nowhere' }),
+        keys: '[MouseMiddle]',
+      })
+
+      expect(open).not.toHaveBeenCalled()
+      expect(onOpenPage).toHaveBeenCalled()
+      open.mockRestore()
+    })
+
+    it('still opens in place on a plain click', () => {
+      const open = vi.spyOn(window, 'open').mockImplementation(() => null)
+      const onOpenPage = vi.fn()
+      renderMd({ body: 'Go to [[The Castle]].', pages: [CASTLE], campaignId: 'c1', onOpenPage })
+
+      fireEvent.click(screen.getByRole('button', { name: 'The Castle' }))
+
+      expect(open).not.toHaveBeenCalled()
+      expect(onOpenPage).toHaveBeenCalledWith(CASTLE, null, expect.anything())
+      open.mockRestore()
+    })
   })
 
   it('supports [[Target|label]] aliasing', () => {

--- a/frontend/src/components/campaigns/WikiView.jsx
+++ b/frontend/src/components/campaigns/WikiView.jsx
@@ -1,5 +1,6 @@
 import { useState, useEffect, useRef, useCallback } from 'react'
 import { createPortal } from 'react-dom'
+import { useSearchParams } from 'react-router-dom'
 import { useTranslation } from 'react-i18next'
 import {
   LuPlus,
@@ -18,6 +19,7 @@ import {
 import { campaigns } from '../../api'
 import { useAudioPlayer } from '../../context/AudioPlayerContext'
 import useIsMobile from '../../hooks/useIsMobile'
+import { isNewTabClick } from '../../hooks/useLinkProps'
 import Spinner from '../Spinner'
 import WikiMarkdown from './WikiMarkdown'
 import WikiImportModal from './WikiImportModal'
@@ -46,8 +48,54 @@ export default function WikiView({ campaign, isOwner, onViewingNoteChange }) {
   const { playQueue } = useAudioPlayer()
   const isMobile = useIsMobile()
   const [pages, setPages] = useState(null)
-  const [selectedId, setSelectedId] = useState(null)
+  // The open note lives in the URL (`?note=<id>`) so a note is linkable: it can
+  // be opened in a new tab, bookmarked, and shared (issue #313). The param is
+  // the single source of truth — there is no mirrored state to drift from it.
+  const [searchParams, setSearchParams] = useSearchParams()
+  const selectedId = searchParams.get('note')
+  // Same contract as a useState setter, including the functional-updater form,
+  // so every existing call site is unchanged. Replaces history entries rather
+  // than pushing: clicking through the sidebar shouldn't bury the page the user
+  // arrived from under one back-step per note.
+  const setSelectedId = useCallback(
+    (next) => {
+      setSearchParams(
+        (prev) => {
+          const current = prev.get('note')
+          const value = typeof next === 'function' ? next(current) : next
+          if (value === current) return prev
+          const params = new URLSearchParams(prev)
+          value ? params.set('note', value) : params.delete('note')
+          return params
+        },
+        { replace: true }
+      )
+    },
+    [setSearchParams]
+  )
+  // Absolute URL for a note, used by the new-tab paths below. Built from the
+  // notes route rather than the live location so it is correct no matter which
+  // note (if any) is currently open.
+  const noteHref = useCallback(
+    (id) => `/campaigns/${campaign.id}/notes?note=${encodeURIComponent(id)}`,
+    [campaign.id]
+  )
   const [page, setPage] = useState(null)
+
+  // Open a note from a click on any note-linking control. Middle click and
+  // ctrl/cmd-click open it in a new tab (issue #313); anything else selects it
+  // in place. Returns true when it handled the event as a new-tab open, so
+  // callers can skip their own in-place work.
+  const openNoteFromClick = (e, id) => {
+    if (!isNewTabClick(e)) {
+      setSelectedId(id)
+      return false
+    }
+    e.preventDefault()
+    e.stopPropagation()
+    window.open(noteHref(id), '_blank', 'noopener,noreferrer')
+    return true
+  }
   const [editing, setEditing] = useState(false)
   const [creating, setCreating] = useState(false)
   const [createParentId, setCreateParentId] = useState('')
@@ -142,7 +190,9 @@ export default function WikiView({ campaign, isOwner, onViewingNoteChange }) {
         })
       })
     },
-    [campaign.id]
+    // setSelectedId is itself memoized on the (stable) setSearchParams, so
+    // listing it here doesn't cost this callback its identity stability.
+    [campaign.id, setSelectedId]
   )
 
   useEffect(() => {
@@ -190,7 +240,7 @@ export default function WikiView({ campaign, isOwner, onViewingNoteChange }) {
       setPendingHeading(heading || null)
       setSelectedId(target.id)
     },
-    [loadList]
+    [loadList, setSelectedId]
   )
 
   // Scroll to the heading a cross-page [[Page:#Heading]] link asked for, once the
@@ -404,9 +454,11 @@ export default function WikiView({ campaign, isOwner, onViewingNoteChange }) {
     const kids = flat ? [] : (childrenOf[p.id] || []).filter((c) => idSet.has(c.id))
     const hasKids = kids.length > 0
     const isCollapsed = collapsed.has(p.id)
-    const selectPage = () => {
+    // Middle click / ctrl-click opens the note in its own tab (issue #313);
+    // otherwise it opens in place, leaving any in-progress create.
+    const selectPage = (e) => {
+      if (openNoteFromClick(e, p.id)) return
       setCreating(false)
-      setSelectedId(p.id)
     }
     // Reordering only applies in the nested tree, not the flattened search view.
     const canDrag = isOwner && !flat
@@ -511,6 +563,8 @@ export default function WikiView({ campaign, isOwner, onViewingNoteChange }) {
           <button
             type="button"
             onClick={selectPage}
+            onAuxClick={selectPage}
+            data-href={noteHref(p.id)}
             style={{
               flex: 1,
               minWidth: 0,
@@ -990,7 +1044,9 @@ export default function WikiView({ campaign, isOwner, onViewingNoteChange }) {
                   {page.backlinks.map((b) => (
                     <button
                       key={b.id}
-                      onClick={() => setSelectedId(b.id)}
+                      onClick={(e) => openNoteFromClick(e, b.id)}
+                      onAuxClick={(e) => openNoteFromClick(e, b.id)}
+                      data-href={noteHref(b.id)}
                       style={{
                         display: 'inline-flex',
                         alignItems: 'center',

--- a/frontend/src/components/campaigns/WikiView.linkable.test.jsx
+++ b/frontend/src/components/campaigns/WikiView.linkable.test.jsx
@@ -1,0 +1,215 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
+import { render, screen, waitFor } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+import { MemoryRouter, Routes, Route, useLocation } from 'react-router-dom'
+import WikiView from './WikiView'
+
+vi.mock('../../api', () => ({
+  default: { get: vi.fn(() => Promise.resolve({})) },
+  mediaUrl: (path) => `http://localhost${path}`,
+  campaigns: {
+    listWikiPages: vi.fn(),
+    getWikiPage: vi.fn(),
+    updateWikiPage: vi.fn(),
+    reorderWikiPages: vi.fn(),
+    createWikiPage: vi.fn(),
+    deleteWikiPage: vi.fn(),
+    exportWiki: vi.fn(),
+    wikiTemplates: vi.fn(),
+    useWikiTemplate: vi.fn(),
+    getWikiTemplate: vi.fn(),
+    fileUrl: (cid, id) => `http://localhost/campaigns/${cid}/files/${id}`,
+  },
+}))
+
+vi.mock('../../context/AudioPlayerContext', () => ({
+  useAudioPlayer: () => ({
+    playQueue: vi.fn(),
+    playNext: vi.fn(),
+    togglePlay: vi.fn(),
+    isCurrent: () => false,
+    isPlayingId: () => false,
+  }),
+}))
+
+import { campaigns } from '../../api'
+
+const campaign = { id: 'c1', name: 'Test', members: [] }
+
+const makePage = (over = {}) => ({
+  id: 'p1',
+  title: 'Dragons',
+  slug: 'dragons',
+  visibility: 'gm',
+  parent_id: null,
+  icon: null,
+  can_edit: true,
+  body: 'Here be dragons',
+  backlinks: [],
+  ...over,
+})
+
+const dragons = makePage()
+const goblins = makePage({ id: 'p2', title: 'Goblins', slug: 'goblins', body: 'Small and mean' })
+
+// Surfaces the live URL so assertions can read the ?note= param.
+function LocationProbe() {
+  const location = useLocation()
+  return <span data-testid="loc">{location.pathname + location.search}</span>
+}
+
+function renderAt(entry = '/campaigns/c1/notes') {
+  return render(
+    <MemoryRouter initialEntries={[entry]}>
+      <LocationProbe />
+      <Routes>
+        <Route
+          path="/campaigns/:campaignId/notes"
+          element={<WikiView campaign={campaign} isOwner />}
+        />
+      </Routes>
+    </MemoryRouter>
+  )
+}
+
+const url = () => screen.getByTestId('loc').textContent
+
+describe('WikiView linkable notes (issue #313)', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    campaigns.listWikiPages.mockResolvedValue([dragons, goblins])
+    campaigns.getWikiPage.mockImplementation((_cid, id) =>
+      Promise.resolve(id === 'p2' ? goblins : dragons)
+    )
+  })
+
+  it('opens the note named by ?note= on load, not the first page', async () => {
+    renderAt('/campaigns/c1/notes?note=p2')
+
+    await waitFor(() => expect(screen.getByText('Small and mean')).toBeInTheDocument())
+    expect(campaigns.getWikiPage).toHaveBeenCalledWith('c1', 'p2')
+  })
+
+  it('puts the note id in the URL when one is selected from the sidebar', async () => {
+    renderAt()
+
+    // Desktop auto-opens the first page, which is itself recorded in the URL.
+    await waitFor(() => expect(url()).toContain('note=p1'))
+
+    await userEvent.click(screen.getByRole('button', { name: 'Goblins' }))
+
+    await waitFor(() => expect(url()).toContain('note=p2'))
+    expect(url()).toBe('/campaigns/c1/notes?note=p2')
+  })
+
+  it('keeps the note in the URL across a back/forward-style remount', async () => {
+    const { unmount } = renderAt()
+    await waitFor(() => expect(url()).toContain('note=p1'))
+    unmount()
+
+    // Re-entering at that URL restores the same note — the point of linkability.
+    renderAt('/campaigns/c1/notes?note=p2')
+    await waitFor(() => expect(screen.getByText('Small and mean')).toBeInTheDocument())
+  })
+
+  // Selection replaces rather than pushes, so browsing the sidebar doesn't bury
+  // the page the user arrived from under one back-step per note they clicked.
+  it('replaces history rather than pushing an entry per note opened', async () => {
+    const seenIdx = []
+    function IdxProbe() {
+      // `idx` is react-router's position in the history stack; it advances on a
+      // push and stays put on a replace.
+      const location = useLocation()
+      seenIdx.push(location.idx ?? window.history.state?.idx ?? 0)
+      return null
+    }
+    render(
+      <MemoryRouter initialEntries={['/campaigns/c1/notes']}>
+        <LocationProbe />
+        <IdxProbe />
+        <Routes>
+          <Route
+            path="/campaigns/:campaignId/notes"
+            element={<WikiView campaign={campaign} isOwner />}
+          />
+        </Routes>
+      </MemoryRouter>
+    )
+
+    await waitFor(() => expect(url()).toContain('note=p1'))
+    await userEvent.click(screen.getByRole('button', { name: 'Goblins' }))
+    await waitFor(() => expect(url()).toContain('note=p2'))
+
+    // Two notes were opened, yet the stack never grew past its starting entry.
+    expect(new Set(seenIdx).size).toBe(1)
+  })
+
+  describe('opening a note in a new tab', () => {
+    let open
+
+    beforeEach(() => {
+      open = vi.spyOn(window, 'open').mockImplementation(() => null)
+    })
+
+    afterEach(() => open.mockRestore())
+
+    it('middle click on a sidebar row opens that note in a new tab', async () => {
+      renderAt()
+      await waitFor(() => expect(url()).toContain('note=p1'))
+
+      await userEvent.pointer({
+        target: screen.getByRole('button', { name: 'Goblins' }),
+        keys: '[MouseMiddle]',
+      })
+
+      expect(open).toHaveBeenCalledWith(
+        '/campaigns/c1/notes?note=p2',
+        '_blank',
+        'noopener,noreferrer'
+      )
+      // The current tab stays on the note it was already showing.
+      expect(url()).toBe('/campaigns/c1/notes?note=p1')
+    })
+
+    it('exposes each sidebar row target as data-href', async () => {
+      renderAt()
+      await waitFor(() => expect(url()).toContain('note=p1'))
+
+      expect(screen.getByRole('button', { name: 'Goblins' })).toHaveAttribute(
+        'data-href',
+        '/campaigns/c1/notes?note=p2'
+      )
+    })
+
+    it('middle click on a backlink chip opens that note in a new tab', async () => {
+      campaigns.getWikiPage.mockResolvedValue(
+        makePage({ backlinks: [{ id: 'p2', title: 'Goblins' }] })
+      )
+      renderAt()
+
+      const chip = await screen.findByRole('button', { name: 'Goblins' })
+      await userEvent.pointer({ target: chip, keys: '[MouseMiddle]' })
+
+      expect(open).toHaveBeenCalledWith(
+        '/campaigns/c1/notes?note=p2',
+        '_blank',
+        'noopener,noreferrer'
+      )
+    })
+
+    it('plain click on a backlink chip still opens it in place', async () => {
+      campaigns.getWikiPage.mockImplementation((_cid, id) =>
+        Promise.resolve(
+          id === 'p2' ? goblins : makePage({ backlinks: [{ id: 'p2', title: 'Goblins' }] })
+        )
+      )
+      renderAt()
+
+      const chip = await screen.findByRole('button', { name: 'Goblins' })
+      await userEvent.click(chip)
+
+      await waitFor(() => expect(url()).toContain('note=p2'))
+      expect(open).not.toHaveBeenCalled()
+    })
+  })
+})

--- a/frontend/src/components/campaigns/WikiView.test.jsx
+++ b/frontend/src/components/campaigns/WikiView.test.jsx
@@ -431,6 +431,13 @@ describe('WikiView create / delete / search', () => {
     ])
     renderView()
     await screen.findByText('Kobolds')
+    // The assertion below rests on the auto-opened page having rendered its
+    // heading. That lands a tick after the sidebar (the note id round-trips
+    // through the URL before the body is fetched), so wait for the heading
+    // itself rather than inferring it from the sidebar row.
+    await waitFor(() =>
+      expect(screen.getAllByText('Dragons').some((n) => n.tagName === 'H2')).toBe(true)
+    )
     fireEvent.change(screen.getByPlaceholderText(/search/i), { target: { value: 'kobold' } })
     // The non-matching sidebar entry is filtered out; Kobolds remains.
     expect(screen.getByText('Kobolds')).toBeInTheDocument()

--- a/frontend/src/components/favorites/AudioFavorite.jsx
+++ b/frontend/src/components/favorites/AudioFavorite.jsx
@@ -10,15 +10,18 @@ import {
   rowFavoriteButtonStyle,
 } from './favoriteStyles'
 import LazyImg from '../LazyImg'
+import useLinkProps from '../../hooks/useLinkProps'
 
 export default function AudioFavorite({ item, grid }) {
   const navigate = useNavigate()
   const open = () => navigate(`/audio/${item.item_id}`)
+  // Middle click / ctrl-click opens this item in a new tab (issue #313).
+  const linkProps = useLinkProps(`/audio/${item.item_id}`, open)
   const label = item.title || item.filename
 
   if (!grid) {
     return (
-      <div onClick={open} style={rowWrapperStyle} onMouseEnter={hoverIn} onMouseLeave={hoverOut}>
+      <div {...linkProps} style={rowWrapperStyle} onMouseEnter={hoverIn} onMouseLeave={hoverOut}>
         <div
           style={{
             width: 40,
@@ -60,7 +63,7 @@ export default function AudioFavorite({ item, grid }) {
   }
 
   return (
-    <div onClick={open} style={cardWrapperStyle} onMouseEnter={hoverIn} onMouseLeave={hoverOut}>
+    <div {...linkProps} style={cardWrapperStyle} onMouseEnter={hoverIn} onMouseLeave={hoverOut}>
       <div
         style={{
           width: '100%',

--- a/frontend/src/components/favorites/BookFavorite.jsx
+++ b/frontend/src/components/favorites/BookFavorite.jsx
@@ -12,6 +12,7 @@ import {
   rowFavoriteButtonStyle,
 } from './favoriteStyles'
 import LazyImg from '../LazyImg'
+import useLinkProps from '../../hooks/useLinkProps'
 
 export default function BookFavorite({ item, grid }) {
   const { t } = useTranslation()
@@ -19,10 +20,14 @@ export default function BookFavorite({ item, grid }) {
   const CatIcon = CATEGORY_ICONS[item.category] || LuFileText
   const open = () =>
     navigate(`/library/book/${item.item_id}`, { state: { from: window.location.pathname } })
+  // Middle click / ctrl-click opens the reader in a new tab (issue #313). The
+  // `from` state is in-page only; a new tab falls back to the reader's default
+  // back target, which is what a real link would do anyway.
+  const linkProps = useLinkProps(`/library/book/${item.item_id}`, open)
 
   if (grid) {
     return (
-      <div onClick={open} style={cardWrapperStyle} onMouseEnter={hoverIn} onMouseLeave={hoverOut}>
+      <div {...linkProps} style={cardWrapperStyle} onMouseEnter={hoverIn} onMouseLeave={hoverOut}>
         <div
           style={{
             width: '100%',
@@ -65,7 +70,7 @@ export default function BookFavorite({ item, grid }) {
   }
 
   return (
-    <div onClick={open} style={rowWrapperStyle} onMouseEnter={hoverIn} onMouseLeave={hoverOut}>
+    <div {...linkProps} style={rowWrapperStyle} onMouseEnter={hoverIn} onMouseLeave={hoverOut}>
       <div
         style={{
           width: 32,

--- a/frontend/src/components/favorites/MapFavorite.jsx
+++ b/frontend/src/components/favorites/MapFavorite.jsx
@@ -10,14 +10,17 @@ import {
   rowFavoriteButtonStyle,
 } from './favoriteStyles'
 import LazyImg from '../LazyImg'
+import useLinkProps from '../../hooks/useLinkProps'
 
 export default function MapFavorite({ item, grid }) {
   const navigate = useNavigate()
   const open = () => navigate(`/maps/${item.item_id}`)
+  // Middle click / ctrl-click opens this item in a new tab (issue #313).
+  const linkProps = useLinkProps(`/maps/${item.item_id}`, open)
 
   if (!grid) {
     return (
-      <div onClick={open} style={rowWrapperStyle} onMouseEnter={hoverIn} onMouseLeave={hoverOut}>
+      <div {...linkProps} style={rowWrapperStyle} onMouseEnter={hoverIn} onMouseLeave={hoverOut}>
         <div
           style={{
             width: 56,
@@ -59,7 +62,7 @@ export default function MapFavorite({ item, grid }) {
   }
 
   return (
-    <div onClick={open} style={cardWrapperStyle} onMouseEnter={hoverIn} onMouseLeave={hoverOut}>
+    <div {...linkProps} style={cardWrapperStyle} onMouseEnter={hoverIn} onMouseLeave={hoverOut}>
       <div
         style={{
           width: '100%',

--- a/frontend/src/components/favorites/SystemFavorite.jsx
+++ b/frontend/src/components/favorites/SystemFavorite.jsx
@@ -10,15 +10,18 @@ import {
   rowFavoriteButtonStyle,
 } from './favoriteStyles'
 import LazyImg from '../LazyImg'
+import useLinkProps from '../../hooks/useLinkProps'
 
 export default function SystemFavorite({ item, grid }) {
   const navigate = useNavigate()
   const open = () => navigate(`/library/system/${item.item_id}`)
+  // Middle click / ctrl-click opens this item in a new tab (issue #313).
+  const linkProps = useLinkProps(`/library/system/${item.item_id}`, open)
   const publisher = (item.publishers || []).map((p) => p.name).join(', ')
 
   if (grid) {
     return (
-      <div onClick={open} style={cardWrapperStyle} onMouseEnter={hoverIn} onMouseLeave={hoverOut}>
+      <div {...linkProps} style={cardWrapperStyle} onMouseEnter={hoverIn} onMouseLeave={hoverOut}>
         <div
           style={{
             width: '100%',
@@ -72,7 +75,7 @@ export default function SystemFavorite({ item, grid }) {
   }
 
   return (
-    <div onClick={open} style={rowWrapperStyle} onMouseEnter={hoverIn} onMouseLeave={hoverOut}>
+    <div {...linkProps} style={rowWrapperStyle} onMouseEnter={hoverIn} onMouseLeave={hoverOut}>
       <div
         style={{
           width: 32,

--- a/frontend/src/components/favorites/TokenFavorite.jsx
+++ b/frontend/src/components/favorites/TokenFavorite.jsx
@@ -10,14 +10,17 @@ import {
   rowFavoriteButtonStyle,
 } from './favoriteStyles'
 import LazyImg from '../LazyImg'
+import useLinkProps from '../../hooks/useLinkProps'
 
 export default function TokenFavorite({ item, grid }) {
   const navigate = useNavigate()
   const open = () => navigate(`/tokens/${item.item_id}`)
+  // Middle click / ctrl-click opens this item in a new tab (issue #313).
+  const linkProps = useLinkProps(`/tokens/${item.item_id}`, open)
 
   if (!grid) {
     return (
-      <div onClick={open} style={rowWrapperStyle} onMouseEnter={hoverIn} onMouseLeave={hoverOut}>
+      <div {...linkProps} style={rowWrapperStyle} onMouseEnter={hoverIn} onMouseLeave={hoverOut}>
         <div
           style={{
             width: 40,
@@ -59,7 +62,7 @@ export default function TokenFavorite({ item, grid }) {
   }
 
   return (
-    <div onClick={open} style={cardWrapperStyle} onMouseEnter={hoverIn} onMouseLeave={hoverOut}>
+    <div {...linkProps} style={cardWrapperStyle} onMouseEnter={hoverIn} onMouseLeave={hoverOut}>
       <div
         style={{
           width: '100%',

--- a/frontend/src/components/library/AgnosticChip.jsx
+++ b/frontend/src/components/library/AgnosticChip.jsx
@@ -1,18 +1,21 @@
 import { useState } from 'react'
 import { useTranslation } from 'react-i18next'
 import { LuLibrary } from 'react-icons/lu'
+import useLinkProps from '../../hooks/useLinkProps'
 import { systemDisplayName } from '../../utils/systemDisplayName'
 
 /**
  * Compact pill for system-agnostic collections — no cover image, sits at the
- * top of the library for quick access.
+ * top of the library for quick access. `to` is the collection's route, which
+ * lets middle click open it in a new tab (issue #313).
  */
-export default function AgnosticChip({ system, onClick }) {
+export default function AgnosticChip({ system, to, onClick }) {
   const { t } = useTranslation()
   const [hovered, setHovered] = useState(false)
+  const linkProps = useLinkProps(to, onClick)
   return (
     <div
-      onClick={onClick}
+      {...linkProps}
       onMouseEnter={() => setHovered(true)}
       onMouseLeave={() => setHovered(false)}
       style={{

--- a/frontend/src/components/library/SystemCard.jsx
+++ b/frontend/src/components/library/SystemCard.jsx
@@ -4,6 +4,7 @@ import { LuLibrary, LuCheck } from 'react-icons/lu'
 import Tag from '../Tag'
 import FavoriteButton from '../FavoriteButton'
 import LazyImg from '../LazyImg'
+import useLinkProps from '../../hooks/useLinkProps'
 import { systemDisplayName } from '../../utils/systemDisplayName'
 import { systemCoverUrl } from '../../utils/systemCoverUrl'
 
@@ -15,9 +16,14 @@ import { systemCoverUrl } from '../../utils/systemCoverUrl'
  * (with shift / cmd-click modifiers) instead of navigating, and a checkbox is
  * shown. Tag chips on the full card link to the tags page (grid tag filtering
  * is handled by the Filters modal's Tags dropdown).
+ *
+ * `to` is the system's route; passing it lets middle click and ctrl/cmd-click
+ * open the system in a new tab (issue #313). In bulk-select mode it is ignored,
+ * since the card selects rather than navigates.
  */
 export default function SystemCard({
   system,
+  to,
   onClick,
   compact,
   list,
@@ -56,6 +62,10 @@ export default function SystemCard({
     onClick()
   }
 
+  // Selection mode owns the modifier keys (shift/cmd extend the selection), so
+  // the card only behaves as a link when it would actually navigate.
+  const linkProps = useLinkProps(selectable ? null : to, handleClick)
+
   const checkbox = (overlay) => (
     <div
       style={{
@@ -84,7 +94,7 @@ export default function SystemCard({
   if (list) {
     return (
       <div
-        onClick={handleClick}
+        {...linkProps}
         onMouseEnter={() => setHovered(true)}
         onMouseLeave={() => setHovered(false)}
         style={{
@@ -177,7 +187,7 @@ export default function SystemCard({
   if (compact) {
     return (
       <div
-        onClick={handleClick}
+        {...linkProps}
         onMouseEnter={() => setHovered(true)}
         onMouseLeave={() => setHovered(false)}
         style={{
@@ -241,7 +251,7 @@ export default function SystemCard({
 
   return (
     <div
-      onClick={handleClick}
+      {...linkProps}
       onMouseEnter={() => setHovered(true)}
       onMouseLeave={() => setHovered(false)}
       style={{

--- a/frontend/src/components/library/SystemCard.test.jsx
+++ b/frontend/src/components/library/SystemCard.test.jsx
@@ -1,4 +1,4 @@
-import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
 import { render as rtlRender, screen } from '@testing-library/react'
 import userEvent from '@testing-library/user-event'
 import { MemoryRouter } from 'react-router-dom'
@@ -288,6 +288,70 @@ describe('SystemCard', () => {
         />
       )
       expect(borderOf(container)).toContain('var(--gold-dim)')
+    })
+  })
+
+  // Issue #313: the card is a <div>, not an <a>, so new-tab behaviour is wired
+  // by hand and needs covering in each layout.
+  describe('opening in a new tab', () => {
+    let open
+
+    beforeEach(() => {
+      open = vi.spyOn(window, 'open').mockImplementation(() => null)
+    })
+
+    afterEach(() => open.mockRestore())
+
+    it.each([
+      ['full', {}],
+      ['compact', { compact: true }],
+      ['list', { list: true }],
+    ])('middle click opens the system in a new tab from the %s layout', async (_name, layout) => {
+      const onClick = vi.fn()
+      const { container } = render(
+        <SystemCard
+          system={makeSystem()}
+          to="/library/system/sys-1"
+          onClick={onClick}
+          {...layout}
+        />
+      )
+
+      await userEvent.pointer({ target: container.firstChild, keys: '[MouseMiddle]' })
+
+      expect(open).toHaveBeenCalledWith('/library/system/sys-1', '_blank', 'noopener,noreferrer')
+      expect(onClick).not.toHaveBeenCalled()
+    })
+
+    it('still navigates in place on a plain click', async () => {
+      const onClick = vi.fn()
+      const { container } = render(
+        <SystemCard system={makeSystem()} to="/library/system/sys-1" onClick={onClick} />
+      )
+
+      await userEvent.click(container.firstChild)
+
+      expect(onClick).toHaveBeenCalledTimes(1)
+      expect(open).not.toHaveBeenCalled()
+    })
+
+    it('selects rather than opening a tab while in bulk-select mode', async () => {
+      const onToggleSelect = vi.fn()
+      const { container } = render(
+        <SystemCard
+          system={makeSystem()}
+          to="/library/system/sys-1"
+          onClick={vi.fn()}
+          selectable
+          onToggleSelect={onToggleSelect}
+        />
+      )
+
+      await userEvent.pointer({ target: container.firstChild, keys: '[MouseMiddle]' })
+      expect(open).not.toHaveBeenCalled()
+
+      await userEvent.click(container.firstChild)
+      expect(onToggleSelect).toHaveBeenCalled()
     })
   })
 })

--- a/frontend/src/components/media/MediaCard.jsx
+++ b/frontend/src/components/media/MediaCard.jsx
@@ -7,6 +7,7 @@ import FavoriteButton from '../FavoriteButton'
 import DownloadButton from '../DownloadButton'
 import AudioPlayer from '../audio/AudioPlayer'
 import LazyImg from '../LazyImg'
+import useLinkProps from '../../hooks/useLinkProps'
 
 const CORNER_POS = {
   'bottom-left': { bottom: 6, left: 6 },
@@ -42,6 +43,11 @@ export default function MediaCard({ config, item, onClick, bulkMode, selected, o
     }
   }
 
+  // Middle click / ctrl-click opens the detail page in a new tab (issue #313).
+  // Bulk mode claims the modifier keys for range and multi-select, so the card
+  // only acts as a link when a plain click would navigate.
+  const linkProps = useLinkProps(bulkMode ? null : config.detailPath(item.id), handleClick)
+
   // Badges that apply to this item, in config order.
   const activeBadges = config.badges.filter((b) => item[b.flag])
 
@@ -58,7 +64,7 @@ export default function MediaCard({ config, item, onClick, bulkMode, selected, o
   if (list) {
     return (
       <div
-        onClick={handleClick}
+        {...linkProps}
         onKeyDown={onKeyDown}
         role="button"
         tabIndex={0}
@@ -172,7 +178,7 @@ export default function MediaCard({ config, item, onClick, bulkMode, selected, o
 
   return (
     <div
-      onClick={handleClick}
+      {...linkProps}
       onKeyDown={onKeyDown}
       role="button"
       tabIndex={0}

--- a/frontend/src/components/media/MediaCard.test.jsx
+++ b/frontend/src/components/media/MediaCard.test.jsx
@@ -1,4 +1,4 @@
-import { describe, it, expect, vi } from 'vitest'
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
 import { render, screen } from '@testing-library/react'
 import userEvent from '@testing-library/user-event'
 import MediaCard from './MediaCard'
@@ -185,5 +185,60 @@ describe('MediaCard — map (no audio controls)', () => {
     screen.getByRole('button', { name: 'cave.png' }).focus()
     await userEvent.keyboard('{Enter}')
     expect(onClick).toHaveBeenCalled()
+  })
+
+  // Issue #313 — the card is a <div>, so new-tab behaviour is wired by hand.
+  describe('opening in a new tab', () => {
+    let open
+
+    beforeEach(() => {
+      open = vi.spyOn(window, 'open').mockImplementation(() => null)
+    })
+
+    afterEach(() => open.mockRestore())
+
+    it.each([
+      ['map', 'map', mapItem, '/maps/m1'],
+      ['audio', 'audio', audioItem, '/audio/a1'],
+    ])('middle click opens a %s in a new tab', async (_label, key, makeItem, href) => {
+      const onClick = vi.fn()
+      render(<MediaCard config={MEDIA_CONFIGS[key]} item={makeItem()} onClick={onClick} />)
+
+      await userEvent.pointer({ target: screen.getAllByRole('button')[0], keys: '[MouseMiddle]' })
+
+      expect(open).toHaveBeenCalledWith(href, '_blank', 'noopener,noreferrer')
+      expect(onClick).not.toHaveBeenCalled()
+    })
+
+    it('opens in a new tab from the list layout too', async () => {
+      render(<MediaCard config={MEDIA_CONFIGS.map} item={mapItem()} onClick={vi.fn()} list />)
+
+      await userEvent.pointer({
+        target: screen.getByRole('button', { name: 'cave.png' }),
+        keys: '[MouseMiddle]',
+      })
+
+      expect(open).toHaveBeenCalledWith('/maps/m1', '_blank', 'noopener,noreferrer')
+    })
+
+    it('selects instead of opening a tab in bulk mode', async () => {
+      const onToggle = vi.fn()
+      render(
+        <MediaCard
+          config={MEDIA_CONFIGS.map}
+          item={mapItem()}
+          onClick={vi.fn()}
+          bulkMode
+          onToggle={onToggle}
+        />
+      )
+
+      await userEvent.pointer({
+        target: screen.getByRole('button', { name: 'cave.png' }),
+        keys: '[MouseMiddle]',
+      })
+
+      expect(open).not.toHaveBeenCalled()
+    })
   })
 })

--- a/frontend/src/components/search/BookGroup.jsx
+++ b/frontend/src/components/search/BookGroup.jsx
@@ -1,5 +1,6 @@
 import { useTranslation } from 'react-i18next'
 import { LuChevronDown, LuChevronRight } from 'react-icons/lu'
+import PageHit from './PageHit'
 import { cardStyle } from './searchStyles'
 
 /** A collapsible book result group in the search view: book header + page hits. */
@@ -52,30 +53,7 @@ export default function BookGroup({ group, collapsed, onToggle, onNavigate }) {
       {!isCollapsed && (
         <div style={{ marginLeft: 16, marginTop: 4, marginBottom: 4 }}>
           {group.pages.map((p, i) => (
-            <div
-              key={i}
-              onClick={() => onNavigate(p.page_number)}
-              style={{ ...cardStyle, borderLeft: '3px solid var(--border)' }}
-              onMouseEnter={(e) => (e.currentTarget.style.background = 'var(--bg-card-hover)')}
-              onMouseLeave={(e) => (e.currentTarget.style.background = 'var(--bg-card)')}
-            >
-              <div
-                style={{
-                  display: 'flex',
-                  justifyContent: 'space-between',
-                  alignItems: 'baseline',
-                  marginBottom: 4,
-                }}
-              >
-                <span style={{ fontSize: 13, color: 'var(--text-muted)' }}>
-                  {t('common.pagePrefixed', { page: p.page_number })}
-                </span>
-              </div>
-              <div
-                style={{ fontSize: 14, color: 'var(--text-dim)', lineHeight: 1.5 }}
-                dangerouslySetInnerHTML={{ __html: p.snippet }}
-              />
-            </div>
+            <PageHit key={i} bookId={group.id} page={p} onOpen={() => onNavigate(p.page_number)} />
           ))}
         </div>
       )}

--- a/frontend/src/components/search/PageHit.jsx
+++ b/frontend/src/components/search/PageHit.jsx
@@ -1,0 +1,38 @@
+import { useTranslation } from 'react-i18next'
+import useLinkProps from '../../hooks/useLinkProps'
+import { cardStyle } from './searchStyles'
+
+/**
+ * One page hit inside a book's search-result group. Behaves like a link: a plain
+ * click opens the reader at that page, middle click and ctrl/cmd-click open it
+ * in a new tab (issue #313).
+ */
+export default function PageHit({ bookId, page, onOpen }) {
+  const { t } = useTranslation()
+  const linkProps = useLinkProps(`/library/book/${bookId}?page=${page.page_number}`, onOpen)
+  return (
+    <div
+      {...linkProps}
+      style={{ ...cardStyle, borderLeft: '3px solid var(--border)' }}
+      onMouseEnter={(e) => (e.currentTarget.style.background = 'var(--bg-card-hover)')}
+      onMouseLeave={(e) => (e.currentTarget.style.background = 'var(--bg-card)')}
+    >
+      <div
+        style={{
+          display: 'flex',
+          justifyContent: 'space-between',
+          alignItems: 'baseline',
+          marginBottom: 4,
+        }}
+      >
+        <span style={{ fontSize: 13, color: 'var(--text-muted)' }}>
+          {t('common.pagePrefixed', { page: page.page_number })}
+        </span>
+      </div>
+      <div
+        style={{ fontSize: 14, color: 'var(--text-dim)', lineHeight: 1.5 }}
+        dangerouslySetInnerHTML={{ __html: page.snippet }}
+      />
+    </div>
+  )
+}

--- a/frontend/src/components/search/PageHit.test.jsx
+++ b/frontend/src/components/search/PageHit.test.jsx
@@ -1,0 +1,45 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
+import { render, screen } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+import PageHit from './PageHit'
+
+const page = { page_number: 12, snippet: 'the <b>lich</b> waits' }
+
+describe('PageHit', () => {
+  let open
+
+  beforeEach(() => {
+    open = vi.spyOn(window, 'open').mockImplementation(() => null)
+  })
+
+  afterEach(() => {
+    open.mockRestore()
+  })
+
+  it('renders the page number and snippet markup', () => {
+    render(<PageHit bookId="b7" page={page} onOpen={vi.fn()} />)
+
+    expect(screen.getByText('p. 12')).toBeInTheDocument()
+    expect(screen.getByText('lich')).toBeInTheDocument()
+  })
+
+  it('opens the page in place on a plain click', async () => {
+    const onOpen = vi.fn()
+    render(<PageHit bookId="b7" page={page} onOpen={onOpen} />)
+
+    await userEvent.click(screen.getByText('p. 12'))
+
+    expect(onOpen).toHaveBeenCalledTimes(1)
+    expect(open).not.toHaveBeenCalled()
+  })
+
+  it('opens the reader at that page in a new tab on middle click', async () => {
+    const onOpen = vi.fn()
+    render(<PageHit bookId="b7" page={page} onOpen={onOpen} />)
+
+    await userEvent.pointer({ target: screen.getByText('p. 12'), keys: '[MouseMiddle]' })
+
+    expect(open).toHaveBeenCalledWith('/library/book/b7?page=12', '_blank', 'noopener,noreferrer')
+    expect(onOpen).not.toHaveBeenCalled()
+  })
+})

--- a/frontend/src/components/search/ResultCard.jsx
+++ b/frontend/src/components/search/ResultCard.jsx
@@ -1,0 +1,24 @@
+import TagList from './TagList'
+import useLinkProps from '../../hooks/useLinkProps'
+import { cardStyle } from './searchStyles'
+
+/**
+ * One media hit (map, token, audio) in the global search results. Behaves like a
+ * link: a plain click navigates in place, middle click and ctrl/cmd-click open
+ * the detail page in a new tab (issue #313).
+ */
+export default function ResultCard({ to, title, subtitle, tags, onOpen }) {
+  const linkProps = useLinkProps(to, onOpen)
+  return (
+    <div
+      {...linkProps}
+      style={cardStyle}
+      onMouseEnter={(e) => (e.currentTarget.style.background = 'var(--bg-card-hover)')}
+      onMouseLeave={(e) => (e.currentTarget.style.background = 'var(--bg-card)')}
+    >
+      <div style={{ fontWeight: 500, fontSize: 15 }}>{title}</div>
+      <div style={{ fontSize: 13, color: 'var(--text-muted)', marginTop: 3 }}>{subtitle}</div>
+      {tags?.length > 0 && <TagList tags={tags} />}
+    </div>
+  )
+}

--- a/frontend/src/components/search/ResultCard.test.jsx
+++ b/frontend/src/components/search/ResultCard.test.jsx
@@ -1,0 +1,69 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
+import { render, screen } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+import ResultCard from './ResultCard'
+
+describe('ResultCard', () => {
+  let open
+
+  beforeEach(() => {
+    open = vi.spyOn(window, 'open').mockImplementation(() => null)
+  })
+
+  afterEach(() => {
+    open.mockRestore()
+  })
+
+  it('renders the title, path and tags', () => {
+    render(
+      <ResultCard
+        to="/maps/5"
+        title="tavern.jpg"
+        subtitle="Maps/Taverns"
+        tags={['indoor']}
+        onOpen={vi.fn()}
+      />
+    )
+
+    expect(screen.getByText('tavern.jpg')).toBeInTheDocument()
+    expect(screen.getByText('Maps/Taverns')).toBeInTheDocument()
+    expect(screen.getByText('indoor')).toBeInTheDocument()
+  })
+
+  it('omits the tag list when the item has no tags', () => {
+    render(<ResultCard to="/maps/5" title="tavern.jpg" subtitle="Maps" onOpen={vi.fn()} />)
+
+    expect(screen.getByText('tavern.jpg')).toBeInTheDocument()
+  })
+
+  it('navigates in place on a plain click', async () => {
+    const onOpen = vi.fn()
+    render(<ResultCard to="/maps/5" title="tavern.jpg" subtitle="Maps" onOpen={onOpen} />)
+
+    await userEvent.click(screen.getByText('tavern.jpg'))
+
+    expect(onOpen).toHaveBeenCalledTimes(1)
+    expect(open).not.toHaveBeenCalled()
+  })
+
+  it('highlights on hover and restores the base background on leave', async () => {
+    render(<ResultCard to="/maps/5" title="tavern.jpg" subtitle="Maps" onOpen={vi.fn()} />)
+    const card = screen.getByText('tavern.jpg').parentElement
+
+    await userEvent.hover(card)
+    expect(card.style.background).toBe('var(--bg-card-hover)')
+
+    await userEvent.unhover(card)
+    expect(card.style.background).toBe('var(--bg-card)')
+  })
+
+  it('opens the detail page in a new tab on middle click', async () => {
+    const onOpen = vi.fn()
+    render(<ResultCard to="/tokens/8" title="goblin.png" subtitle="Tokens" onOpen={onOpen} />)
+
+    await userEvent.pointer({ target: screen.getByText('goblin.png'), keys: '[MouseMiddle]' })
+
+    expect(open).toHaveBeenCalledWith('/tokens/8', '_blank', 'noopener,noreferrer')
+    expect(onOpen).not.toHaveBeenCalled()
+  })
+})

--- a/frontend/src/components/system/BookRow.jsx
+++ b/frontend/src/components/system/BookRow.jsx
@@ -7,6 +7,7 @@ import { useFavorites } from '../../context/FavoritesContext'
 import { getBookPrefs } from '../../hooks/useBookPrefs'
 import FavoriteButton from '../FavoriteButton'
 import LazyImg from '../LazyImg'
+import useLinkProps from '../../hooks/useLinkProps'
 import BookActionsMenu from './BookActionsMenu'
 
 /**
@@ -62,6 +63,14 @@ export default function BookRow({
       handleClick(e)
     }
   }
+
+  // Middle click / ctrl-click opens the reader in a new tab (issue #313).
+  // Archives have no reader page — clicking them downloads the file — and bulk
+  // mode claims the modifier keys for range select, so neither is linkable.
+  const linkProps = useLinkProps(
+    bulkMode || isArchive ? null : `/library/book/${book.id}`,
+    handleClick
+  )
 
   // Overlaid checkbox shown over thumbnails in the grid layouts.
   const overlayCheckbox = bulkMode && (
@@ -122,7 +131,7 @@ export default function BookRow({
     const thumbHeight = compact ? 110 : 160
     return (
       <div
-        onClick={handleClick}
+        {...linkProps}
         onKeyDown={handleKeyDown}
         role="button"
         tabIndex={0}
@@ -255,7 +264,7 @@ export default function BookRow({
   // ----- List layout (default) -----
   return (
     <div
-      onClick={handleClick}
+      {...linkProps}
       onKeyDown={handleKeyDown}
       role="button"
       tabIndex={0}

--- a/frontend/src/components/system/BookRow.test.jsx
+++ b/frontend/src/components/system/BookRow.test.jsx
@@ -1,5 +1,6 @@
-import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
 import { render, screen, fireEvent } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
 import BookRow from './BookRow'
 import * as FavCtx from '../../context/FavoritesContext'
 import * as api from '../../api'
@@ -395,5 +396,55 @@ describe('BookRow', () => {
     render(<BookRow book={makeBook({ tags: ['official', 'errata'] })} onOpen={() => {}} />)
     expect(screen.getByText('Official')).toBeInTheDocument()
     expect(screen.getByText('Errata')).toBeInTheDocument()
+  })
+
+  // Issue #313 — the row is a <div>, so new-tab behaviour is wired by hand.
+  describe('opening in a new tab', () => {
+    let open
+
+    beforeEach(() => {
+      open = vi.spyOn(window, 'open').mockImplementation(() => null)
+    })
+
+    afterEach(() => open.mockRestore())
+
+    it.each([
+      ['list', {}],
+      ['card', { card: true }],
+      ['compact', { compact: true }],
+    ])('middle click opens the reader in a new tab from the %s layout', async (_name, layout) => {
+      const onOpen = vi.fn()
+      render(<BookRow book={makeBook()} onOpen={onOpen} {...layout} />)
+
+      await userEvent.pointer({
+        target: screen.getByRole('button', { name: /open player's handbook/i }),
+        keys: '[MouseMiddle]',
+      })
+
+      expect(open).toHaveBeenCalledWith('/library/book/book-1', '_blank', 'noopener,noreferrer')
+      expect(onOpen).not.toHaveBeenCalled()
+    })
+
+    it('does not offer a new tab for an archive, which downloads instead', async () => {
+      render(<BookRow book={archiveBook()} onOpen={vi.fn()} />)
+
+      await userEvent.pointer({
+        target: screen.getByRole('button', { name: /open lancer bundle/i }),
+        keys: '[MouseMiddle]',
+      })
+
+      expect(open).not.toHaveBeenCalled()
+    })
+
+    it('does not offer a new tab in bulk-select mode', async () => {
+      render(<BookRow book={makeBook()} onOpen={vi.fn()} bulkMode onToggle={vi.fn()} />)
+
+      await userEvent.pointer({
+        target: screen.getByRole('button', { name: /open player's handbook/i }),
+        keys: '[MouseMiddle]',
+      })
+
+      expect(open).not.toHaveBeenCalled()
+    })
   })
 })

--- a/frontend/src/components/system/SystemContainerView.jsx
+++ b/frontend/src/components/system/SystemContainerView.jsx
@@ -158,6 +158,7 @@ export default function SystemContainerView({
             <SystemCard
               key={child.id}
               system={child}
+              to={`/library/system/${child.id}`}
               compact={compact}
               list={list}
               onClick={() => onOpenChild(child)}

--- a/frontend/src/components/system/SystemPageHit.jsx
+++ b/frontend/src/components/system/SystemPageHit.jsx
@@ -1,0 +1,45 @@
+import { useTranslation } from 'react-i18next'
+import useLinkProps from '../../hooks/useLinkProps'
+
+/**
+ * One full-text page hit in the in-system search results. Behaves like a link:
+ * a plain click opens the reader at that page, middle click and ctrl/cmd-click
+ * open it in a new tab (issue #313).
+ */
+export default function SystemPageHit({ result, onOpen }) {
+  const { t } = useTranslation()
+  const linkProps = useLinkProps(`/library/book/${result.id}?page=${result.page_number}`, onOpen)
+  return (
+    <div
+      {...linkProps}
+      style={{
+        background: 'var(--bg-card)',
+        border: '1px solid var(--border)',
+        borderRadius: 8,
+        padding: 14,
+        marginBottom: 8,
+        cursor: 'pointer',
+      }}
+      onMouseEnter={(e) => (e.currentTarget.style.background = 'var(--bg-card-hover)')}
+      onMouseLeave={(e) => (e.currentTarget.style.background = 'var(--bg-card)')}
+    >
+      <div
+        style={{
+          display: 'flex',
+          justifyContent: 'space-between',
+          alignItems: 'baseline',
+          marginBottom: 4,
+        }}
+      >
+        <span style={{ fontWeight: 600, fontSize: 15 }}>{result.title}</span>
+        <span style={{ fontSize: 13, color: 'var(--text-muted)', flexShrink: 0, marginLeft: 12 }}>
+          {t('common.pagePrefixed', { page: result.page_number })}
+        </span>
+      </div>
+      <div
+        style={{ fontSize: 14, color: 'var(--text-dim)', lineHeight: 1.5 }}
+        dangerouslySetInnerHTML={{ __html: result.snippet }}
+      />
+    </div>
+  )
+}

--- a/frontend/src/components/system/SystemPageHit.test.jsx
+++ b/frontend/src/components/system/SystemPageHit.test.jsx
@@ -1,0 +1,55 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
+import { render, screen } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+import SystemPageHit from './SystemPageHit'
+
+const result = {
+  id: 'book-1',
+  title: 'Player Handbook',
+  page_number: 42,
+  snippet: 'a <b>dragon</b> appears',
+}
+
+describe('SystemPageHit', () => {
+  let open
+
+  beforeEach(() => {
+    open = vi.spyOn(window, 'open').mockImplementation(() => null)
+  })
+
+  afterEach(() => {
+    open.mockRestore()
+  })
+
+  it('renders the book title, page number and snippet markup', () => {
+    render(<SystemPageHit result={result} onOpen={vi.fn()} />)
+
+    expect(screen.getByText('Player Handbook')).toBeInTheDocument()
+    expect(screen.getByText('p. 42')).toBeInTheDocument()
+    expect(screen.getByText('dragon')).toBeInTheDocument()
+  })
+
+  it('opens the page in place on a plain click', async () => {
+    const onOpen = vi.fn()
+    render(<SystemPageHit result={result} onOpen={onOpen} />)
+
+    await userEvent.click(screen.getByText('Player Handbook'))
+
+    expect(onOpen).toHaveBeenCalledTimes(1)
+    expect(open).not.toHaveBeenCalled()
+  })
+
+  it('opens the reader at that page in a new tab on middle click', async () => {
+    const onOpen = vi.fn()
+    render(<SystemPageHit result={result} onOpen={onOpen} />)
+
+    await userEvent.pointer({ target: screen.getByText('Player Handbook'), keys: '[MouseMiddle]' })
+
+    expect(open).toHaveBeenCalledWith(
+      '/library/book/book-1?page=42',
+      '_blank',
+      'noopener,noreferrer'
+    )
+    expect(onOpen).not.toHaveBeenCalled()
+  })
+})

--- a/frontend/src/components/system/SystemSearchResults.jsx
+++ b/frontend/src/components/system/SystemSearchResults.jsx
@@ -1,5 +1,6 @@
 import { useTranslation } from 'react-i18next'
 import BookRow from './BookRow'
+import SystemPageHit from './SystemPageHit'
 
 /**
  * The search-results view shown inside SystemDetailView when a full-text search
@@ -74,45 +75,7 @@ export default function SystemSearchResults({
             })}
           </div>
           {searchResults.results.map((r, i) => (
-            <div
-              key={i}
-              onClick={() => onOpenPage(r)}
-              style={{
-                background: 'var(--bg-card)',
-                border: '1px solid var(--border)',
-                borderRadius: 8,
-                padding: 14,
-                marginBottom: 8,
-                cursor: 'pointer',
-              }}
-              onMouseEnter={(e) => (e.currentTarget.style.background = 'var(--bg-card-hover)')}
-              onMouseLeave={(e) => (e.currentTarget.style.background = 'var(--bg-card)')}
-            >
-              <div
-                style={{
-                  display: 'flex',
-                  justifyContent: 'space-between',
-                  alignItems: 'baseline',
-                  marginBottom: 4,
-                }}
-              >
-                <span style={{ fontWeight: 600, fontSize: 15 }}>{r.title}</span>
-                <span
-                  style={{
-                    fontSize: 13,
-                    color: 'var(--text-muted)',
-                    flexShrink: 0,
-                    marginLeft: 12,
-                  }}
-                >
-                  {t('common.pagePrefixed', { page: r.page_number })}
-                </span>
-              </div>
-              <div
-                style={{ fontSize: 14, color: 'var(--text-dim)', lineHeight: 1.5 }}
-                dangerouslySetInnerHTML={{ __html: r.snippet }}
-              />
-            </div>
+            <SystemPageHit key={i} result={r} onOpen={() => onOpenPage(r)} />
           ))}
         </div>
       )}

--- a/frontend/src/components/tags/TagListButton.jsx
+++ b/frontend/src/components/tags/TagListButton.jsx
@@ -1,0 +1,40 @@
+import useLinkProps from '../../hooks/useLinkProps'
+
+/**
+ * One tag in the tags page's left-hand list. Selecting a tag is a URL change
+ * (`/tags?tag=<internal>`), so the row behaves like a link: plain click selects
+ * it in place, while middle click and ctrl/cmd-click open it in a new tab
+ * (issue #313).
+ */
+export default function TagListButton({ tag, active, onSelect }) {
+  const linkProps = useLinkProps(`/tags?tag=${encodeURIComponent(tag.internal)}`, () =>
+    onSelect(tag.internal)
+  )
+  return (
+    <button
+      type="button"
+      {...linkProps}
+      aria-current={active}
+      style={{
+        flex: 1,
+        display: 'flex',
+        justifyContent: 'space-between',
+        alignItems: 'center',
+        gap: 8,
+        padding: '7px 10px 7px 2px',
+        background: 'none',
+        border: 'none',
+        cursor: 'pointer',
+        color: 'var(--text)',
+        fontSize: 14,
+        textAlign: 'left',
+        minWidth: 0,
+      }}
+    >
+      <span style={{ overflow: 'hidden', textOverflow: 'ellipsis', whiteSpace: 'nowrap' }}>
+        {tag.display}
+      </span>
+      <span style={{ color: 'var(--text-muted)', fontSize: 12, flexShrink: 0 }}>{tag.count}</span>
+    </button>
+  )
+}

--- a/frontend/src/components/tags/TagListButton.test.jsx
+++ b/frontend/src/components/tags/TagListButton.test.jsx
@@ -1,0 +1,51 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
+import { render, screen } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+import TagListButton from './TagListButton'
+
+const tag = { internal: 'city watch', display: 'City Watch', count: 4 }
+
+describe('TagListButton', () => {
+  let open
+
+  beforeEach(() => {
+    open = vi.spyOn(window, 'open').mockImplementation(() => null)
+  })
+
+  afterEach(() => {
+    open.mockRestore()
+  })
+
+  it('renders the tag label and its count', () => {
+    render(<TagListButton tag={tag} active={false} onSelect={vi.fn()} />)
+
+    expect(screen.getByText('City Watch')).toBeInTheDocument()
+    expect(screen.getByText('4')).toBeInTheDocument()
+  })
+
+  it('selects the tag by its internal key on a plain click', async () => {
+    const onSelect = vi.fn()
+    render(<TagListButton tag={tag} active={false} onSelect={onSelect} />)
+
+    await userEvent.click(screen.getByRole('button'))
+
+    expect(onSelect).toHaveBeenCalledWith('city watch')
+    expect(open).not.toHaveBeenCalled()
+  })
+
+  it('opens the tag in a new tab on middle click, with the key URL-encoded', async () => {
+    const onSelect = vi.fn()
+    render(<TagListButton tag={tag} active={false} onSelect={onSelect} />)
+
+    await userEvent.pointer({ target: screen.getByRole('button'), keys: '[MouseMiddle]' })
+
+    expect(open).toHaveBeenCalledWith('/tags?tag=city%20watch', '_blank', 'noopener,noreferrer')
+    expect(onSelect).not.toHaveBeenCalled()
+  })
+
+  it('marks the active tag as current', () => {
+    render(<TagListButton tag={tag} active onSelect={vi.fn()} />)
+
+    expect(screen.getByRole('button')).toHaveAttribute('aria-current', 'true')
+  })
+})

--- a/frontend/src/hooks/useLinkProps.js
+++ b/frontend/src/hooks/useLinkProps.js
@@ -1,0 +1,98 @@
+import { useCallback } from 'react'
+
+/**
+ * Returns true when a mouse event should open the target in a new tab rather
+ * than navigating in place: middle click, or ctrl/cmd/shift-click (issue #313).
+ */
+export function isNewTabClick(e) {
+  if (!e) return false
+  // `auxclick` fires for every non-primary button; only the middle one (1)
+  // means "open in a new tab". The right button opens the context menu.
+  if (e.type === 'auxclick') return e.button === 1
+  // `button` is often absent on synthetic clicks, where 0 (primary) is implied.
+  return !e.button && !!(e.metaKey || e.ctrlKey || e.shiftKey)
+}
+
+/**
+ * Opens an in-app path in a new browser tab. Paths are absolute app routes and
+ * the app mounts BrowserRouter at the origin root with no basename, so the
+ * route and the URL are the same string.
+ */
+function openInNewTab(to) {
+  // noopener/noreferrer: the new tab must not get a handle on this window.
+  window.open(to, '_blank', 'noopener,noreferrer')
+}
+
+/**
+ * Props that turn a non-anchor element (a card `<div>`, a chip `<button>`) into
+ * something that behaves like a real link for mouse users.
+ *
+ * Cards across the app navigate with `navigate()` from an `onClick` handler
+ * rather than rendering an `<a>`, because they nest their own buttons — favorite
+ * toggles, kebab menus, download actions — which may not legally live inside an
+ * anchor, and because bulk-select mode reuses the same click target for
+ * selection. That left middle click doing nothing at all (issue #313).
+ *
+ * This hook keeps the existing click behaviour and layers link semantics on top:
+ *
+ * - `onClick` — a plain click runs `onActivate` (the caller's normal handler);
+ *   ctrl/cmd/shift-click opens `to` in a new tab instead.
+ * - `onAuxClick` — middle click opens `to` in a new tab.
+ * - `data-href` — the target route, so tests and tooling can see where it goes.
+ *
+ * `to` may be null (a card in bulk-select mode, an item with no route), in which
+ * case the new-tab paths are skipped and `onActivate` always runs.
+ *
+ * Deliberately does not use `useNavigate`/`useHref`: these chips and cards are
+ * rendered — and unit-tested — outside a Router in several places, and needing
+ * a Router context just to compute a URL would be a needless coupling.
+ *
+ * Spread onto the clickable element:
+ *
+ *   const linkProps = useLinkProps(`/library/system/${id}`, handleClick)
+ *   <div {...linkProps} role="button" tabIndex={0}>…</div>
+ */
+export default function useLinkProps(to, onActivate) {
+  const onClick = useCallback(
+    (e) => {
+      if (to && isNewTabClick(e)) {
+        e.preventDefault()
+        e.stopPropagation()
+        openInNewTab(to)
+        return
+      }
+      onActivate?.(e)
+    },
+    [to, onActivate]
+  )
+
+  const onAuxClick = useCallback(
+    (e) => {
+      if (!to || !isNewTabClick(e)) return
+      // Firefox otherwise starts autoscroll on middle click.
+      e.preventDefault()
+      e.stopPropagation()
+      openInNewTab(to)
+    },
+    [to]
+  )
+
+  return { onClick, onAuxClick, 'data-href': to || undefined }
+}
+
+/**
+ * Variant for callers that already own their `onClick` and only need the
+ * new-tab affordances — click handlers where rewriting the existing logic would
+ * be more churn than it's worth.
+ */
+export function useNewTabHandler(to) {
+  return useCallback(
+    (e) => {
+      if (!to || !isNewTabClick(e)) return
+      e.preventDefault()
+      e.stopPropagation()
+      openInNewTab(to)
+    },
+    [to]
+  )
+}

--- a/frontend/src/hooks/useLinkProps.test.jsx
+++ b/frontend/src/hooks/useLinkProps.test.jsx
@@ -1,0 +1,162 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
+import { render, screen } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+import useLinkProps, { useNewTabHandler, isNewTabClick } from './useLinkProps'
+
+function Card({ to, onActivate }) {
+  const linkProps = useLinkProps(to, onActivate)
+  return (
+    <div {...linkProps} role="button" tabIndex={0}>
+      card
+    </div>
+  )
+}
+
+function NewTabButton({ to }) {
+  const onNewTab = useNewTabHandler(to)
+  return (
+    <button type="button" onAuxClick={onNewTab} onClick={onNewTab}>
+      go
+    </button>
+  )
+}
+
+describe('isNewTabClick', () => {
+  it('is true for a middle-button auxclick', () => {
+    expect(isNewTabClick({ type: 'auxclick', button: 1 })).toBe(true)
+  })
+
+  it('is false for a right-button auxclick', () => {
+    expect(isNewTabClick({ type: 'auxclick', button: 2 })).toBe(false)
+  })
+
+  it('is true for a modified left click', () => {
+    expect(isNewTabClick({ type: 'click', button: 0, metaKey: true })).toBe(true)
+    expect(isNewTabClick({ type: 'click', button: 0, ctrlKey: true })).toBe(true)
+    expect(isNewTabClick({ type: 'click', button: 0, shiftKey: true })).toBe(true)
+  })
+
+  it('is false for a plain left click', () => {
+    expect(isNewTabClick({ type: 'click', button: 0 })).toBe(false)
+  })
+
+  it('is false for a missing event', () => {
+    expect(isNewTabClick(null)).toBe(false)
+  })
+})
+
+describe('useLinkProps', () => {
+  let open
+
+  beforeEach(() => {
+    open = vi.spyOn(window, 'open').mockImplementation(() => null)
+  })
+
+  afterEach(() => {
+    open.mockRestore()
+  })
+
+  it('runs the normal handler on a plain click', async () => {
+    const onActivate = vi.fn()
+    render(<Card to="/library/system/7" onActivate={onActivate} />)
+
+    await userEvent.click(screen.getByRole('button'))
+
+    expect(onActivate).toHaveBeenCalledTimes(1)
+    expect(open).not.toHaveBeenCalled()
+  })
+
+  it('opens the target in a new tab on middle click', async () => {
+    const onActivate = vi.fn()
+    render(<Card to="/library/system/7" onActivate={onActivate} />)
+
+    await userEvent.pointer({
+      target: screen.getByRole('button'),
+      keys: '[MouseMiddle]',
+    })
+
+    expect(open).toHaveBeenCalledWith('/library/system/7', '_blank', 'noopener,noreferrer')
+    expect(onActivate).not.toHaveBeenCalled()
+  })
+
+  it('opens the target in a new tab on ctrl-click instead of navigating', async () => {
+    const onActivate = vi.fn()
+    render(<Card to="/maps/3" onActivate={onActivate} />)
+
+    // A single setup() session keeps the modifier held across the click; the
+    // default export resets keyboard state between calls.
+    const user = userEvent.setup()
+    await user.keyboard('{Control>}')
+    await user.click(screen.getByRole('button'))
+    await user.keyboard('{/Control}')
+
+    expect(open).toHaveBeenCalledWith('/maps/3', '_blank', 'noopener,noreferrer')
+    expect(onActivate).not.toHaveBeenCalled()
+  })
+
+  it('ignores a right-button aux click', async () => {
+    render(<Card to="/maps/3" onActivate={vi.fn()} />)
+
+    await userEvent.pointer({
+      target: screen.getByRole('button'),
+      keys: '[MouseRight]',
+    })
+
+    expect(open).not.toHaveBeenCalled()
+  })
+
+  it('falls back to the normal handler when there is no target', async () => {
+    const onActivate = vi.fn()
+    render(<Card to={null} onActivate={onActivate} />)
+
+    await userEvent.click(screen.getByRole('button'))
+    await userEvent.pointer({ target: screen.getByRole('button'), keys: '[MouseMiddle]' })
+
+    expect(onActivate).toHaveBeenCalledTimes(1)
+    expect(open).not.toHaveBeenCalled()
+  })
+
+  it('exposes the target as data-href, and omits it without one', () => {
+    const { rerender } = render(<Card to="/tokens/9" onActivate={vi.fn()} />)
+    expect(screen.getByRole('button')).toHaveAttribute('data-href', '/tokens/9')
+
+    rerender(<Card to={null} onActivate={vi.fn()} />)
+    expect(screen.getByRole('button')).not.toHaveAttribute('data-href')
+  })
+})
+
+describe('useNewTabHandler', () => {
+  let open
+
+  beforeEach(() => {
+    open = vi.spyOn(window, 'open').mockImplementation(() => null)
+  })
+
+  afterEach(() => {
+    open.mockRestore()
+  })
+
+  it('opens the target on middle click', async () => {
+    render(<NewTabButton to="/audio/2" />)
+
+    await userEvent.pointer({ target: screen.getByRole('button'), keys: '[MouseMiddle]' })
+
+    expect(open).toHaveBeenCalledWith('/audio/2', '_blank', 'noopener,noreferrer')
+  })
+
+  it('does nothing on a plain click', async () => {
+    render(<NewTabButton to="/audio/2" />)
+
+    await userEvent.click(screen.getByRole('button'))
+
+    expect(open).not.toHaveBeenCalled()
+  })
+
+  it('does nothing without a target', async () => {
+    render(<NewTabButton to={null} />)
+
+    await userEvent.pointer({ target: screen.getByRole('button'), keys: '[MouseMiddle]' })
+
+    expect(open).not.toHaveBeenCalled()
+  })
+})

--- a/frontend/src/views/CampaignDetailView.jsx
+++ b/frontend/src/views/CampaignDetailView.jsx
@@ -30,6 +30,7 @@ import InvitePanel from '../components/campaigns/InvitePanel'
 import GuestPanel from '../components/campaigns/GuestPanel'
 import { utcTimeToLocal, USER_TZ } from '../components/campaigns/_scheduleShared'
 import useIsMobile from '../hooks/useIsMobile'
+import useLinkProps from '../hooks/useLinkProps'
 
 const CARD = {
   background: 'var(--bg-card)',
@@ -135,6 +136,10 @@ export default function CampaignDetailView() {
   const [showInvite, setShowInvite] = useState(false)
   const [showGuests, setShowGuests] = useState(false)
   const [error, setError] = useState(null)
+  // Open Notes behaves like a link, so middle click opens it in a new tab (#313).
+  const notesLinkProps = useLinkProps(`/campaigns/${campaignId}/notes`, () =>
+    navigate(`/campaigns/${campaignId}/notes`)
+  )
 
   const load = () => {
     campaigns
@@ -443,7 +448,7 @@ export default function CampaignDetailView() {
 
           <div style={{ display: 'flex', gap: 8, flexShrink: 0, flexWrap: 'wrap' }}>
             <button
-              onClick={() => navigate(`/campaigns/${campaignId}/notes`)}
+              {...notesLinkProps}
               style={{
                 display: 'flex',
                 alignItems: 'center',

--- a/frontend/src/views/LibraryView.jsx
+++ b/frontend/src/views/LibraryView.jsx
@@ -359,6 +359,7 @@ export default function LibraryView() {
                 <AgnosticChip
                   key={system.id}
                   system={system}
+                  to={`/library/system/${system.id}`}
                   onClick={() => navigate(`/library/system/${system.id}`)}
                 />
               ))}
@@ -483,6 +484,7 @@ export default function LibraryView() {
                   <SystemCard
                     key={system.id}
                     system={system}
+                    to={`/library/system/${system.id}`}
                     onClick={() => navigate(`/library/system/${system.id}`)}
                     compact={compact}
                     list={list}

--- a/frontend/src/views/SearchView.jsx
+++ b/frontend/src/views/SearchView.jsx
@@ -13,8 +13,8 @@ import {
 import api from '../api'
 import Spinner from '../components/Spinner'
 import BookGroup from '../components/search/BookGroup'
-import TagList from '../components/search/TagList'
-import { sectionHeadStyle, cardStyle, controlStyle } from '../components/search/searchStyles'
+import ResultCard from '../components/search/ResultCard'
+import { sectionHeadStyle, controlStyle } from '../components/search/searchStyles'
 
 export default function SearchView() {
   const { t } = useTranslation()
@@ -245,21 +245,14 @@ export default function SearchView() {
                   </button>
                   {!collapsed.maps &&
                     maps.map((m) => (
-                      <div
+                      <ResultCard
                         key={m.id}
-                        onClick={() => navigate(`/maps/${m.id}`)}
-                        style={cardStyle}
-                        onMouseEnter={(e) =>
-                          (e.currentTarget.style.background = 'var(--bg-card-hover)')
-                        }
-                        onMouseLeave={(e) => (e.currentTarget.style.background = 'var(--bg-card)')}
-                      >
-                        <div style={{ fontWeight: 500, fontSize: 15 }}>{m.filename}</div>
-                        <div style={{ fontSize: 13, color: 'var(--text-muted)', marginTop: 3 }}>
-                          {m.relative_path}
-                        </div>
-                        {m.tags?.length > 0 && <TagList tags={m.tags} />}
-                      </div>
+                        to={`/maps/${m.id}`}
+                        title={m.filename}
+                        subtitle={m.relative_path}
+                        tags={m.tags}
+                        onOpen={() => navigate(`/maps/${m.id}`)}
+                      />
                     ))}
                 </div>
               )}
@@ -275,21 +268,14 @@ export default function SearchView() {
                   </button>
                   {!collapsed.tokens &&
                     tokens.map((tok) => (
-                      <div
+                      <ResultCard
                         key={tok.id}
-                        onClick={() => navigate(`/tokens/${tok.id}`)}
-                        style={cardStyle}
-                        onMouseEnter={(e) =>
-                          (e.currentTarget.style.background = 'var(--bg-card-hover)')
-                        }
-                        onMouseLeave={(e) => (e.currentTarget.style.background = 'var(--bg-card)')}
-                      >
-                        <div style={{ fontWeight: 500, fontSize: 15 }}>{tok.filename}</div>
-                        <div style={{ fontSize: 13, color: 'var(--text-muted)', marginTop: 3 }}>
-                          {tok.relative_path}
-                        </div>
-                        {tok.tags?.length > 0 && <TagList tags={tok.tags} />}
-                      </div>
+                        to={`/tokens/${tok.id}`}
+                        title={tok.filename}
+                        subtitle={tok.relative_path}
+                        tags={tok.tags}
+                        onOpen={() => navigate(`/tokens/${tok.id}`)}
+                      />
                     ))}
                 </div>
               )}
@@ -305,21 +291,14 @@ export default function SearchView() {
                   </button>
                   {!collapsed.audio &&
                     audio.map((a) => (
-                      <div
+                      <ResultCard
                         key={a.id}
-                        onClick={() => navigate(`/audio/${a.id}`)}
-                        style={cardStyle}
-                        onMouseEnter={(e) =>
-                          (e.currentTarget.style.background = 'var(--bg-card-hover)')
-                        }
-                        onMouseLeave={(e) => (e.currentTarget.style.background = 'var(--bg-card)')}
-                      >
-                        <div style={{ fontWeight: 500, fontSize: 15 }}>{a.title || a.filename}</div>
-                        <div style={{ fontSize: 13, color: 'var(--text-muted)', marginTop: 3 }}>
-                          {a.relative_path}
-                        </div>
-                        {a.tags?.length > 0 && <TagList tags={a.tags} />}
-                      </div>
+                        to={`/audio/${a.id}`}
+                        title={a.title || a.filename}
+                        subtitle={a.relative_path}
+                        tags={a.tags}
+                        onOpen={() => navigate(`/audio/${a.id}`)}
+                      />
                     ))}
                 </div>
               )}

--- a/frontend/src/views/TagsView.jsx
+++ b/frontend/src/views/TagsView.jsx
@@ -16,6 +16,7 @@ import { useFavorites } from '../context/FavoritesContext'
 import { getUserPrefs, saveUserPref } from '../hooks/useUserPrefs'
 import Spinner from '../components/Spinner'
 import TagDetail from '../components/tags/TagDetail'
+import TagListButton from '../components/tags/TagListButton'
 
 const CATS_COLLAPSED_KEY = 'tagsCategoryCollapsed'
 
@@ -431,44 +432,11 @@ export default function TagsView() {
                               >
                                 <LuHeart size={13} fill={fav ? 'var(--gold)' : 'none'} />
                               </button>
-                              <button
-                                onClick={() => selectTag(tg.internal)}
-                                aria-current={tg.internal === activeTag}
-                                style={{
-                                  flex: 1,
-                                  display: 'flex',
-                                  justifyContent: 'space-between',
-                                  alignItems: 'center',
-                                  gap: 8,
-                                  padding: '7px 10px 7px 2px',
-                                  background: 'none',
-                                  border: 'none',
-                                  cursor: 'pointer',
-                                  color: 'var(--text)',
-                                  fontSize: 14,
-                                  textAlign: 'left',
-                                  minWidth: 0,
-                                }}
-                              >
-                                <span
-                                  style={{
-                                    overflow: 'hidden',
-                                    textOverflow: 'ellipsis',
-                                    whiteSpace: 'nowrap',
-                                  }}
-                                >
-                                  {tg.display}
-                                </span>
-                                <span
-                                  style={{
-                                    color: 'var(--text-muted)',
-                                    fontSize: 12,
-                                    flexShrink: 0,
-                                  }}
-                                >
-                                  {tg.count}
-                                </span>
-                              </button>
+                              <TagListButton
+                                tag={tg}
+                                active={tg.internal === activeTag}
+                                onSelect={selectTag}
+                              />
                             </div>
                           )
                         })}


### PR DESCRIPTION
## Summary

<!-- What does this PR do? A few sentences is fine. -->

## Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / cleanup
- [ ] Docs / configuration only

## Testing

<!-- How did you verify this works? Check all that apply. -->

- [x] Backend tests pass (`pytest -q`)
- [x] Frontend tests pass (`npm test`)
- [x] Tested manually in the browser

## Notes for reviewer

<!-- Anything that needs extra context, known limitations, or follow-up work. Delete if not needed. -->
