### PR TITLE
Feat: group embed picker content by category with a category toggle

### DIFF
--- a/frontend/src/components/campaigns/GrimoireEmbedPicker.jsx
+++ b/frontend/src/components/campaigns/GrimoireEmbedPicker.jsx
@@ -15,7 +15,9 @@ import {
 import { campaigns, mediaUrl } from '../../api'
 import Spinner from '../Spinner'
 import ImageUploadPanel from './ImageUploadPanel'
+import SegmentControl from './SegmentControl'
 import { miniBtn, miniBtnGhost } from './embedPickerStyles'
+import { buildEmbedGroups } from './embedPickerGroups'
 import LazyImg from '../LazyImg'
 
 const TYPE_ICON = { book: LuBookOpen, map: LuMap, token: LuUser, audio: LuMusic, file: LuFile }
@@ -24,10 +26,12 @@ const TYPE_ICON = { book: LuBookOpen, map: LuMap, token: LuUser, audio: LuMusic,
 // [[...]] embed token to insert into a wiki note. Only resources already linked
 // to this campaign are listed — to embed new library content, link it first in
 // the Resources panel.
-export default function GrimoireEmbedPicker({ campaignId, onInsert, onClose }) {
+export default function GrimoireEmbedPicker({ campaignId, groupOrder, onInsert, onClose }) {
   const { t } = useTranslation()
   const [query, setQuery] = useState('')
   const [resources, setResources] = useState(null)
+  const [categories, setCategories] = useState([])
+  const [activeGroup, setActiveGroup] = useState(null) // null until groups load
   const [pageFor, setPageFor] = useState(null) // book item awaiting a page number
   const [pageNum, setPageNum] = useState('')
   const [uploadOpen, setUploadOpen] = useState(false)
@@ -44,6 +48,12 @@ export default function GrimoireEmbedPicker({ campaignId, onInsert, onClose }) {
       .listResources(campaignId)
       .then((list) => setResources(list || []))
       .catch(() => setResources([]))
+    // Categories only affect how rows are grouped, so a failure here degrades
+    // to the built-in type tabs rather than blocking the picker.
+    campaigns
+      .listCategories(campaignId, 'resource')
+      .then((list) => setCategories(list || []))
+      .catch(() => setCategories([]))
   }, [campaignId])
 
   // The embed token for a resource. Images use the `image:` prefix so they render
@@ -66,9 +76,31 @@ export default function GrimoireEmbedPicker({ campaignId, onInsert, onClose }) {
     onInsert(`[[image:${created.resource_id}]]`)
   }
 
-  const filtered = (resources || []).filter((r) =>
-    (r.name || '').toLowerCase().includes(query.trim().toLowerCase())
+  const TYPE_LABELS = {
+    book: t('resources.books'),
+    map: t('resources.maps'),
+    token: t('resources.tokens'),
+    audio: t('resources.audio'),
+    file: t('resources.files'),
+  }
+
+  const search = query.trim().toLowerCase()
+  const matchesQuery = (r) => (r.name || '').toLowerCase().includes(search)
+
+  const groups = buildEmbedGroups(
+    resources || [],
+    categories,
+    groupOrder,
+    (type) => TYPE_LABELS[type] || type
   )
+
+  // The first group is shown by default, and a tab that disappears (its last
+  // match filtered away) falls back to the first one that's still there.
+  const current = groups.find((g) => g.key === activeGroup) || groups[0]
+
+  // Searching spans every category — scoping it to the open tab would hide
+  // matches behind tabs the user can't see, which reads as "no results".
+  const filtered = search ? (resources || []).filter(matchesQuery) : current ? current.items : []
 
   return (
     <div
@@ -162,6 +194,24 @@ export default function GrimoireEmbedPicker({ campaignId, onInsert, onClose }) {
                 <LuImage size={14} /> {t('wiki.uploadImage')}
               </button>
             </div>
+
+            {/* While searching, results span every category, so the tabs
+                would no longer describe what's listed below. */}
+            {!search && groups.length > 1 && (
+              <div style={{ marginBottom: 12 }}>
+                <SegmentControl
+                  value={current?.key}
+                  options={groups.map((g) => ({
+                    key: g.key,
+                    label: `${g.label} (${g.items.length})`,
+                  }))}
+                  onChange={setActiveGroup}
+                  equalWidth={false}
+                  asTabs
+                  label={t('wiki.embedCategoryTabs')}
+                />
+              </div>
+            )}
 
             <div style={{ overflowY: 'auto', flex: 1 }}>
               {resources === null ? (

--- a/frontend/src/components/campaigns/GrimoireEmbedPicker.test.jsx
+++ b/frontend/src/components/campaigns/GrimoireEmbedPicker.test.jsx
@@ -5,12 +5,19 @@ import GrimoireEmbedPicker from './GrimoireEmbedPicker'
 import { campaigns } from '../../api'
 
 vi.mock('../../api', () => ({
-  campaigns: { listResources: vi.fn(), fileUrl: (cid, id) => `http://localhost/c/${cid}/f/${id}` },
+  campaigns: {
+    listResources: vi.fn(),
+    listCategories: vi.fn(),
+    fileUrl: (cid, id) => `http://localhost/c/${cid}/f/${id}`,
+  },
   mediaUrl: (p) => `http://localhost${p}`,
 }))
 vi.mock('./ImageUploadPanel', () => ({ default: () => <div>upload-panel</div> }))
 
-beforeEach(() => vi.clearAllMocks())
+beforeEach(() => {
+  vi.clearAllMocks()
+  campaigns.listCategories.mockResolvedValue([])
+})
 
 const resources = [
   { id: 'r1', resource_type: 'audio', resource_id: 'a1', name: 'Tavern', has_thumbnail: true },
@@ -19,32 +26,79 @@ const resources = [
 ]
 
 describe('GrimoireEmbedPicker', () => {
-  it('lists linked resources', async () => {
+  it('shows the first category by default and hides the others', async () => {
     campaigns.listResources.mockResolvedValue(resources)
     render(<GrimoireEmbedPicker campaignId="c1" onInsert={vi.fn()} onClose={vi.fn()} />)
-    await waitFor(() => expect(screen.getByText('Tavern')).toBeInTheDocument())
+    // Books lead the built-in type order, so the book is the only row visible.
+    await waitFor(() => expect(screen.getByText('PHB')).toBeInTheDocument())
+    expect(screen.queryByText('Cave')).not.toBeInTheDocument()
+    expect(screen.queryByText('Tavern')).not.toBeInTheDocument()
+  })
+
+  it('switches the listed resources when another category tab is picked', async () => {
+    campaigns.listResources.mockResolvedValue(resources)
+    render(<GrimoireEmbedPicker campaignId="c1" onInsert={vi.fn()} onClose={vi.fn()} />)
+    await waitFor(() => screen.getByText('PHB'))
+    await userEvent.click(screen.getByRole('tab', { name: /maps/i }))
     expect(screen.getByText('Cave')).toBeInTheDocument()
-    expect(screen.getByText('PHB')).toBeInTheDocument()
+    expect(screen.queryByText('PHB')).not.toBeInTheDocument()
+  })
+
+  it('labels each category tab with its item count', async () => {
+    campaigns.listResources.mockResolvedValue(resources)
+    render(<GrimoireEmbedPicker campaignId="c1" onInsert={vi.fn()} onClose={vi.fn()} />)
+    await waitFor(() => screen.getByText('PHB'))
+    expect(screen.getByRole('tab', { name: /books \(1\)/i })).toBeInTheDocument()
+  })
+
+  it('groups by the campaign’s custom resource categories', async () => {
+    campaigns.listResources.mockResolvedValue([
+      { id: 'r1', resource_type: 'map', resource_id: 'm1', name: 'Cave', category_id: 'c9' },
+      { id: 'r2', resource_type: 'book', resource_id: 'b1', name: 'PHB' },
+    ])
+    campaigns.listCategories.mockResolvedValue([{ id: 'c9', name: 'Handouts', sort_order: 1 }])
+    render(<GrimoireEmbedPicker campaignId="c1" onInsert={vi.fn()} onClose={vi.fn()} />)
+    // Custom categories lead, so the Handouts map shows before the book group.
+    await waitFor(() => expect(screen.getByText('Cave')).toBeInTheDocument())
+    expect(screen.getByRole('tab', { name: /handouts/i })).toBeInTheDocument()
+    expect(screen.queryByText('PHB')).not.toBeInTheDocument()
+  })
+
+  it('still lists resources when the categories request fails', async () => {
+    campaigns.listResources.mockResolvedValue(resources)
+    campaigns.listCategories.mockRejectedValue(new Error('nope'))
+    render(<GrimoireEmbedPicker campaignId="c1" onInsert={vi.fn()} onClose={vi.fn()} />)
+    await waitFor(() => expect(screen.getByText('PHB')).toBeInTheDocument())
   })
 
   it('inserts an [[audio:ID]] token when an audio resource is picked', async () => {
     campaigns.listResources.mockResolvedValue(resources)
     const onInsert = vi.fn()
     render(<GrimoireEmbedPicker campaignId="c1" onInsert={onInsert} onClose={vi.fn()} />)
-    await waitFor(() => screen.getByText('Tavern'))
-    // Resources render in order, so the first Insert button is the audio row's.
-    const insertButtons = screen.getAllByRole('button', { name: /insert/i })
-    await userEvent.click(insertButtons[0])
+    await waitFor(() => screen.getByText('PHB'))
+    await userEvent.click(screen.getByRole('tab', { name: /audio/i }))
+    await userEvent.click(screen.getByRole('button', { name: /insert/i }))
     expect(onInsert).toHaveBeenCalledWith('[[audio:a1]]')
   })
 
-  it('filters resources by the search query', async () => {
+  it('searches across every category, not just the open tab', async () => {
     campaigns.listResources.mockResolvedValue(resources)
     render(<GrimoireEmbedPicker campaignId="c1" onInsert={vi.fn()} onClose={vi.fn()} />)
-    await waitFor(() => screen.getByText('Tavern'))
+    await waitFor(() => screen.getByText('PHB'))
+    // "Cave" is a map, behind another tab — searching must still surface it.
     await userEvent.type(screen.getByPlaceholderText(/search/i), 'cave')
-    expect(screen.queryByText('Tavern')).not.toBeInTheDocument()
     expect(screen.getByText('Cave')).toBeInTheDocument()
+    expect(screen.queryByText('PHB')).not.toBeInTheDocument()
+    expect(screen.queryByText('Tavern')).not.toBeInTheDocument()
+  })
+
+  it('hides the category tabs while a search is active', async () => {
+    campaigns.listResources.mockResolvedValue(resources)
+    render(<GrimoireEmbedPicker campaignId="c1" onInsert={vi.fn()} onClose={vi.fn()} />)
+    await waitFor(() => screen.getByText('PHB'))
+    expect(screen.getAllByRole('tab').length).toBeGreaterThan(1)
+    await userEvent.type(screen.getByPlaceholderText(/search/i), 'cave')
+    expect(screen.queryByRole('tab')).not.toBeInTheDocument()
   })
 
   it('shows an empty state when no resources are linked', async () => {

--- a/frontend/src/components/campaigns/PageEditor.jsx
+++ b/frontend/src/components/campaigns/PageEditor.jsx
@@ -595,6 +595,7 @@ export default function PageEditor({
       {showEmbedPicker && (
         <GrimoireEmbedPicker
           campaignId={campaign.id}
+          groupOrder={campaign.resource_group_order}
           onInsert={(token) => {
             insertAtCursor(token)
             setShowEmbedPicker(false)

--- a/frontend/src/components/campaigns/ScheduleEditor.test.jsx
+++ b/frontend/src/components/campaigns/ScheduleEditor.test.jsx
@@ -46,6 +46,27 @@ describe('SegmentControl', () => {
     fireEvent.click(screen.getByText('B'))
     expect(onChange).toHaveBeenCalledWith('b')
   })
+
+  it('stays plain buttons unless asTabs is set', () => {
+    const options = [
+      { key: 'a', label: 'A' },
+      { key: 'b', label: 'B' },
+    ]
+    render(<SegmentControl value="a" options={options} onChange={vi.fn()} />)
+    expect(screen.queryByRole('tab')).toBeNull()
+    expect(screen.queryByRole('tablist')).toBeNull()
+  })
+
+  it('exposes tab semantics when asTabs is set', () => {
+    const options = [
+      { key: 'a', label: 'A' },
+      { key: 'b', label: 'B' },
+    ]
+    render(<SegmentControl value="a" options={options} onChange={vi.fn()} asTabs label="Groups" />)
+    expect(screen.getByRole('tablist', { name: 'Groups' })).toBeTruthy()
+    expect(screen.getByRole('tab', { name: 'A' }).getAttribute('aria-selected')).toBe('true')
+    expect(screen.getByRole('tab', { name: 'B' }).getAttribute('aria-selected')).toBe('false')
+  })
 })
 
 describe('ScheduleEditor', () => {

--- a/frontend/src/components/campaigns/SegmentControl.jsx
+++ b/frontend/src/components/campaigns/SegmentControl.jsx
@@ -1,22 +1,46 @@
-/** Segmented button group (single-select) used in the schedule editor. */
-export default function SegmentControl({ value, options, onChange }) {
+/**
+ * Segmented button group (single-select) used in the schedule editor and the
+ * embed picker's category tabs.
+ *
+ * Options share the width evenly by default. Pass `equalWidth={false}` when the
+ * option count is open-ended (campaign categories, say) — segments then size to
+ * their label and the strip scrolls sideways instead of crushing them.
+ *
+ * `asTabs` adds tab semantics. It's opt-in because the control is also used for
+ * plain single-select choices (a schedule's frequency) that switch a value
+ * rather than a panel, where announcing "tab" would mislead.
+ */
+export default function SegmentControl({
+  value,
+  options,
+  onChange,
+  equalWidth = true,
+  asTabs = false,
+  label,
+}) {
   return (
     <div
+      role={asTabs ? 'tablist' : undefined}
+      aria-label={asTabs ? label : undefined}
       style={{
         display: 'flex',
         background: 'var(--bg-deep)',
         borderRadius: 10,
         padding: 4,
         gap: 2,
+        ...(equalWidth ? null : { overflowX: 'auto', scrollbarWidth: 'thin' }),
       }}
     >
       {options.map((o) => (
         <button
           key={o.key}
+          role={asTabs ? 'tab' : undefined}
+          aria-selected={asTabs ? value === o.key : undefined}
           onClick={() => onChange(o.key)}
           style={{
-            flex: 1,
-            padding: '7px 4px',
+            flex: equalWidth ? 1 : '0 0 auto',
+            whiteSpace: 'nowrap',
+            padding: equalWidth ? '7px 4px' : '7px 12px',
             borderRadius: 7,
             cursor: 'pointer',
             fontSize: 13,

--- a/frontend/src/components/campaigns/embedPickerGroups.js
+++ b/frontend/src/components/campaigns/embedPickerGroups.js
@@ -1,0 +1,57 @@
+// Groups embeddable campaign resources for the embed picker's category tabs.
+//
+// The grouping deliberately mirrors ResourcesPanel: the GM's custom resource
+// categories come first (in their saved sort order), then the built-in type
+// groups hold whatever is left over, and the campaign's saved
+// `resource_group_order` reorders the whole set. A GM who has arranged their
+// Resources panel sees the same tabs, in the same order, when embedding.
+
+import { TYPE_ICONS } from './resourcesShared'
+
+/**
+ * Build the tab groups for a resource list.
+ *
+ * @param {Array} resources   linked campaign resources
+ * @param {Array} categories  the campaign's `resource`-kind categories
+ * @param {Array} groupOrder  saved group keys, e.g. ['cat:abc', 'type:book']
+ * @param {(type: string) => string} typeLabel  localized label for a type group
+ * @returns {Array} `{ key, label, items }`, empty groups dropped
+ */
+export function buildEmbedGroups(resources, categories, groupOrder, typeLabel) {
+  const items = resources || []
+  const cats = categories || []
+  const catById = new Map(cats.map((c) => [c.id, c]))
+
+  const groups = [...cats]
+    .sort((a, b) => a.sort_order - b.sort_order)
+    .map((cat) => ({
+      key: `cat:${cat.id}`,
+      label: cat.name,
+      items: items.filter((r) => r.category_id === cat.id),
+    }))
+
+  // A resource whose category was deleted falls back to its type group, so
+  // nothing can drop out of the picker entirely.
+  for (const type of Object.keys(TYPE_ICONS)) {
+    groups.push({
+      key: `type:${type}`,
+      label: typeLabel(type),
+      items: items.filter(
+        (r) => r.resource_type === type && (!r.category_id || !catById.has(r.category_id))
+      ),
+    })
+  }
+
+  // Groups the GM has explicitly ordered lead, in that order; the rest keep
+  // their default relative order behind them.
+  const order = groupOrder || []
+  const orderIndex = (key) => {
+    const i = order.indexOf(key)
+    return i === -1 ? order.length + groups.findIndex((g) => g.key === key) : i
+  }
+  groups.sort((a, b) => orderIndex(a.key) - orderIndex(b.key))
+
+  // Unlike the Resources panel, empty groups are dropped — a tab you can select
+  // only to find nothing behind it is noise when you're picking something.
+  return groups.filter((g) => g.items.length > 0)
+}

--- a/frontend/src/components/campaigns/embedPickerGroups.test.js
+++ b/frontend/src/components/campaigns/embedPickerGroups.test.js
@@ -1,0 +1,60 @@
+import { describe, it, expect } from 'vitest'
+import { buildEmbedGroups } from './embedPickerGroups'
+
+const label = (type) => type.toUpperCase()
+
+const res = (id, type, categoryId) => ({
+  id,
+  resource_type: type,
+  resource_id: id,
+  name: id,
+  category_id: categoryId,
+})
+
+describe('buildEmbedGroups', () => {
+  it('groups by type when the campaign has no categories', () => {
+    const groups = buildEmbedGroups([res('b1', 'book'), res('m1', 'map')], [], [], label)
+    expect(groups.map((g) => g.key)).toEqual(['type:book', 'type:map'])
+    expect(groups[0].items).toHaveLength(1)
+  })
+
+  it('drops groups with no items', () => {
+    const groups = buildEmbedGroups([res('b1', 'book')], [], [], label)
+    expect(groups.map((g) => g.key)).toEqual(['type:book'])
+  })
+
+  it('puts custom categories first, in sort order', () => {
+    const cats = [
+      { id: 'c2', name: 'Lore', sort_order: 2 },
+      { id: 'c1', name: 'Handouts', sort_order: 1 },
+    ]
+    const groups = buildEmbedGroups(
+      [res('b1', 'book', 'c2'), res('m1', 'map', 'c1'), res('t1', 'token')],
+      cats,
+      [],
+      label
+    )
+    expect(groups.map((g) => g.label)).toEqual(['Handouts', 'Lore', 'TOKEN'])
+  })
+
+  it('honours the saved group order', () => {
+    const cats = [{ id: 'c1', name: 'Handouts', sort_order: 1 }]
+    const groups = buildEmbedGroups(
+      [res('b1', 'book'), res('m1', 'map', 'c1')],
+      cats,
+      ['type:book', 'cat:c1'],
+      label
+    )
+    expect(groups.map((g) => g.key)).toEqual(['type:book', 'cat:c1'])
+  })
+
+  it('falls back to the type group when a category no longer exists', () => {
+    const groups = buildEmbedGroups([res('b1', 'book', 'gone')], [], [], label)
+    expect(groups.map((g) => g.key)).toEqual(['type:book'])
+    expect(groups[0].items[0].id).toBe('b1')
+  })
+
+  it('tolerates null resources, categories and order', () => {
+    expect(buildEmbedGroups(null, null, null, label)).toEqual([])
+  })
+})

--- a/frontend/src/locales/de-DE.json
+++ b/frontend/src/locales/de-DE.json
@@ -1317,6 +1317,7 @@
     "secretHint": "Nur GM — vor Spielern verborgen",
     "embedPickerTitle": "Grimoire-Inhalt einbetten",
     "embedSearchPlaceholder": "Bücher, Karten und Tokens durchsuchen…",
+    "embedCategoryTabs": "Inhaltskategorien",
     "insert": "Einfügen",
     "withPage": "Bei Seite…",
     "pageNum": "Seite",

--- a/frontend/src/locales/en-CA.json
+++ b/frontend/src/locales/en-CA.json
@@ -1317,6 +1317,7 @@
     "secretHint": "GM only — hidden from players",
     "embedPickerTitle": "Embed Grimoire content",
     "embedSearchPlaceholder": "Search books, maps, and tokens…",
+    "embedCategoryTabs": "Content categories",
     "insert": "Insert",
     "withPage": "At page…",
     "pageNum": "Page",

--- a/frontend/src/locales/en-US.json
+++ b/frontend/src/locales/en-US.json
@@ -1317,6 +1317,7 @@
     "secretHint": "GM only — hidden from players",
     "embedPickerTitle": "Embed Grimoire content",
     "embedSearchPlaceholder": "Search books, maps, and tokens…",
+    "embedCategoryTabs": "Content categories",
     "insert": "Insert",
     "withPage": "At page…",
     "pageNum": "Page",

--- a/frontend/src/locales/es-ES.json
+++ b/frontend/src/locales/es-ES.json
@@ -1317,6 +1317,7 @@
     "secretHint": "Solo DJ: oculto para los jugadores",
     "embedPickerTitle": "Incrustar contenido de Grimoire",
     "embedSearchPlaceholder": "Buscar libros, mapas y fichas…",
+    "embedCategoryTabs": "Categorías de contenido",
     "insert": "Insertar",
     "withPage": "En la página…",
     "pageNum": "Página",

--- a/frontend/src/locales/es-MX.json
+++ b/frontend/src/locales/es-MX.json
@@ -1317,6 +1317,7 @@
     "secretHint": "Solo DJ: oculto para los jugadores",
     "embedPickerTitle": "Incrustar contenido de Grimoire",
     "embedSearchPlaceholder": "Buscar libros, mapas y fichas…",
+    "embedCategoryTabs": "Categorías de contenido",
     "insert": "Insertar",
     "withPage": "En la página…",
     "pageNum": "Página",

--- a/frontend/src/locales/fr-CA.json
+++ b/frontend/src/locales/fr-CA.json
@@ -1317,6 +1317,7 @@
     "secretHint": "MJ seulement — masqué pour les joueurs",
     "embedPickerTitle": "Intégrer du contenu Grimoire",
     "embedSearchPlaceholder": "Rechercher livres, cartes et jetons…",
+    "embedCategoryTabs": "Catégories de contenu",
     "insert": "Insérer",
     "withPage": "À la page…",
     "pageNum": "Page",

--- a/frontend/src/locales/fr-FR.json
+++ b/frontend/src/locales/fr-FR.json
@@ -1317,6 +1317,7 @@
     "secretHint": "MJ seulement — masqué pour les joueurs",
     "embedPickerTitle": "Intégrer du contenu Grimoire",
     "embedSearchPlaceholder": "Rechercher livres, cartes et jetons…",
+    "embedCategoryTabs": "Catégories de contenu",
     "insert": "Insérer",
     "withPage": "À la page…",
     "pageNum": "Page",

--- a/frontend/src/locales/nl-NL.json
+++ b/frontend/src/locales/nl-NL.json
@@ -1317,6 +1317,7 @@
     "secretHint": "Alleen GM — verborgen voor spelers",
     "embedPickerTitle": "Grimoire-inhoud insluiten",
     "embedSearchPlaceholder": "Zoek boeken, kaarten en tokens…",
+    "embedCategoryTabs": "Inhoudscategorieën",
     "insert": "Invoegen",
     "withPage": "Bij pagina…",
     "pageNum": "Pagina",

--- a/frontend/src/locales/pt-BR.json
+++ b/frontend/src/locales/pt-BR.json
@@ -1317,6 +1317,7 @@
     "secretHint": "Apenas GM — oculto dos jogadores",
     "embedPickerTitle": "Incorporar conteúdo do Grimoire",
     "embedSearchPlaceholder": "Buscar livros, mapas e tokens…",
+    "embedCategoryTabs": "Categorias de conteúdo",
     "insert": "Inserir",
     "withPage": "Na página…",
     "pageNum": "Página",

--- a/frontend/src/locales/pt-PT.json
+++ b/frontend/src/locales/pt-PT.json
@@ -1317,6 +1317,7 @@
     "secretHint": "Apenas GM — oculto dos jogadores",
     "embedPickerTitle": "Incorporar conteúdo do Grimoire",
     "embedSearchPlaceholder": "Pesquisar livros, mapas e tokens…",
+    "embedCategoryTabs": "Categorias de conteúdo",
     "insert": "Inserir",
     "withPage": "Na página…",
     "pageNum": "Página",


### PR DESCRIPTION
## Summary

<!-- What does this PR do? A few sentences is fine. -->

## Type of change

- [ ] Bug fix
- [x] New feature
- [ ] Refactor / cleanup
- [ ] Docs / configuration only

## Testing

<!-- How did you verify this works? Check all that apply. -->

- [x] Backend tests pass (`pytest -q`)
- [x] Frontend tests pass (`npm test`)
- [x] Tested manually in the browser

## Notes for reviewer

<!-- Anything that needs extra context, known limitations, or follow-up work. Delete if not needed. -->
