### PR TITLE
Fix: restore scroll position when returning via in-app Back buttons

### DIFF
--- a/frontend/src/hooks/useScrollRestoration.js
+++ b/frontend/src/hooks/useScrollRestoration.js
@@ -1,6 +1,12 @@
 import { useEffect, useRef } from 'react'
 import { useLocation } from 'react-router-dom'
 
+// How long to keep trying to restore before giving up. Views fetch their data
+// after mount, so the container is usually still empty (and unscrollable) on the
+// first frame; we retry until the content is tall enough to honour the saved
+// offset. Bounded so a view that legitimately got shorter doesn't retry forever.
+const RESTORE_TIMEOUT_MS = 3000
+
 /**
  * Saves and restores the scroll position of a container element as the user
  * navigates between routes.
@@ -12,8 +18,11 @@ import { useLocation } from 'react-router-dom'
  * Positions are stored in sessionStorage (keyed by pathname) so they survive
  * in-session navigation but reset on a full page reload.
  *
- * Restoration is deferred one frame to let the incoming view finish its initial
- * render before scrollTop is applied.
+ * Restoration retries across animation frames until the incoming view has
+ * rendered enough content to reach the saved offset (issue #257): applying
+ * scrollTop while the view is still showing its loading spinner would clamp to
+ * 0 and silently lose the position. Any scroll the user performs themselves
+ * ends the retry loop, so restoration never fights a deliberate scroll.
  */
 export default function useScrollRestoration() {
   const ref = useRef(null)
@@ -27,30 +36,59 @@ export default function useScrollRestoration() {
 
     const leavingPath = prevPathname.current
 
-    const save = () => {
+    // Save the departing path's position before updating the ref.
+    if (leavingPath !== pathname) {
       try {
         sessionStorage.setItem(`grimoire:scroll:${leavingPath}`, String(el.scrollTop))
       } catch {}
     }
 
-    // Save the departing path's position before updating the ref.
-    if (leavingPath !== pathname) {
-      save()
-    }
-
     prevPathname.current = pathname
 
-    // Restore position for the new pathname after the view renders.
-    const frame = requestAnimationFrame(() => {
-      try {
-        const saved = sessionStorage.getItem(`grimoire:scroll:${pathname}`)
-        if (saved !== null && el) {
-          el.scrollTop = Number(saved)
-        }
-      } catch {}
+    let target = null
+    try {
+      const saved = sessionStorage.getItem(`grimoire:scroll:${pathname}`)
+      if (saved !== null) target = Number(saved)
+    } catch {}
+
+    if (target === null || !Number.isFinite(target) || target <= 0) return
+
+    let frame = 0
+    let done = false
+    const deadline = Date.now() + RESTORE_TIMEOUT_MS
+
+    // A scroll the user initiated means they've taken over — stop restoring.
+    const onUserScroll = () => {
+      done = true
+    }
+
+    const attempt = () => {
+      if (done) return
+      // Applying the target is only meaningful once the content can reach it.
+      // scrollTop silently clamps, so compare against what the element accepted.
+      el.scrollTop = target
+      if (el.scrollTop >= target || Date.now() > deadline) {
+        done = true
+        return
+      }
+      frame = requestAnimationFrame(attempt)
+    }
+
+    // Let the incoming view render before the first attempt, and only listen for
+    // user scrolls from that point — the restoring writes above fire scroll
+    // events of their own, which must not be mistaken for a user gesture.
+    frame = requestAnimationFrame(() => {
+      el.addEventListener('wheel', onUserScroll, { passive: true })
+      el.addEventListener('touchmove', onUserScroll, { passive: true })
+      attempt()
     })
 
-    return () => cancelAnimationFrame(frame)
+    return () => {
+      done = true
+      cancelAnimationFrame(frame)
+      el.removeEventListener('wheel', onUserScroll)
+      el.removeEventListener('touchmove', onUserScroll)
+    }
   }, [pathname])
 
   // Also save on unmount / page unload so the last position isn't lost.

--- a/frontend/src/hooks/useScrollRestoration.test.jsx
+++ b/frontend/src/hooks/useScrollRestoration.test.jsx
@@ -114,4 +114,160 @@ describe('useScrollRestoration', () => {
     // No saved state — scrollTop stays at its default (0 in jsdom).
     expect(divEl?.scrollTop ?? 0).toBe(0)
   })
+
+  // jsdom has no layout, so scrollTop accepts any value. These tests install a
+  // clamping accessor that mimics a real element: writes above the current
+  // content height are pinned, exactly the situation that made restoration fail
+  // while a view was still loading its data (issue #257).
+  function makeClamped(el, initialMaxScroll) {
+    let value = 0
+    let maxScroll = initialMaxScroll
+    Object.defineProperty(el, 'scrollTop', {
+      configurable: true,
+      get: () => value,
+      set: (v) => {
+        value = Math.min(v, maxScroll)
+      },
+    })
+    return {
+      // Simulates the view's data arriving and the content growing taller.
+      grow: (next) => {
+        maxScroll = next
+      },
+    }
+  }
+
+  it('retries across frames until the content is tall enough to reach the saved offset', () => {
+    sessionStorage.setItem('grimoire:scroll:/library', '400')
+
+    // Drive rAF manually so we control when each restore attempt runs.
+    const callbacks = []
+    vi.stubGlobal('requestAnimationFrame', (cb) => callbacks.push(cb))
+
+    let divEl = null
+    let content = null
+    render(
+      <MemoryRouter initialEntries={['/library']}>
+        <ScrollComponent
+          onRef={(el) => {
+            if (el && !content) content = makeClamped(el, 0)
+            divEl = el
+          }}
+        />
+      </MemoryRouter>
+    )
+
+    const flush = () => {
+      const pending = callbacks.splice(0, callbacks.length)
+      act(() => pending.forEach((cb) => cb()))
+    }
+
+    // First frame: the view is still empty, so the write clamps to 0.
+    flush()
+    expect(divEl.scrollTop).toBe(0)
+
+    // Still loading — the hook keeps a retry queued rather than giving up.
+    flush()
+    expect(divEl.scrollTop).toBe(0)
+    expect(callbacks.length).toBeGreaterThan(0)
+
+    // Data arrives and the grid renders: the next retry lands the position.
+    content.grow(1000)
+    flush()
+    expect(divEl.scrollTop).toBe(400)
+
+    // Target reached, so the loop stops queueing further frames.
+    expect(callbacks).toHaveLength(0)
+  })
+
+  it('stops retrying once the user scrolls the container themselves', () => {
+    sessionStorage.setItem('grimoire:scroll:/library', '400')
+
+    const callbacks = []
+    vi.stubGlobal('requestAnimationFrame', (cb) => callbacks.push(cb))
+
+    let divEl = null
+    let content = null
+    render(
+      <MemoryRouter initialEntries={['/library']}>
+        <ScrollComponent
+          onRef={(el) => {
+            if (el && !content) content = makeClamped(el, 0)
+            divEl = el
+          }}
+        />
+      </MemoryRouter>
+    )
+
+    const flush = () => {
+      const pending = callbacks.splice(0, callbacks.length)
+      act(() => pending.forEach((cb) => cb()))
+    }
+
+    flush()
+    expect(divEl.scrollTop).toBe(0)
+
+    // The user scrolls while the view is still loading — they've taken over.
+    act(() => {
+      divEl.dispatchEvent(new Event('wheel'))
+    })
+
+    // Even once the content grows, the saved offset is no longer forced on them.
+    content.grow(1000)
+    flush()
+    expect(divEl.scrollTop).toBe(0)
+    expect(callbacks).toHaveLength(0)
+  })
+
+  it('gives up after the timeout when the view never grows tall enough', () => {
+    sessionStorage.setItem('grimoire:scroll:/library', '400')
+
+    const callbacks = []
+    vi.stubGlobal('requestAnimationFrame', (cb) => callbacks.push(cb))
+    const nowSpy = vi.spyOn(Date, 'now')
+    nowSpy.mockReturnValue(0)
+
+    let content = null
+    render(
+      <MemoryRouter initialEntries={['/library']}>
+        <ScrollComponent
+          onRef={(el) => {
+            if (el && !content) content = makeClamped(el, 0)
+          }}
+        />
+      </MemoryRouter>
+    )
+
+    const flush = () => {
+      const pending = callbacks.splice(0, callbacks.length)
+      act(() => pending.forEach((cb) => cb()))
+    }
+
+    flush()
+    expect(callbacks.length).toBeGreaterThan(0)
+
+    // Past the retry window with the content still short: the loop ends instead
+    // of spinning forever on a view that simply got shorter.
+    nowSpy.mockReturnValue(10_000)
+    flush()
+    expect(callbacks).toHaveLength(0)
+
+    nowSpy.mockRestore()
+  })
+
+  it('does not attempt restoration for a saved position of zero', () => {
+    sessionStorage.setItem('grimoire:scroll:/library', '0')
+
+    const callbacks = []
+    vi.stubGlobal('requestAnimationFrame', (cb) => callbacks.push(cb))
+
+    render(
+      <MemoryRouter initialEntries={['/library']}>
+        <ScrollComponent />
+      </MemoryRouter>
+    )
+
+    // Nothing to restore — no retry loop is started at all.
+    expect(callbacks).toHaveLength(0)
+  })
 })


### PR DESCRIPTION
## Summary

<!-- What does this PR do? A few sentences is fine. -->

## Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / cleanup
- [ ] Docs / configuration only

## Testing

<!-- How did you verify this works? Check all that apply. -->

- [ ] Backend tests pass (`pytest -q`)
- [x] Frontend tests pass (`npm test`)
- [x] Tested manually in the browser

## Notes for reviewer

<!-- Anything that needs extra context, known limitations, or follow-up work. Delete if not needed. -->
