### PR TITLE
Fix: stop bulk-edit metadata refetching and cover-picker layout shift

### DIFF
--- a/frontend/src/components/BulkEditModal.jsx
+++ b/frontend/src/components/BulkEditModal.jsx
@@ -6,6 +6,7 @@ import SystemBulkEditFields from './system/SystemBulkEditFields'
 import BookBulkEditFields from './system/BookBulkEditFields'
 import ApplyToAllDialog from './system/ApplyToAllDialog'
 import MetadataFetchDialog from './system/MetadataFetchDialog'
+import useMetadataSources from './system/useMetadataSources'
 import { intoBookForm } from './system/metadataFieldValue'
 import { cleanLinks } from './metadata/metadataUtils'
 
@@ -316,10 +317,13 @@ export default function BulkEditModal({
   // "Fetch metadata", mirroring the single-item editors. Only offered when the
   // current item actually has an add-on source, so the button never promises
   // something the server cannot do.
-  const [hasSources, setHasSources] = useState(false)
+  // Cached per kind, so paging through the carousel neither refetches per item
+  // nor makes the button pop in a beat after each system renders.
+  const metadataKind = cfg.metadataKind
+  const { sources: metadataSources } = useMetadataSources(metadataKind, current.id)
+  const hasSources = metadataSources.length > 0
   const [fetching, setFetching] = useState(false)
   const [applyingAll, setApplyingAll] = useState(false)
-  const metadataKind = cfg.metadataKind
 
   // Dismissing the modal throws the drafts away, which is punishing after
   // editing a large selection — so a dirty modal asks first (issue #256).
@@ -329,18 +333,6 @@ export default function BulkEditModal({
     if (Object.keys(diffDrafts(items, drafts, cfg)).length) setConfirmingClose(true)
     else onClose()
   }
-
-  useEffect(() => {
-    if (!metadataKind) return undefined
-    let active = true
-    api
-      .get(`/${metadataKind}/${current.id}/metadata-sources`)
-      .then((data) => active && setHasSources((data.sources || []).length > 0))
-      .catch(() => active && setHasSources(false))
-    return () => {
-      active = false
-    }
-  }, [metadataKind, current.id])
 
   // The fetch dialog PATCHes the fields it applies, so the draft is refreshed
   // to match rather than left holding pre-fetch values that "Save all" would

--- a/frontend/src/components/BulkEditModal.test.jsx
+++ b/frontend/src/components/BulkEditModal.test.jsx
@@ -1,6 +1,7 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest'
 import { render, screen, fireEvent, waitFor, within } from '@testing-library/react'
 import BulkEditModal from './BulkEditModal'
+import { clearMetadataSourcesCache } from './system/useMetadataSources'
 
 const patch = vi.fn(() => Promise.resolve({}))
 const post = vi.fn(() => Promise.resolve({ id: 'g1', name: 'Fantasy' }))
@@ -50,6 +51,9 @@ describe('BulkEditModal', () => {
   beforeEach(() => {
     patch.mockClear()
     get.mockClear()
+    // Sources are cached per kind for the session; without this, the first
+    // test's mocked list would answer for every later one.
+    clearMetadataSourcesCache()
     bulkUpdate.mockClear()
     bulkUpdate.mockResolvedValue({ updated: [], errors: [] })
     get.mockImplementation(defaultGet)

--- a/frontend/src/components/LazyImg.jsx
+++ b/frontend/src/components/LazyImg.jsx
@@ -1,3 +1,5 @@
+import { useState } from 'react'
+
 /**
  * Image wrapper that defaults to lazy loading and async decoding so dense
  * grids/lists (library covers, favorites, campaign resources, …) only fetch
@@ -7,15 +9,68 @@
  * above-the-fold hero, a persistently-visible logo), which sets
  * loading="eager" and lets the browser decode synchronously.
  *
+ * Pass `placeholder` to hold the image's space while it loads: a tinted block
+ * sits behind the image and fades out once it arrives, so a grid of covers
+ * doesn't collapse to nothing and shove the surrounding UI around as thumbnails
+ * stream in. This needs a known size — it only applies when the caller has
+ * given both a width and a height (via `width`/`height` props or `style`), and
+ * is otherwise ignored, since a placeholder of unknown size can't reserve
+ * anything and would only add a wrapper element.
+ *
  * All other props (src, alt, style, className, …) pass straight through to the
  * underlying <img>. Callers may still override `loading`/`decoding` explicitly.
  */
-export default function LazyImg({ eager = false, loading, decoding, ...props }) {
-  return (
+export default function LazyImg({
+  eager = false,
+  loading,
+  decoding,
+  placeholder = false,
+  style,
+  onLoad,
+  onError,
+  ...props
+}) {
+  const [settled, setSettled] = useState(false)
+
+  const img = (
     <img
       loading={loading ?? (eager ? 'eager' : 'lazy')}
       decoding={decoding ?? (eager ? 'auto' : 'async')}
+      style={style}
+      onLoad={(e) => {
+        setSettled(true)
+        onLoad?.(e)
+      }}
+      // A broken image must clear the placeholder too, or the tint sits there
+      // forever looking like an image that never finished loading.
+      onError={(e) => {
+        setSettled(true)
+        onError?.(e)
+      }}
       {...props}
     />
+  )
+
+  // Only reserve space when the size is actually known — see the note above.
+  const width = props.width ?? style?.width
+  const height = props.height ?? style?.height
+  if (!placeholder || width == null || height == null) return img
+
+  return (
+    <span
+      style={{
+        display: 'block',
+        position: 'relative',
+        width,
+        height,
+        // The tint is the reserved box: it is what occupies the space before
+        // the image paints, and it stays put underneath afterwards.
+        background: settled ? 'none' : 'var(--bg-deep)',
+        borderRadius: 'inherit',
+        overflow: 'hidden',
+      }}
+    >
+      {img}
+    </span>
   )
 }

--- a/frontend/src/components/LazyImg.test.jsx
+++ b/frontend/src/components/LazyImg.test.jsx
@@ -1,5 +1,5 @@
-import { render } from '@testing-library/react'
-import { describe, it, expect } from 'vitest'
+import { render, fireEvent } from '@testing-library/react'
+import { describe, it, expect, vi } from 'vitest'
 import LazyImg from './LazyImg'
 
 describe('LazyImg', () => {
@@ -33,5 +33,85 @@ describe('LazyImg', () => {
     const img = container.querySelector('img')
     expect(img).toHaveClass('cover')
     expect(img).toHaveStyle({ width: '100%' })
+  })
+
+  // A grid of covers that collapses to nothing until the images land shoves
+  // whatever sits below it around — reserving the box is the fix.
+  describe('placeholder', () => {
+    it('reserves a sized box until the image loads', () => {
+      const { container } = render(
+        <LazyImg src="/x.webp" alt="" placeholder style={{ width: 60, height: 80 }} />
+      )
+      const box = container.querySelector('span')
+      expect(box).toHaveStyle({ width: '60px', height: '80px' })
+      expect(box).toHaveStyle({ background: 'var(--bg-deep)' })
+    })
+
+    it('drops the tint once the image has loaded', () => {
+      const { container } = render(
+        <LazyImg src="/x.webp" alt="" placeholder style={{ width: 60, height: 80 }} />
+      )
+      fireEvent.load(container.querySelector('img'))
+      expect(container.querySelector('span')).toHaveStyle({ background: 'none' })
+    })
+
+    // Otherwise a broken image leaves the tint sitting there forever.
+    it('drops the tint when the image fails', () => {
+      const { container } = render(
+        <LazyImg src="/gone.webp" alt="" placeholder style={{ width: 60, height: 80 }} />
+      )
+      fireEvent.error(container.querySelector('img'))
+      expect(container.querySelector('span')).toHaveStyle({ background: 'none' })
+    })
+
+    it('accepts the size from width/height props', () => {
+      const { container } = render(
+        <LazyImg src="/x.webp" alt="" placeholder width={60} height={80} />
+      )
+      expect(container.querySelector('span')).toHaveStyle({ width: '60px', height: '80px' })
+    })
+
+    // Nothing to reserve without a size, so it must not add a wrapper.
+    it('is ignored when the size is unknown', () => {
+      const { container } = render(<LazyImg src="/x.webp" alt="" placeholder />)
+      expect(container.querySelector('span')).toBeNull()
+      expect(container.querySelector('img')).toBeInTheDocument()
+    })
+
+    it('is ignored when only one dimension is known', () => {
+      const { container } = render(
+        <LazyImg src="/x.webp" alt="" placeholder style={{ width: 60 }} />
+      )
+      expect(container.querySelector('span')).toBeNull()
+    })
+
+    it('adds no wrapper when not asked for', () => {
+      const { container } = render(
+        <LazyImg src="/x.webp" alt="" style={{ width: 60, height: 80 }} />
+      )
+      expect(container.querySelector('span')).toBeNull()
+    })
+
+    it('still calls a caller onLoad', () => {
+      const onLoad = vi.fn()
+      const { container } = render(
+        <LazyImg
+          src="/x.webp"
+          alt=""
+          placeholder
+          style={{ width: 60, height: 80 }}
+          onLoad={onLoad}
+        />
+      )
+      fireEvent.load(container.querySelector('img'))
+      expect(onLoad).toHaveBeenCalled()
+    })
+
+    it('still calls a caller onError', () => {
+      const onError = vi.fn()
+      const { container } = render(<LazyImg src="/gone.webp" alt="" onError={onError} />)
+      fireEvent.error(container.querySelector('img'))
+      expect(onError).toHaveBeenCalled()
+    })
   })
 })

--- a/frontend/src/components/system/BookEditor.jsx
+++ b/frontend/src/components/system/BookEditor.jsx
@@ -12,6 +12,7 @@ import TagPicker from '../metadata/TagPicker'
 import useLookups from '../metadata/useLookups'
 import { cleanLinks, linksForEditing } from '../metadata/metadataUtils'
 import MetadataFetchDialog from './MetadataFetchDialog'
+import useMetadataSources from './useMetadataSources'
 import { intoBookForm } from './metadataFieldValue'
 
 export default function BookEditor({
@@ -45,16 +46,11 @@ export default function BookEditor({
   })
   const [tags, setTags] = useState(book.tags || [])
   // "Fetch metadata" only appears when a source is actually available, so the
-  // button never promises something the server cannot do.
-  const [hasSources, setHasSources] = useState(false)
+  // button never promises something the server cannot do. Cached per kind, so
+  // reopening an editor doesn't re-ask and the button doesn't pop in late.
+  const { sources: metadataSources } = useMetadataSources('books', book.id)
+  const hasSources = metadataSources.length > 0
   const [fetching, setFetching] = useState(false)
-
-  useEffect(() => {
-    api
-      .get(`/books/${book.id}/metadata-sources`)
-      .then((data) => setHasSources((data.sources || []).length > 0))
-      .catch(() => setHasSources(false))
-  }, [book.id])
 
   // Applied fields arrive in API shape (arrays, numbers); the form holds some
   // of them as text, so they are converted before merging in. Tags live in

--- a/frontend/src/components/system/BookEditor.test.jsx
+++ b/frontend/src/components/system/BookEditor.test.jsx
@@ -1,6 +1,7 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest'
 import { render, screen, fireEvent, waitFor } from '@testing-library/react'
 import BookEditor from './BookEditor'
+import { clearMetadataSourcesCache } from './useMetadataSources'
 
 vi.mock('react-i18next', () => ({
   useTranslation: () => ({ t: (k) => k }),
@@ -59,6 +60,9 @@ describe('BookEditor category combobox', () => {
   beforeEach(() => {
     mockPatch.mockClear()
     mockPatch.mockResolvedValue({})
+    // Sources are cached per kind for the session; without this, the first
+    // test's mocked list would answer for every later one.
+    clearMetadataSourcesCache()
     // Reset to the default lookup responses; the metadata-source tests below
     // override this per case.
     mockGet.mockReset()

--- a/frontend/src/components/system/CoverPicker.jsx
+++ b/frontend/src/components/system/CoverPicker.jsx
@@ -6,7 +6,8 @@ import LazyImg from '../LazyImg'
 import { sortForCoverPicker } from './coverPickerUtils'
 
 // A system can have hundreds of books; showing every thumbnail at once is both
-// slow and unusable, so start with a page and let the user ask for more.
+// slow and unusable, so start with a page and let the user ask for more. The
+// bulk-edit modal is narrower and passes a smaller page via `pageSize`.
 const PAGE_SIZE = 10
 
 // Hover delay before the enlarged preview appears. Long enough that sweeping
@@ -25,10 +26,19 @@ const PREVIEW_DELAY_MS = 500
  *   books    – the system's books (only ones with a thumbnail are shown)
  *   value    – currently selected book id, or null
  *   onChange – (bookId | null) => void
+ *   pageSize – how many covers to show per page (default 10)
+ *   loading  – books are still being fetched; hold the section's space rather
+ *              than rendering nothing and expanding once they arrive
  */
-export default function CoverPicker({ books, value, onChange }) {
+export default function CoverPicker({
+  books,
+  value,
+  onChange,
+  pageSize = PAGE_SIZE,
+  loading = false,
+}) {
   const { t } = useTranslation()
-  const [shown, setShown] = useState(PAGE_SIZE)
+  const [shown, setShown] = useState(pageSize)
   const [preview, setPreview] = useState(null)
   const timerRef = useRef(null)
 
@@ -48,7 +58,10 @@ export default function CoverPicker({ books, value, onChange }) {
     setPreview(null)
   }
 
-  if (candidates.length === 0) return null
+  // Nothing to show and nothing coming — collapse entirely. While books are
+  // still loading we keep the space instead, so the section doesn't pop into
+  // existence and shove everything below it (the modal's buttons) down.
+  if (candidates.length === 0 && !loading) return null
 
   const visible = candidates.slice(0, shown)
   const remaining = candidates.length - visible.length
@@ -69,7 +82,8 @@ export default function CoverPicker({ books, value, onChange }) {
         <LuImage size={14} /> {t('systemEditor.coverImage')}
       </label>
 
-      <div style={{ display: 'flex', flexWrap: 'wrap', gap: 10 }}>
+      {/* One tile's worth of height, held while the book list is in flight. */}
+      <div style={{ display: 'flex', flexWrap: 'wrap', gap: 10, minHeight: loading ? 80 : 0 }}>
         {visible.map((b) => (
           <div key={b.id} style={{ position: 'relative' }}>
             <button
@@ -95,6 +109,7 @@ export default function CoverPicker({ books, value, onChange }) {
               <LazyImg
                 src={mediaUrl(`/books/${b.id}/thumbnail`)}
                 alt={b.title}
+                placeholder
                 style={{ width: '100%', height: '100%', objectFit: 'cover', display: 'block' }}
               />
             </button>
@@ -142,7 +157,7 @@ export default function CoverPicker({ books, value, onChange }) {
 
       {remaining > 0 && (
         <button
-          onClick={() => setShown((n) => n + PAGE_SIZE)}
+          onClick={() => setShown((n) => n + pageSize)}
           style={{
             marginTop: 10,
             padding: '6px 14px',

--- a/frontend/src/components/system/CoverPicker.test.jsx
+++ b/frontend/src/components/system/CoverPicker.test.jsx
@@ -34,6 +34,19 @@ describe('CoverPicker', () => {
     expect(container).toBeEmptyDOMElement()
   })
 
+  // Collapsing to nothing and then expanding once the books arrive is what
+  // pushed the bulk-edit modal's buttons down under the cursor.
+  it('holds its space while books are still loading', () => {
+    const { container } = render(<CoverPicker books={[]} value={null} onChange={vi.fn()} loading />)
+    expect(container).not.toBeEmptyDOMElement()
+    expect(screen.getByText('systemEditor.coverImage')).toBeInTheDocument()
+  })
+
+  it('collapses once loading finishes with nothing to show', () => {
+    const { container } = render(<CoverPicker books={[]} value={null} onChange={vi.fn()} />)
+    expect(container).toBeEmptyDOMElement()
+  })
+
   it('shows the whole list when it is short', () => {
     render(<CoverPicker books={books(4)} value={null} onChange={vi.fn()} />)
     expect(screen.getAllByRole('button', { name: /Book/ })).toHaveLength(4)
@@ -63,6 +76,20 @@ describe('CoverPicker', () => {
       render(<CoverPicker books={books(12)} value={null} onChange={vi.fn()} />)
       await user.click(screen.getByText('systemEditor.loadMoreCovers:2'))
       expect(screen.queryByText(/loadMoreCovers/)).toBeNull()
+    })
+
+    // The bulk-edit modal is narrower and asks for a smaller page.
+    it('honours a caller-supplied page size', () => {
+      render(<CoverPicker books={books(25)} value={null} onChange={vi.fn()} pageSize={8} />)
+      expect(screen.getAllByRole('button', { name: /Book/ })).toHaveLength(8)
+      expect(screen.getByText('systemEditor.loadMoreCovers:17')).toBeInTheDocument()
+    })
+
+    it('pages by the supplied size on each reveal', async () => {
+      const user = userEvent.setup()
+      render(<CoverPicker books={books(25)} value={null} onChange={vi.fn()} pageSize={8} />)
+      await user.click(screen.getByText('systemEditor.loadMoreCovers:17'))
+      expect(screen.getAllByRole('button', { name: /Book/ })).toHaveLength(16)
     })
 
     it('keeps the selected cover visible even when it sorts late', () => {

--- a/frontend/src/components/system/MetadataFetchDialog.jsx
+++ b/frontend/src/components/system/MetadataFetchDialog.jsx
@@ -10,6 +10,7 @@ import {
   isMergedField,
   labelKey,
 } from './metadataFieldValue'
+import useMetadataSources from './useMetadataSources'
 
 /**
  * Review-and-merge dialog for fetching metadata from an add-on (issue #203).
@@ -32,7 +33,11 @@ import {
  */
 export default function MetadataFetchDialog({ resource, kind = 'systems', onApply, onClose }) {
   const { t } = useTranslation()
-  const [sources, setSources] = useState([])
+  const {
+    sources,
+    loading: loadingSources,
+    error: sourcesError,
+  } = useMetadataSources(kind, resource.id)
   const [sourceId, setSourceId] = useState('')
   const [query, setQuery] = useState(resource.name || resource.title || '')
   const [results, setResults] = useState(null)
@@ -56,15 +61,11 @@ export default function MetadataFetchDialog({ resource, kind = 'systems', onAppl
     return () => window.removeEventListener('keydown', onKey)
   }, [onClose])
 
+  // Default to the first source once the list is known, without clobbering a
+  // choice the user already made.
   useEffect(() => {
-    api
-      .get(`/${kind}/${resource.id}/metadata-sources`)
-      .then((data) => {
-        setSources(data.sources || [])
-        if (data.sources?.length) setSourceId(data.sources[0].id)
-      })
-      .catch((e) => setError(e.message))
-  }, [kind, resource.id])
+    if (sources.length && !sources.some((s) => s.id === sourceId)) setSourceId(sources[0].id)
+  }, [sources, sourceId])
 
   const runSearch = useCallback(() => {
     if (!sourceId) return
@@ -199,7 +200,12 @@ export default function MetadataFetchDialog({ resource, kind = 'systems', onAppl
           </button>
         </div>
 
-        {sources.length === 0 && !error && (
+        {/* Only claim there are no sources once we actually know — showing this
+            while the list is still loading reads as "no scrapers installed"
+            and then flips, which is worse than showing nothing. */}
+        {loadingSources && <Spinner />}
+
+        {!loadingSources && sources.length === 0 && !error && !sourcesError && (
           <p style={{ fontSize: 13, color: 'var(--text-dim)' }}>{t('metadataFetch.noSources')}</p>
         )}
 
@@ -324,7 +330,7 @@ export default function MetadataFetchDialog({ resource, kind = 'systems', onAppl
           </div>
         )}
 
-        {error && (
+        {(error || sourcesError) && (
           <p
             role="alert"
             style={{
@@ -337,7 +343,7 @@ export default function MetadataFetchDialog({ resource, kind = 'systems', onAppl
             }}
           >
             <LuTriangleAlert size={14} />
-            {error}
+            {error || sourcesError}
           </p>
         )}
 

--- a/frontend/src/components/system/MetadataFetchDialog.test.jsx
+++ b/frontend/src/components/system/MetadataFetchDialog.test.jsx
@@ -2,6 +2,7 @@ import { describe, it, expect, vi, beforeEach } from 'vitest'
 import { render, screen, waitFor } from '@testing-library/react'
 import userEvent from '@testing-library/user-event'
 import MetadataFetchDialog from './MetadataFetchDialog'
+import { clearMetadataSourcesCache } from './useMetadataSources'
 
 vi.mock('react-i18next', () => ({
   useTranslation: () => ({
@@ -72,6 +73,9 @@ async function openDiff(user) {
 
 beforeEach(() => {
   vi.clearAllMocks()
+  // Sources are cached per kind for the session; without this, the first
+  // test's mocked list would answer for every later one.
+  clearMetadataSourcesCache()
 })
 
 describe('MetadataFetchDialog', () => {
@@ -86,6 +90,17 @@ describe('MetadataFetchDialog', () => {
     api.get.mockResolvedValue({ sources: [] })
     render(<MetadataFetchDialog resource={SYSTEM} onApply={vi.fn()} onClose={vi.fn()} />)
     expect(await screen.findByText('metadataFetch.noSources')).toBeInTheDocument()
+  })
+
+  // The message used to render while the lookup was still in flight, so every
+  // bulk-edit scrape flashed "an admin can install a metadata scraper" first.
+  it('does not claim there are no sources while still loading', () => {
+    let resolve
+    api.get.mockReturnValue(new Promise((r) => (resolve = r)))
+    render(<MetadataFetchDialog resource={SYSTEM} onApply={vi.fn()} onClose={vi.fn()} />)
+
+    expect(screen.queryByText('metadataFetch.noSources')).toBeNull()
+    resolve({ sources: [] })
   })
 
   it('lists candidates returned by a search', async () => {

--- a/frontend/src/components/system/SystemBulkEditFields.jsx
+++ b/frontend/src/components/system/SystemBulkEditFields.jsx
@@ -1,8 +1,8 @@
 import { useState, useEffect, useRef } from 'react'
 import { useTranslation } from 'react-i18next'
-import { LuImage, LuX, LuPlus } from 'react-icons/lu'
-import api, { mediaUrl } from '../../api'
-import LazyImg from '../LazyImg'
+import { LuX, LuPlus } from 'react-icons/lu'
+import api from '../../api'
+import CoverPicker from './CoverPicker'
 import GenrePicker from '../metadata/GenrePicker'
 import LinkListEditor from '../metadata/LinkListEditor'
 import LookupCombobox from '../metadata/LookupCombobox'
@@ -71,8 +71,6 @@ export default function SystemBulkEditFields({ system, draft, setField }) {
       'publishers',
       publishers.filter((_, i) => i !== idx)
     )
-
-  const booksWithThumbnails = (books || []).filter((b) => b.has_thumbnail)
 
   return (
     <div style={{ display: 'flex', flexDirection: 'column', gap: 14 }}>
@@ -263,42 +261,19 @@ export default function SystemBulkEditFields({ system, draft, setField }) {
         </span>
       </label>
 
-      {booksWithThumbnails.length > 0 && (
-        <div>
-          <label style={{ ...label, display: 'flex', alignItems: 'center', gap: 6 }}>
-            <LuImage size={14} /> {t('systemEditor.coverImage')}
-          </label>
-          <div style={{ display: 'flex', flexWrap: 'wrap', gap: 10 }}>
-            {booksWithThumbnails.map((b) => (
-              <button
-                key={b.id}
-                type="button"
-                onClick={() =>
-                  setField('cover_book_id', draft.cover_book_id === b.id ? null : b.id)
-                }
-                title={b.title}
-                style={{
-                  padding: 0,
-                  border: `2px solid ${draft.cover_book_id === b.id ? 'var(--gold)' : 'var(--border)'}`,
-                  borderRadius: 6,
-                  overflow: 'hidden',
-                  cursor: 'pointer',
-                  background: 'none',
-                  width: 60,
-                  height: 80,
-                  flexShrink: 0,
-                }}
-              >
-                <LazyImg
-                  src={mediaUrl(`/books/${b.id}/thumbnail`)}
-                  alt={b.title}
-                  style={{ width: '100%', height: '100%', objectFit: 'cover', display: 'block' }}
-                />
-              </button>
-            ))}
-          </div>
-        </div>
-      )}
+      {/* Same picker the single-system editor uses: core books first, paged,
+          with hover previews. Eight per page rather than the default ten —
+          this modal is narrower, so ten wraps to a third row. `books` is null
+          until the lazy fetch lands, which is what `loading` reserves space
+          for: without it the section appears from nothing and pushes the
+          modal's buttons down just as you go to click them. */}
+      <CoverPicker
+        books={books || []}
+        value={draft.cover_book_id ?? null}
+        onChange={(id) => setField('cover_book_id', id)}
+        pageSize={8}
+        loading={books === null}
+      />
     </div>
   )
 }

--- a/frontend/src/components/system/SystemBulkEditFields.test.jsx
+++ b/frontend/src/components/system/SystemBulkEditFields.test.jsx
@@ -77,6 +77,22 @@ describe('SystemBulkEditFields', () => {
     expect(draft.cover_book_id).toBeNull()
   })
 
+  // Rendering every thumbnail at once made the modal's footer buttons shift as
+  // covers streamed in, so bulk edit pages exactly like the single-system
+  // editor does.
+  it('pages covers at eight rather than rendering the whole library', () => {
+    const books = Array.from({ length: 20 }, (_, i) => ({
+      id: `b${i}`,
+      title: `Book ${i}`,
+      has_thumbnail: true,
+    }))
+    const draft = { tags: [], publishers: [], cover_book_id: null }
+    render(<Harness system={withBooks(books)} initialDraft={draft} />)
+
+    expect(screen.getAllByRole('button', { name: /^Book \d+$/ })).toHaveLength(8)
+    expect(screen.getByText('Show 12 more')).toBeInTheDocument()
+  })
+
   it('edits the system family via the combobox', () => {
     const draft = { tags: [], publishers: [], system_family: '' }
     render(<Harness system={withBooks([])} initialDraft={draft} />)
@@ -112,5 +128,29 @@ describe('SystemBulkEditFields', () => {
 
     await waitFor(() => expect(get).toHaveBeenCalledWith('/systems/s1'))
     await screen.findByRole('button', { name: 'Fetched' })
+  })
+
+  // A system whose books fail to load still has to be editable — the cover
+  // picker just has nothing to offer.
+  it('degrades to no covers when the book lookup fails', async () => {
+    get.mockImplementation((path) => {
+      if (path === '/systems/s1') return Promise.reject(new Error('nope'))
+      if (path?.includes('genres')) return Promise.resolve({ genres: [] })
+      return Promise.resolve({ families: [] })
+    })
+    const draft = { tags: [], publishers: [], cover_book_id: null }
+    render(<Harness system={{ id: 's1', name: 'Alpha' }} initialDraft={draft} />)
+
+    await waitFor(() => expect(get).toHaveBeenCalledWith('/systems/s1'))
+    expect(screen.queryByText('Cover image')).toBeNull()
+  })
+
+  it('reuses books already carried on the system without refetching', async () => {
+    const books = [{ id: 'b1', title: 'Core', has_thumbnail: true }]
+    const draft = { tags: [], publishers: [], cover_book_id: null }
+    render(<Harness system={withBooks(books)} initialDraft={draft} />)
+
+    await screen.findByRole('button', { name: 'Core' })
+    expect(get).not.toHaveBeenCalledWith('/systems/s1')
   })
 })

--- a/frontend/src/components/system/SystemEditor.jsx
+++ b/frontend/src/components/system/SystemEditor.jsx
@@ -5,6 +5,7 @@ import api from '../../api'
 import CoverPicker from './CoverPicker'
 import CoverUpload from './CoverUpload'
 import MetadataFetchDialog from './MetadataFetchDialog'
+import useMetadataSources from './useMetadataSources'
 import GenrePicker from '../metadata/GenrePicker'
 import TagPicker from '../metadata/TagPicker'
 import LinkListEditor from '../metadata/LinkListEditor'
@@ -45,16 +46,11 @@ export default function SystemEditor({ system, onSave, onCoverChange }) {
     is_explicit: system.is_explicit || false,
   })
   // "Fetch metadata" only appears when a source is actually available, so the
-  // button never promises something the server cannot do.
-  const [hasSources, setHasSources] = useState(false)
+  // button never promises something the server cannot do. Cached per kind, so
+  // reopening an editor doesn't re-ask and the button doesn't pop in late.
+  const { sources: metadataSources } = useMetadataSources('systems', system.id)
+  const hasSources = metadataSources.length > 0
   const [fetching, setFetching] = useState(false)
-
-  useEffect(() => {
-    api
-      .get(`/systems/${system.id}/metadata-sources`)
-      .then((data) => setHasSources((data.sources || []).length > 0))
-      .catch(() => setHasSources(false))
-  }, [system.id])
 
   // Merge applied fields into the form so the editor reflects them immediately,
   // and tell the parent so its copy of the system stays in step.

--- a/frontend/src/components/system/SystemEditor.test.jsx
+++ b/frontend/src/components/system/SystemEditor.test.jsx
@@ -2,6 +2,7 @@ import { describe, it, expect, vi, beforeEach } from 'vitest'
 import { render, screen, waitFor } from '@testing-library/react'
 import userEvent from '@testing-library/user-event'
 import SystemEditor from './SystemEditor'
+import { clearMetadataSourcesCache } from './useMetadataSources'
 import api from '../../api'
 
 vi.mock('../../api', () => ({
@@ -12,6 +13,9 @@ vi.mock('../../api', () => ({
 
 beforeEach(() => {
   vi.clearAllMocks()
+  // Sources are cached per kind for the session; without this, the first
+  // test's mocked list would answer for every later one.
+  clearMetadataSourcesCache()
   api.patch.mockResolvedValue({})
   // useLookups loads genres + system families on mount.
   api.get.mockImplementation((path) =>

--- a/frontend/src/components/system/useMetadataSources.js
+++ b/frontend/src/components/system/useMetadataSources.js
@@ -1,0 +1,92 @@
+import { useEffect, useState } from 'react'
+import api from '../../api'
+
+// The source list depends only on which add-ons are installed and what target
+// they serve ('game-system' / 'book') — never on the resource being edited (the
+// id in the URL is only an existence check server-side). So one fetch per kind
+// answers for every system and every book.
+//
+// This matters most in bulk edit: paging through a 40-system selection used to
+// fire 40 identical requests, and the "Fetch metadata" button popped in a beat
+// late on each one. Cached per kind, only the first system pays.
+//
+// The cache holds the promise, not just the result, so editors mounting
+// together share one in-flight request instead of racing to issue their own.
+const cache = new Map()
+
+// Resolved values are kept alongside the promises so a warm hook can seed its
+// initial state synchronously — awaiting even a settled promise costs a tick,
+// and that tick is exactly the flash of "no sources" we're removing.
+const settled = new Map()
+
+/** Drop cached source lists — call after installing or enabling an add-on. */
+export function clearMetadataSourcesCache() {
+  cache.clear()
+  settled.clear()
+}
+
+// The endpoint is addressed per resource, so priming the cache needs some id of
+// that kind — any will do, since the answer is identical for all of them.
+function loadSources(kind, sampleId) {
+  if (!cache.has(kind)) {
+    cache.set(
+      kind,
+      api
+        .get(`/${kind}/${sampleId}/metadata-sources`)
+        .then((data) => {
+          const sources = data.sources || []
+          settled.set(kind, sources)
+          return sources
+        })
+        // A failed lookup must not be cached as "no sources forever" — an
+        // offline blip would disable the feature for the rest of the session.
+        .catch((e) => {
+          cache.delete(kind)
+          throw e
+        })
+    )
+  }
+  return cache.get(kind)
+}
+
+/**
+ * The metadata add-on sources available for `kind` ('systems' | 'books').
+ *
+ * `sampleId` is any resource id of that kind — the endpoint is addressed per
+ * resource but answers the same for all of them.
+ *
+ * Returns `{ sources, loading, error }`. On a warm cache `loading` is false and
+ * `sources` is populated from the very first render, so paging through a bulk
+ * selection neither refetches nor flashes the "an admin can install a metadata
+ * scraper" empty state.
+ */
+export default function useMetadataSources(kind, sampleId) {
+  const [state, setState] = useState(() =>
+    kind && settled.has(kind)
+      ? { sources: settled.get(kind), loading: false, error: '' }
+      : { sources: [], loading: !!(kind && sampleId), error: '' }
+  )
+
+  useEffect(() => {
+    if (!kind || !sampleId) return undefined
+    if (settled.has(kind)) {
+      setState({ sources: settled.get(kind), loading: false, error: '' })
+      return undefined
+    }
+    let active = true
+    // Note: no "start loading" setState here. It would re-run this effect's
+    // cleanup on some paths and cancel the very request it announced; the
+    // initial state already says loading, and a cold cache is the only way to
+    // reach this line.
+    loadSources(kind, sampleId)
+      .then((sources) => active && setState({ sources, loading: false, error: '' }))
+      .catch(
+        (e) => active && setState({ sources: [], loading: false, error: e.message || String(e) })
+      )
+    return () => {
+      active = false
+    }
+  }, [kind, sampleId])
+
+  return state
+}

--- a/frontend/src/components/system/useMetadataSources.test.js
+++ b/frontend/src/components/system/useMetadataSources.test.js
@@ -1,0 +1,119 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { renderHook, waitFor } from '@testing-library/react'
+import useMetadataSources, { clearMetadataSourcesCache } from './useMetadataSources'
+import api from '../../api'
+
+vi.mock('../../api', () => ({
+  default: { get: vi.fn() },
+}))
+
+const SOURCES = [{ id: 'ttrpg-wiki', name: 'TTRPG Wiki' }]
+
+beforeEach(() => {
+  vi.clearAllMocks()
+  clearMetadataSourcesCache()
+  api.get.mockResolvedValue({ sources: SOURCES })
+})
+
+describe('useMetadataSources', () => {
+  it('loads the sources for a kind', async () => {
+    const { result } = renderHook(() => useMetadataSources('systems', 'sys-1'))
+
+    expect(result.current.loading).toBe(true)
+    await waitFor(() => expect(result.current.loading).toBe(false))
+    expect(result.current.sources).toEqual(SOURCES)
+    expect(api.get).toHaveBeenCalledWith('/systems/sys-1/metadata-sources')
+  })
+
+  it('treats a missing sources key as an empty list', async () => {
+    api.get.mockResolvedValue({})
+    const { result } = renderHook(() => useMetadataSources('systems', 'sys-1'))
+
+    await waitFor(() => expect(result.current.loading).toBe(false))
+    expect(result.current.sources).toEqual([])
+  })
+
+  // The whole point of the hook: bulk edit pages through dozens of resources of
+  // the same kind, and the answer is identical for every one of them.
+  it('asks the server only once per kind, whatever the resource', async () => {
+    const first = renderHook(() => useMetadataSources('systems', 'sys-1'))
+    await waitFor(() => expect(first.result.current.loading).toBe(false))
+
+    renderHook(() => useMetadataSources('systems', 'sys-2'))
+    renderHook(() => useMetadataSources('systems', 'sys-3'))
+
+    expect(api.get).toHaveBeenCalledTimes(1)
+  })
+
+  // A late-arriving answer is what made the "Fetch metadata" button pop in and
+  // the "no scrapers installed" note flash; a warm cache must skip both.
+  it('serves a warm cache on the first render, without loading', async () => {
+    const first = renderHook(() => useMetadataSources('systems', 'sys-1'))
+    await waitFor(() => expect(first.result.current.loading).toBe(false))
+
+    const second = renderHook(() => useMetadataSources('systems', 'sys-2'))
+    expect(second.result.current.loading).toBe(false)
+    expect(second.result.current.sources).toEqual(SOURCES)
+  })
+
+  it('keeps books and systems in separate cache entries', async () => {
+    const systems = renderHook(() => useMetadataSources('systems', 'sys-1'))
+    await waitFor(() => expect(systems.result.current.loading).toBe(false))
+
+    const books = renderHook(() => useMetadataSources('books', 'book-1'))
+    await waitFor(() => expect(books.result.current.loading).toBe(false))
+
+    expect(api.get).toHaveBeenCalledTimes(2)
+    expect(api.get).toHaveBeenCalledWith('/books/book-1/metadata-sources')
+  })
+
+  it('shares one in-flight request between editors mounting together', async () => {
+    const a = renderHook(() => useMetadataSources('systems', 'sys-1'))
+    const b = renderHook(() => useMetadataSources('systems', 'sys-2'))
+
+    await waitFor(() => expect(a.result.current.loading).toBe(false))
+    await waitFor(() => expect(b.result.current.loading).toBe(false))
+
+    expect(api.get).toHaveBeenCalledTimes(1)
+    expect(b.result.current.sources).toEqual(SOURCES)
+  })
+
+  it('reports a failure instead of hanging on loading', async () => {
+    api.get.mockRejectedValue(new Error('nope'))
+    const { result } = renderHook(() => useMetadataSources('systems', 'sys-1'))
+
+    await waitFor(() => expect(result.current.loading).toBe(false))
+    expect(result.current.error).toBe('nope')
+    expect(result.current.sources).toEqual([])
+  })
+
+  // An offline blip must not disable the feature for the rest of the session.
+  it('does not cache a failure', async () => {
+    api.get.mockRejectedValue(new Error('nope'))
+    const failed = renderHook(() => useMetadataSources('systems', 'sys-1'))
+    await waitFor(() => expect(failed.result.current.loading).toBe(false))
+
+    api.get.mockResolvedValue({ sources: SOURCES })
+    const retried = renderHook(() => useMetadataSources('systems', 'sys-1'))
+    await waitFor(() => expect(retried.result.current.sources).toEqual(SOURCES))
+  })
+
+  it('stays idle without a kind or a sample id', () => {
+    const { result } = renderHook(() => useMetadataSources('systems', null))
+
+    expect(result.current.loading).toBe(false)
+    expect(result.current.sources).toEqual([])
+    expect(api.get).not.toHaveBeenCalled()
+  })
+
+  it('refetches after the cache is cleared, as on add-on install', async () => {
+    const first = renderHook(() => useMetadataSources('systems', 'sys-1'))
+    await waitFor(() => expect(first.result.current.loading).toBe(false))
+
+    clearMetadataSourcesCache()
+    const second = renderHook(() => useMetadataSources('systems', 'sys-1'))
+    await waitFor(() => expect(second.result.current.loading).toBe(false))
+
+    expect(api.get).toHaveBeenCalledTimes(2)
+  })
+})


### PR DESCRIPTION
## Summary

<!-- What does this PR do? A few sentences is fine. -->

## Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / cleanup
- [ ] Docs / configuration only

## Testing

<!-- How did you verify this works? Check all that apply. -->

- [ ] Backend tests pass (`pytest -q`)
- [x] Frontend tests pass (`npm test`)
- [x] Tested manually in the browser

## Notes for reviewer

<!-- Anything that needs extra context, known limitations, or follow-up work. Delete if not needed. -->
