### PR TITLE
Fix: focus the embed picker page input when "at page" is clicked

### DIFF
--- a/frontend/src/components/campaigns/GrimoireEmbedPicker.jsx
+++ b/frontend/src/components/campaigns/GrimoireEmbedPicker.jsx
@@ -31,6 +31,13 @@ export default function GrimoireEmbedPicker({ campaignId, onInsert, onClose }) {
   const [pageFor, setPageFor] = useState(null) // book item awaiting a page number
   const [pageNum, setPageNum] = useState('')
   const [uploadOpen, setUploadOpen] = useState(false)
+  const pageInputRef = useRef(null)
+
+  // Clicking "at page" reveals the page input — focus it so the number can be
+  // typed right away instead of requiring a second click.
+  useEffect(() => {
+    if (pageFor !== null) pageInputRef.current?.focus()
+  }, [pageFor])
 
   useEffect(() => {
     campaigns
@@ -222,10 +229,17 @@ export default function GrimoireEmbedPicker({ campaignId, onInsert, onClose }) {
                       {awaitingPage ? (
                         <div style={{ display: 'flex', alignItems: 'center', gap: 4 }}>
                           <input
+                            ref={pageInputRef}
                             type="number"
                             min="1"
                             value={pageNum}
                             onChange={(e) => setPageNum(e.target.value)}
+                            onKeyDown={(e) => {
+                              if (e.key === 'Enter') {
+                                e.preventDefault()
+                                insert(item, pageNum || null)
+                              }
+                            }}
                             placeholder={t('wiki.pageNum')}
                             aria-label={t('wiki.pageNum')}
                             style={{

--- a/frontend/src/components/campaigns/GrimoireEmbedPicker.test.jsx
+++ b/frontend/src/components/campaigns/GrimoireEmbedPicker.test.jsx
@@ -67,6 +67,41 @@ describe('GrimoireEmbedPicker', () => {
     expect(onInsert).toHaveBeenCalledWith('[[book:b1:42]]')
   })
 
+  it('focuses the page input as soon as "at page" is clicked', async () => {
+    campaigns.listResources.mockResolvedValue([
+      { id: 'r3', resource_type: 'book', resource_id: 'b1', name: 'PHB', has_thumbnail: false },
+    ])
+    render(<GrimoireEmbedPicker campaignId="c1" onInsert={vi.fn()} onClose={vi.fn()} />)
+    await waitFor(() => screen.getByText('PHB'))
+    await userEvent.click(screen.getByRole('button', { name: /at page/i }))
+    expect(screen.getByPlaceholderText(/page/i)).toHaveFocus()
+  })
+
+  it('inserts the book embed when Enter is pressed in the page input', async () => {
+    campaigns.listResources.mockResolvedValue([
+      { id: 'r3', resource_type: 'book', resource_id: 'b1', name: 'PHB', has_thumbnail: false },
+    ])
+    const onInsert = vi.fn()
+    render(<GrimoireEmbedPicker campaignId="c1" onInsert={onInsert} onClose={vi.fn()} />)
+    await waitFor(() => screen.getByText('PHB'))
+    await userEvent.click(screen.getByRole('button', { name: /at page/i }))
+    // The input is already focused, so typing goes straight to it.
+    await userEvent.keyboard('42{Enter}')
+    expect(onInsert).toHaveBeenCalledWith('[[book:b1:42]]')
+  })
+
+  it('inserts without a page when Enter is pressed on an empty page input', async () => {
+    campaigns.listResources.mockResolvedValue([
+      { id: 'r3', resource_type: 'book', resource_id: 'b1', name: 'PHB', has_thumbnail: false },
+    ])
+    const onInsert = vi.fn()
+    render(<GrimoireEmbedPicker campaignId="c1" onInsert={onInsert} onClose={vi.fn()} />)
+    await waitFor(() => screen.getByText('PHB'))
+    await userEvent.click(screen.getByRole('button', { name: /at page/i }))
+    await userEvent.keyboard('{Enter}')
+    expect(onInsert).toHaveBeenCalledWith('[[book:b1]]')
+  })
+
   it('opens the image upload panel', async () => {
     campaigns.listResources.mockResolvedValue([])
     render(<GrimoireEmbedPicker campaignId="c1" onInsert={vi.fn()} onClose={vi.fn()} />)


### PR DESCRIPTION
## Summary

<!-- What does this PR do? A few sentences is fine. -->

## Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / cleanup
- [ ] Docs / configuration only

## Testing

<!-- How did you verify this works? Check all that apply. -->

- [x] Backend tests pass (`pytest -q`)
- [x] Frontend tests pass (`npm test`)
- [x] Tested manually in the browser

## Notes for reviewer

<!-- Anything that needs extra context, known limitations, or follow-up work. Delete if not needed. -->
