### PR TITLE
Fix: keep the selection after bulk edits and tag applies

### DIFF
--- a/frontend/src/components/BulkEditModal.jsx
+++ b/frontend/src/components/BulkEditModal.jsx
@@ -170,6 +170,40 @@ const stringToTags = (s) =>
     .filter(Boolean)
 
 /**
+ * Build the { id: changedFields } patch map for a set of drafts — every field
+ * whose draft value differs from the item's current value. Shared by the save
+ * path and the unsaved-changes check behind Cancel (issue #256).
+ */
+const diffDrafts = (items, drafts, cfg) => {
+  const changedById = {}
+  for (const it of items) {
+    const d = drafts[it.id]
+    const patch = {}
+    for (const f of cfg.fields) {
+      if (f === 'tags') {
+        const next = cfg.custom ? d.tags : stringToTags(d.tags)
+        if (tagsToString(next) !== tagsToString(it.tags)) patch.tags = next
+      } else if (STRUCTURED_FIELDS.has(f)) {
+        const next = cleanStructured(f, d[f])
+        if (JSON.stringify(next) !== JSON.stringify(it[f] || [])) patch[f] = next
+      } else if (f === 'is_explicit') {
+        if (!!d.is_explicit !== !!it.is_explicit) patch.is_explicit = !!d.is_explicit
+      } else if (f === 'cover_book_id') {
+        if ((d.cover_book_id ?? null) !== (it.cover_book_id ?? null))
+          patch.cover_book_id = d.cover_book_id ?? null
+      } else if (f === 'year' || f === 'month' || f === 'day') {
+        const next = d[f] === '' || d[f] == null ? null : Number(d[f])
+        if (next !== (it[f] ?? null)) patch[f] = next
+      } else if ((d[f] ?? '') !== (it[f] ?? '')) {
+        patch[f] = d[f]
+      }
+    }
+    if (Object.keys(patch).length) changedById[it.id] = patch
+  }
+  return changedById
+}
+
+/**
  * Edit a set of items one at a time via a carousel. Receives the selected item
  * objects and a `type` (book|map|token|audio|system). On save, persists every
  * changed item in a single bulk request and calls `onSaved` with a map of
@@ -287,6 +321,15 @@ export default function BulkEditModal({
   const [applyingAll, setApplyingAll] = useState(false)
   const metadataKind = cfg.metadataKind
 
+  // Dismissing the modal throws the drafts away, which is punishing after
+  // editing a large selection — so a dirty modal asks first (issue #256).
+  // Checked lazily on dismiss rather than tracked per keystroke.
+  const [confirmingClose, setConfirmingClose] = useState(false)
+  const requestClose = () => {
+    if (Object.keys(diffDrafts(items, drafts, cfg)).length) setConfirmingClose(true)
+    else onClose()
+  }
+
   useEffect(() => {
     if (!metadataKind) return undefined
     let active = true
@@ -319,31 +362,7 @@ export default function BulkEditModal({
     setSaving(true)
     setError(null)
     try {
-      const changedById = {}
-      for (const it of items) {
-        const d = drafts[it.id]
-        const patch = {}
-        for (const f of cfg.fields) {
-          if (f === 'tags') {
-            const next = cfg.custom ? d.tags : stringToTags(d.tags)
-            if (tagsToString(next) !== tagsToString(it.tags)) patch.tags = next
-          } else if (STRUCTURED_FIELDS.has(f)) {
-            const next = cleanStructured(f, d[f])
-            if (JSON.stringify(next) !== JSON.stringify(it[f] || [])) patch[f] = next
-          } else if (f === 'is_explicit') {
-            if (!!d.is_explicit !== !!it.is_explicit) patch.is_explicit = !!d.is_explicit
-          } else if (f === 'cover_book_id') {
-            if ((d.cover_book_id ?? null) !== (it.cover_book_id ?? null))
-              patch.cover_book_id = d.cover_book_id ?? null
-          } else if (f === 'year' || f === 'month' || f === 'day') {
-            const next = d[f] === '' || d[f] == null ? null : Number(d[f])
-            if (next !== (it[f] ?? null)) patch[f] = next
-          } else if ((d[f] ?? '') !== (it[f] ?? '')) {
-            patch[f] = d[f]
-          }
-        }
-        if (Object.keys(patch).length) changedById[it.id] = patch
-      }
+      const changedById = diffDrafts(items, drafts, cfg)
 
       const changes = Object.entries(changedById).map(([id, patch]) => ({ id, ...patch }))
       if (changes.length) {
@@ -373,14 +392,14 @@ export default function BulkEditModal({
       role="dialog"
       aria-modal="true"
       style={overlay}
-      onClick={(e) => e.target === e.currentTarget && onClose()}
+      onClick={(e) => e.target === e.currentTarget && requestClose()}
     >
       <div style={panel}>
         <div style={header}>
           <span style={{ fontSize: 15, fontWeight: 600 }}>
             {t('bulkEdit.title', { count: items.length })}
           </span>
-          <button onClick={onClose} style={closeBtn} aria-label={t('common.close')}>
+          <button onClick={requestClose} style={closeBtn} aria-label={t('common.close')}>
             <LuX size={16} />
           </button>
         </div>
@@ -488,7 +507,7 @@ export default function BulkEditModal({
               {t('bookEditor.fetchMetadata')}
             </button>
           )}
-          <button onClick={onClose} style={{ ...cancelBtn, marginLeft: 'auto' }}>
+          <button onClick={requestClose} style={{ ...cancelBtn, marginLeft: 'auto' }}>
             {t('common.cancel')}
           </button>
           <button
@@ -518,6 +537,33 @@ export default function BulkEditModal({
           onApply={handleFetched}
           onClose={() => setFetching(false)}
         />
+      )}
+
+      {confirmingClose && (
+        <div
+          role="dialog"
+          aria-modal="true"
+          aria-labelledby="bulk-discard-title"
+          style={confirmOverlay}
+          onClick={(e) => e.target === e.currentTarget && setConfirmingClose(false)}
+        >
+          <div style={confirmPanel}>
+            <div id="bulk-discard-title" style={{ fontSize: 15, fontWeight: 600, marginBottom: 8 }}>
+              {t('bulkEdit.discardTitle')}
+            </div>
+            <p style={{ fontSize: 13, color: 'var(--text-muted)', margin: '0 0 16px' }}>
+              {t('bulkEdit.discardHint')}
+            </p>
+            <div style={{ display: 'flex', gap: 8, justifyContent: 'flex-end' }}>
+              <button onClick={() => setConfirmingClose(false)} style={cancelBtn}>
+                {t('bulkEdit.keepEditing')}
+              </button>
+              <button onClick={onClose} style={dangerBtn}>
+                {t('bulkEdit.discardChanges')}
+              </button>
+            </div>
+          </div>
+        </div>
       )}
     </div>
   )
@@ -627,6 +673,36 @@ const goldBtn = {
   padding: '7px 18px',
   borderRadius: 6,
   background: 'var(--gold-dim)',
+  border: 'none',
+  color: 'var(--bg-deep)',
+  fontSize: 14,
+  fontWeight: 600,
+  cursor: 'pointer',
+}
+const confirmOverlay = {
+  position: 'fixed',
+  inset: 0,
+  // Above the bulk-edit modal itself (1200), matching ApplyToAllDialog.
+  zIndex: 1300,
+  display: 'flex',
+  alignItems: 'center',
+  justifyContent: 'center',
+  background: 'rgba(0,0,0,0.55)',
+  padding: 16,
+}
+const confirmPanel = {
+  background: 'var(--bg-panel)',
+  border: '1px solid var(--border)',
+  borderRadius: 10,
+  padding: 24,
+  width: 400,
+  maxWidth: '94vw',
+  boxSizing: 'border-box',
+}
+const dangerBtn = {
+  padding: '7px 18px',
+  borderRadius: 6,
+  background: 'var(--danger)',
   border: 'none',
   color: 'var(--bg-deep)',
   fontSize: 14,

--- a/frontend/src/components/BulkEditModal.test.jsx
+++ b/frontend/src/components/BulkEditModal.test.jsx
@@ -359,4 +359,70 @@ describe('BulkEditModal', () => {
       expect(get).not.toHaveBeenCalledWith(expect.stringContaining('metadata-sources'))
     })
   })
+
+  // Issue #256: dismissing threw the drafts away silently, which is punishing
+  // after editing a large selection, so a dirty modal confirms first.
+  describe('unsaved-changes guard', () => {
+    const dirty = () =>
+      fireEvent.change(screen.getByPlaceholderText('Comma-separated tags'), {
+        target: { value: 'old, new' },
+      })
+
+    it('closes straight away when nothing was edited', () => {
+      const onClose = vi.fn()
+      renderModal({ onClose })
+
+      fireEvent.click(screen.getByText('Cancel'))
+
+      expect(onClose).toHaveBeenCalled()
+      expect(screen.queryByText('Discard unsaved changes?')).toBeNull()
+    })
+
+    it('asks before discarding edits instead of closing', () => {
+      const onClose = vi.fn()
+      renderModal({ onClose })
+      dirty()
+
+      fireEvent.click(screen.getByText('Cancel'))
+
+      expect(onClose).not.toHaveBeenCalled()
+      expect(screen.getByText('Discard unsaved changes?')).toBeInTheDocument()
+    })
+
+    it('keeps the edits when the user backs out of the confirmation', () => {
+      const onClose = vi.fn()
+      renderModal({ onClose })
+      dirty()
+      fireEvent.click(screen.getByText('Cancel'))
+
+      fireEvent.click(screen.getByText('Keep editing'))
+
+      expect(onClose).not.toHaveBeenCalled()
+      expect(screen.queryByText('Discard unsaved changes?')).toBeNull()
+      // The draft survived the round trip through the confirmation.
+      expect(screen.getByPlaceholderText('Comma-separated tags')).toHaveValue('old, new')
+    })
+
+    it('closes once the discard is confirmed', () => {
+      const onClose = vi.fn()
+      renderModal({ onClose })
+      dirty()
+      fireEvent.click(screen.getByText('Cancel'))
+
+      fireEvent.click(screen.getByText('Discard changes'))
+
+      expect(onClose).toHaveBeenCalled()
+    })
+
+    it('guards the X button too', () => {
+      const onClose = vi.fn()
+      renderModal({ onClose })
+      dirty()
+
+      fireEvent.click(screen.getByLabelText('Close'))
+
+      expect(onClose).not.toHaveBeenCalled()
+      expect(screen.getByText('Discard unsaved changes?')).toBeInTheDocument()
+    })
+  })
 })

--- a/frontend/src/hooks/useMediaGallery.js
+++ b/frontend/src/hooks/useMediaGallery.js
@@ -134,8 +134,9 @@ export default function useMediaGallery(config) {
             : item
         ),
       }))
-
-      bulk.clear()
+      // Selection is deliberately kept so tags can be applied one at a time to
+      // the same batch, and a typo can be corrected without re-picking every
+      // item (issue #256). The bar's input clears itself instead.
     } finally {
       // Always released, so a failed apply re-enables the button instead of
       // leaving it stuck on "Applying" (issue #270).

--- a/frontend/src/hooks/useSystemLibrary.js
+++ b/frontend/src/hooks/useSystemLibrary.js
@@ -59,7 +59,8 @@ export default function useSystemLibrary(systems, setSystems) {
       // The server returns each system's resulting tag list, so local state is
       // patched from what actually landed rather than a client-side guess.
       applyEdits(Object.fromEntries(ids.map((id) => [id, { tags: tags?.[id] || [] }])))
-      bulk.clear()
+      // Selection is deliberately kept so tags can be applied one at a time to
+      // the same batch (issue #256).
     } finally {
       setApplying(false)
     }

--- a/frontend/src/hooks/useSystemLibrary.test.js
+++ b/frontend/src/hooks/useSystemLibrary.test.js
@@ -132,7 +132,9 @@ describe('useSystemLibrary', () => {
       expect(view.latest.find((s) => s.id === 's2').tags).toEqual(['scifi'])
     })
 
-    it('clears the selection after a successful apply', async () => {
+    // Issue #256: applying tags keeps the selection so the same batch can be
+    // tagged again — one tag at a time, or to correct a typo.
+    it('keeps the selection after a successful apply', async () => {
       const { result } = setup()
       act(() => result.current.bulk.toggleItem('s1'))
 
@@ -140,7 +142,8 @@ describe('useSystemLibrary', () => {
         await result.current.applyTags(['new'])
       })
 
-      expect(result.current.bulk.count).toBe(0)
+      expect(result.current.bulk.count).toBe(1)
+      expect(result.current.bulk.selectedIds.has('s1')).toBe(true)
     })
 
     it('does nothing while the systems list is still loading', async () => {

--- a/frontend/src/locales/de-DE.json
+++ b/frontend/src/locales/de-DE.json
@@ -1477,7 +1477,11 @@
     "applySelected_other": "{{count}} Felder anwenden",
     "selectAll": "Alle auswählen",
     "selectNone": "Keine auswählen",
-    "emptyValue": "leer"
+    "emptyValue": "leer",
+    "discardTitle": "Nicht gespeicherte Änderungen verwerfen?",
+    "discardHint": "Du hast nicht gespeicherte Änderungen in dieser Sammelbearbeitung. Beim Schließen gehen sie verloren.",
+    "keepEditing": "Weiter bearbeiten",
+    "discardChanges": "Änderungen verwerfen"
   },
   "guests": {
     "guests": "Gäste",

--- a/frontend/src/locales/en-CA.json
+++ b/frontend/src/locales/en-CA.json
@@ -1477,7 +1477,11 @@
     "applySelected_other": "Apply {{count}} fields",
     "selectAll": "Select all",
     "selectNone": "Select none",
-    "emptyValue": "empty"
+    "emptyValue": "empty",
+    "discardTitle": "Discard unsaved changes?",
+    "discardHint": "You have unsaved edits in this bulk edit. Closing now will lose them.",
+    "keepEditing": "Keep editing",
+    "discardChanges": "Discard changes"
   },
   "guests": {
     "guests": "Guests",

--- a/frontend/src/locales/en-US.json
+++ b/frontend/src/locales/en-US.json
@@ -1477,7 +1477,11 @@
     "applySelected_other": "Apply {{count}} fields",
     "selectAll": "Select all",
     "selectNone": "Select none",
-    "emptyValue": "empty"
+    "emptyValue": "empty",
+    "discardTitle": "Discard unsaved changes?",
+    "discardHint": "You have unsaved edits in this bulk edit. Closing now will lose them.",
+    "keepEditing": "Keep editing",
+    "discardChanges": "Discard changes"
   },
   "guests": {
     "guests": "Guests",

--- a/frontend/src/locales/es-ES.json
+++ b/frontend/src/locales/es-ES.json
@@ -1477,7 +1477,11 @@
     "applySelected_other": "Aplicar {{count}} campos",
     "selectAll": "Seleccionar todo",
     "selectNone": "No seleccionar nada",
-    "emptyValue": "vacío"
+    "emptyValue": "vacío",
+    "discardTitle": "¿Descartar los cambios sin guardar?",
+    "discardHint": "Tienes cambios sin guardar en esta edición masiva. Si cierras ahora, se perderán.",
+    "keepEditing": "Seguir editando",
+    "discardChanges": "Descartar cambios"
   },
   "guests": {
     "guests": "Invitados",

--- a/frontend/src/locales/es-MX.json
+++ b/frontend/src/locales/es-MX.json
@@ -1477,7 +1477,11 @@
     "applySelected_other": "Aplicar {{count}} campos",
     "selectAll": "Seleccionar todo",
     "selectNone": "No seleccionar nada",
-    "emptyValue": "vacío"
+    "emptyValue": "vacío",
+    "discardTitle": "¿Descartar los cambios sin guardar?",
+    "discardHint": "Tienes cambios sin guardar en esta edición masiva. Si cierras ahora, se perderán.",
+    "keepEditing": "Seguir editando",
+    "discardChanges": "Descartar cambios"
   },
   "guests": {
     "guests": "Invitados",

--- a/frontend/src/locales/fr-CA.json
+++ b/frontend/src/locales/fr-CA.json
@@ -1477,7 +1477,11 @@
     "applySelected_other": "Appliquer {{count}} champs",
     "selectAll": "Tout sélectionner",
     "selectNone": "Tout désélectionner",
-    "emptyValue": "vide"
+    "emptyValue": "vide",
+    "discardTitle": "Abandonner les modifications non enregistrées ?",
+    "discardHint": "Vous avez des modifications non enregistrées dans cette édition groupée. Les perdre en fermant ?",
+    "keepEditing": "Continuer l'édition",
+    "discardChanges": "Abandonner les modifications"
   },
   "guests": {
     "guests": "Invités",

--- a/frontend/src/locales/fr-FR.json
+++ b/frontend/src/locales/fr-FR.json
@@ -1477,7 +1477,11 @@
     "applySelected_other": "Appliquer {{count}} champs",
     "selectAll": "Tout sélectionner",
     "selectNone": "Tout désélectionner",
-    "emptyValue": "vide"
+    "emptyValue": "vide",
+    "discardTitle": "Abandonner les modifications non enregistrées ?",
+    "discardHint": "Vous avez des modifications non enregistrées dans cette édition groupée. Les perdre en fermant ?",
+    "keepEditing": "Continuer l'édition",
+    "discardChanges": "Abandonner les modifications"
   },
   "guests": {
     "guests": "Invités",

--- a/frontend/src/locales/nl-NL.json
+++ b/frontend/src/locales/nl-NL.json
@@ -1477,7 +1477,11 @@
     "applySelected_other": "{{count}} velden toepassen",
     "selectAll": "Alles selecteren",
     "selectNone": "Niets selecteren",
-    "emptyValue": "leeg"
+    "emptyValue": "leeg",
+    "discardTitle": "Niet-opgeslagen wijzigingen negeren?",
+    "discardHint": "Je hebt niet-opgeslagen bewerkingen in deze bulkbewerking. Als je nu sluit, gaan ze verloren.",
+    "keepEditing": "Verder bewerken",
+    "discardChanges": "Wijzigingen negeren"
   },
   "guests": {
     "guests": "Gasten",

--- a/frontend/src/locales/pt-BR.json
+++ b/frontend/src/locales/pt-BR.json
@@ -1477,7 +1477,11 @@
     "applySelected_other": "Aplicar {{count}} campos",
     "selectAll": "Selecionar tudo",
     "selectNone": "Não selecionar nada",
-    "emptyValue": "vazio"
+    "emptyValue": "vazio",
+    "discardTitle": "Descartar alterações não salvas?",
+    "discardHint": "Você tem edições não salvas nesta edição em massa. Fechar agora vai perdê-las.",
+    "keepEditing": "Continuar editando",
+    "discardChanges": "Descartar alterações"
   },
   "guests": {
     "guests": "Convidados",

--- a/frontend/src/locales/pt-PT.json
+++ b/frontend/src/locales/pt-PT.json
@@ -1477,7 +1477,11 @@
     "applySelected_other": "Aplicar {{count}} campos",
     "selectAll": "Selecionar tudo",
     "selectNone": "Não selecionar nada",
-    "emptyValue": "vazio"
+    "emptyValue": "vazio",
+    "discardTitle": "Descartar alterações não guardadas?",
+    "discardHint": "Tem edições não guardadas nesta edição em massa. Fechar agora irá perdê-las.",
+    "keepEditing": "Continuar a editar",
+    "discardChanges": "Descartar alterações"
   },
   "guests": {
     "guests": "Convidados",

--- a/frontend/src/views/AudioView.jsx
+++ b/frontend/src/views/AudioView.jsx
@@ -54,10 +54,7 @@ export default function AudioView() {
             .selectedObjects()
             .map((a) => ({ resource_type: 'audio', resource_id: a.id }))}
           onClose={() => setShowAddToCampaign(false)}
-          onAdded={() => {
-            setShowAddToCampaign(false)
-            gallery.bulk.exit()
-          }}
+          onAdded={() => setShowAddToCampaign(false)}
         />
       )}
 
@@ -69,7 +66,6 @@ export default function AudioView() {
           onSaved={(edited) => {
             gallery.applyEdits(edited)
             setShowBulkEdit(false)
-            gallery.bulk.exit()
           }}
         />
       )}

--- a/frontend/src/views/AudioView.modals.test.jsx
+++ b/frontend/src/views/AudioView.modals.test.jsx
@@ -73,7 +73,10 @@ describe('AudioView modals', () => {
     expect(modal).toHaveTextContent('audio:a1')
     expect(modal).toHaveTextContent('audio:a2')
     await userEvent.click(screen.getByText('x'))
-    expect(bulkExit).toHaveBeenCalled()
+    // Issue #256: the modal closes but the selection is left alone, so the same
+    // batch can be added to another campaign without re-picking it.
+    expect(screen.queryByTestId('campaign-modal')).not.toBeInTheDocument()
+    expect(bulkExit).not.toHaveBeenCalled()
   })
 
   it('opens the bulk-edit modal with type=audio and saves edits', async () => {
@@ -81,7 +84,10 @@ describe('AudioView modals', () => {
     await userEvent.click(screen.getByText('fire-bulk'))
     expect(screen.getByTestId('bulk-modal')).toHaveTextContent('audio')
     await userEvent.click(screen.getByText('save-bulk'))
-    expect(bulkExit).toHaveBeenCalled()
+    // Issue #256: saving closes the modal but keeps the selection, so a typo can
+    // be corrected without re-picking every track.
+    expect(screen.queryByTestId('bulk-modal')).not.toBeInTheDocument()
+    expect(bulkExit).not.toHaveBeenCalled()
   })
 
   // onSelectItem is removed; navigation to the track detail page is now handled

--- a/frontend/src/views/LibraryView.jsx
+++ b/frontend/src/views/LibraryView.jsx
@@ -591,7 +591,6 @@ export default function LibraryView() {
           onSaved={(edited) => {
             library.applyEdits(edited)
             setShowBulkEdit(false)
-            bulk.exit()
           }}
         />
       )}

--- a/frontend/src/views/MapsView.jsx
+++ b/frontend/src/views/MapsView.jsx
@@ -55,10 +55,7 @@ export default function MapsView() {
             .selectedObjects()
             .map((m) => ({ resource_type: 'map', resource_id: m.id }))}
           onClose={() => setShowAddToCampaign(false)}
-          onAdded={() => {
-            setShowAddToCampaign(false)
-            gallery.bulk.exit()
-          }}
+          onAdded={() => setShowAddToCampaign(false)}
         />
       )}
 
@@ -70,7 +67,6 @@ export default function MapsView() {
           onSaved={(edited) => {
             gallery.applyEdits(edited)
             setShowBulkEdit(false)
-            gallery.bulk.exit()
           }}
         />
       )}

--- a/frontend/src/views/MapsView.test.jsx
+++ b/frontend/src/views/MapsView.test.jsx
@@ -261,8 +261,9 @@ describe('MapsView', () => {
       expect(screen.getByTestId('atc-payload')).toHaveTextContent('m1')
     })
 
-    // Adding leaves bulk mode, so the Select toggle returns to its idle label.
-    it('exits bulk mode once maps are added to a campaign', async () => {
+    // Issue #256: the modal closes but bulk mode and the selection stay up, so
+    // the same batch can be sent to another campaign without re-picking it.
+    it('keeps bulk mode once maps are added to a campaign', async () => {
       setupMaps([makeMap({ id: 'm1', filename: 'cave.png', relative_path: 'maps/cave.png' })])
       renderView()
       await waitFor(() => expect(screen.getByText('cave.png')).toBeInTheDocument())
@@ -272,10 +273,11 @@ describe('MapsView', () => {
       await userEvent.click(screen.getByRole('button', { name: 'confirm atc' }))
 
       expect(screen.queryByTestId('add-to-campaign')).not.toBeInTheDocument()
-      expect(screen.getByRole('button', { name: /^select$/i })).toBeInTheDocument()
+      expect(screen.getByRole('button', { name: /^done$/i })).toBeInTheDocument()
+      expect(screen.getByText(/1 selected/i)).toBeInTheDocument()
     })
 
-    it('applies bulk edits and exits bulk mode on save', async () => {
+    it('applies bulk edits and keeps the selection on save', async () => {
       setupMaps([makeMap({ id: 'm1', filename: 'cave.png', relative_path: 'maps/cave.png' })])
       renderView()
       await waitFor(() => expect(screen.getByText('cave.png')).toBeInTheDocument())
@@ -286,6 +288,8 @@ describe('MapsView', () => {
 
       expect(screen.queryByTestId('bulk-edit')).not.toBeInTheDocument()
       await waitFor(() => expect(screen.getByText('renamed.png')).toBeInTheDocument())
+      // Issue #256: still in bulk mode with the map selected.
+      expect(screen.getByText(/1 selected/i)).toBeInTheDocument()
     })
   })
 

--- a/frontend/src/views/SystemDetailView.jsx
+++ b/frontend/src/views/SystemDetailView.jsx
@@ -305,7 +305,8 @@ export default function SystemDetailView() {
         ...s,
         books: s.books.map((b) => (tags?.[b.id] ? { ...b, tags: tags[b.id] } : b)),
       }))
-      bulk.clear()
+      // Selection is deliberately kept so tags can be applied one at a time to
+      // the same batch (issue #256).
     } finally {
       setBulkApplying(false)
     }
@@ -886,10 +887,7 @@ export default function SystemDetailView() {
         <AddToCampaignModal
           items={selectedBookObjects().map((b) => ({ resource_type: 'book', resource_id: b.id }))}
           onClose={() => setShowAddToCampaign(false)}
-          onAdded={() => {
-            setShowAddToCampaign(false)
-            bulk.exit()
-          }}
+          onAdded={() => setShowAddToCampaign(false)}
         />
       )}
 
@@ -903,7 +901,6 @@ export default function SystemDetailView() {
           onSaved={(edited) => {
             applyBookEdits(edited)
             setShowBulkEdit(false)
-            bulk.exit()
           }}
         />
       )}

--- a/frontend/src/views/SystemDetailView.test.jsx
+++ b/frontend/src/views/SystemDetailView.test.jsx
@@ -885,8 +885,10 @@ describe('SystemDetailView — header, tag filter, and bulk actions', () => {
     await waitFor(() => expect(bulk.addTags).toHaveBeenCalledTimes(1))
     expect(bulk.addTags).toHaveBeenCalledWith('book', ['b1', 'b2'], ['fresh'])
     expect(api.patch).not.toHaveBeenCalled()
-    // Selection is cleared after applying (count resets to 0).
-    await waitFor(() => expect(screen.getByTestId('bulk-count').textContent).toBe('0'))
+    // Issue #256: the selection survives applying tags, so another tag can be
+    // added to the same batch without re-picking every book.
+    await waitFor(() => expect(bulk.addTags).toHaveBeenCalledTimes(1))
+    expect(screen.getByTestId('bulk-count').textContent).toBe('2')
   })
 
   it('applies bulk edits from the bulk edit modal', async () => {
@@ -900,9 +902,11 @@ describe('SystemDetailView — header, tag filter, and bulk actions', () => {
     expect(screen.getByTestId('bulk-edit-modal')).toBeInTheDocument()
 
     fireEvent.click(screen.getByText('bulk-save'))
-    // Edits merge into the book and the bulk UI closes.
+    // Edits merge into the book and the modal closes, but issue #256 keeps the
+    // bulk bar and the selection up so a mistake can be corrected immediately.
     await waitFor(() => expect(screen.queryByTestId('bulk-edit-modal')).not.toBeInTheDocument())
-    await waitFor(() => expect(screen.queryByTestId('bulk-bar')).not.toBeInTheDocument())
+    expect(screen.getByTestId('bulk-bar')).toBeInTheDocument()
+    expect(screen.getByTestId('bulk-count').textContent).toBe('1')
   })
 })
 

--- a/frontend/src/views/TokensView.jsx
+++ b/frontend/src/views/TokensView.jsx
@@ -54,10 +54,7 @@ export default function TokensView() {
             .selectedObjects()
             .map((tok) => ({ resource_type: 'token', resource_id: tok.id }))}
           onClose={() => setShowAddToCampaign(false)}
-          onAdded={() => {
-            setShowAddToCampaign(false)
-            gallery.bulk.exit()
-          }}
+          onAdded={() => setShowAddToCampaign(false)}
         />
       )}
 
@@ -69,7 +66,6 @@ export default function TokensView() {
           onSaved={(edited) => {
             gallery.applyEdits(edited)
             setShowBulkEdit(false)
-            gallery.bulk.exit()
           }}
         />
       )}

--- a/frontend/src/views/TokensView.test.jsx
+++ b/frontend/src/views/TokensView.test.jsx
@@ -236,14 +236,16 @@ describe('TokensView', () => {
       expect(screen.queryByTestId('add-to-campaign')).not.toBeInTheDocument()
     })
 
-    // Adding leaves bulk mode, so the Select toggle returns to its idle label.
-    it('exits bulk mode once tokens are added to a campaign', async () => {
+    // Issue #256: the modal closes but bulk mode and the selection stay up, so
+    // the same batch can be sent to another campaign without re-picking it.
+    it('keeps bulk mode once tokens are added to a campaign', async () => {
       await setupOneToken()
       await userEvent.click(screen.getByRole('button', { name: /add to campaign/i }))
       await userEvent.click(screen.getByRole('button', { name: 'confirm atc' }))
 
       expect(screen.queryByTestId('add-to-campaign')).not.toBeInTheDocument()
-      expect(screen.getByRole('button', { name: /^select$/i })).toBeInTheDocument()
+      expect(screen.getByRole('button', { name: /^done$/i })).toBeInTheDocument()
+      expect(screen.getByText(/1 selected/i)).toBeInTheDocument()
     })
 
     it('opens the bulk edit modal for the token type', async () => {


### PR DESCRIPTION
## Summary

<!-- What does this PR do? A few sentences is fine. -->

## Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / cleanup
- [ ] Docs / configuration only

## Testing

<!-- How did you verify this works? Check all that apply. -->

- [x] Backend tests pass (`pytest -q`)
- [x] Frontend tests pass (`npm test`)
- [x] Tested manually in the browser

## Notes for reviewer

<!-- Anything that needs extra context, known limitations, or follow-up work. Delete if not needed. -->
