### PR TITLE
Fix: Apply .grimoireignore when enumerating system folders

### DIFF
--- a/backend/indexer/scan.py
+++ b/backend/indexer/scan.py
@@ -92,6 +92,18 @@ def _prune_dirs(root: str, dirs: list[str], ignore: Optional[IgnoreMatcher]) -> 
     ]
 
 
+def _keep_entry(path: Path, ignore: Optional[IgnoreMatcher], *, is_dir: bool) -> bool:
+    """Return True if a directly-enumerated entry should be scanned.
+
+    The ``os.walk`` paths prune with :func:`_prune_dirs`, but the system and
+    container walks list a directory themselves (``Path.iterdir``) and so need
+    the same hidden-plus-``.grimoireignore`` test applied per entry (issue #333).
+    """
+    return not path.name.startswith(".") and not (
+        ignore and ignore.is_ignored(str(path), is_dir=is_dir)
+    )
+
+
 def _count_eligible_files(
     directory: Path, extensions: set, ignore: Optional[IgnoreMatcher] = None
 ) -> int:
@@ -418,7 +430,7 @@ def _scan_books(ctx: _ScanContext, books_dir: Path) -> None:
         # Whole library, or scope == "books" root: iterate every system.
         system_dirs = sorted(books_dir.iterdir())
     for system_dir in system_dirs:
-        if not system_dir.is_dir() or system_dir.name.startswith("."):
+        if not system_dir.is_dir() or not _keep_entry(system_dir, ctx.ignore, is_dir=True):
             continue
 
         folder = _resolve_system_folder(system_dir)
@@ -518,7 +530,7 @@ def _scan_container(
         ctx.stats["errors"] += 1
         return False
 
-    child_dirs = [d for d in entries if d.is_dir() and not d.name.startswith(".")]
+    child_dirs = [d for d in entries if d.is_dir() and _keep_entry(d, ctx.ignore, is_dir=True)]
     for child_dir in child_dirs:
         if scoped_child and child_dir.name != scoped_child:
             continue
@@ -561,7 +573,7 @@ def _scan_container(
     if scoped_child:
         return False
 
-    loose_files = [f for f in entries if f.is_file() and not f.name.startswith(".")]
+    loose_files = [f for f in entries if f.is_file() and _keep_entry(f, ctx.ignore, is_dir=False)]
     if kind == CONTAINER_ONE_PAGE:
         return _scan_one_page_loose_files(ctx, container, container_folder, loose_files)
     # Every other container kind: loose files belong to the container itself.

--- a/backend/tests/test_indexer_ignore.py
+++ b/backend/tests/test_indexer_ignore.py
@@ -149,6 +149,74 @@ class TestOtherCollectionsIgnore:
         assert "keep.mp3" in audio_names and "skip.mp3" not in audio_names
 
 
+class TestSystemFolderIgnore:
+    """Directly-enumerated system folders honour ignore rules too (issue #333).
+
+    The container and top-level system walks list directories themselves rather
+    than going through ``os.walk``/``_prune_dirs``, so an ignored folder used to
+    still be registered as a system (a NAS ``@eaDir`` becoming a bogus edition).
+    """
+
+    def test_ignored_container_child_not_registered_as_system(self):
+        tmp, lib = _mk_lib()
+        container = _mkdir(lib, "books", "Ign333 Shadowrun")
+        (container / ".parent-system-container").write_text("")
+        _touch_pdf(_mkdir(container, "6 DE", "core"), "core-book.pdf")
+        _mkdir(container, "@eaDir")
+        (lib / IGNORE_FILENAME).write_text("@eaDir/\n**/@eaDir/\n")
+
+        _scan(lib, tmp)
+
+        db = SessionLocal()
+        try:
+            children = db.query(GameSystem).filter_by(parent_system="Ign333 Shadowrun").all()
+            editions = {c.edition for c in children}
+        finally:
+            db.close()
+        # The real edition registers; the ignored NAS folder does not.
+        assert "6 DE" in editions
+        assert "@eaDir" not in editions
+
+    def test_ignored_loose_file_not_registered_in_one_page_container(self):
+        tmp, lib = _mk_lib()
+        container = _mkdir(lib, "books", "Ign333 One Pagers")
+        (container / ".one-page-container").write_text("")
+        # Names are prefixed because game_systems.name is globally unique and the
+        # test DB is shared across the suite.
+        _touch_pdf(container, "ign333-honey-heist.pdf")
+        _touch_pdf(container, "ign333-skip-me.pdf")
+        (lib / IGNORE_FILENAME).write_text("ign333-skip-me.pdf\n")
+
+        _scan(lib, tmp)
+
+        db = SessionLocal()
+        try:
+            container_row = db.query(GameSystem).filter_by(slug="ign333-one-pagers").first()
+            names = {
+                s.name for s in db.query(GameSystem).filter_by(parent_id=container_row.id).all()
+            }
+        finally:
+            db.close()
+        assert any("Honey Heist" in n for n in names)
+        assert not any("Skip Me" in n for n in names)
+
+    def test_ignored_top_level_folder_not_registered_as_system(self):
+        tmp, lib = _mk_lib()
+        _touch_pdf(_mkdir(lib, "books", "Ign333 Keeper", "core"), "book.pdf")
+        _mkdir(lib, "books", "@eaDir")
+        (lib / IGNORE_FILENAME).write_text("@eaDir/\n**/@eaDir/\n")
+
+        _scan(lib, tmp)
+
+        db = SessionLocal()
+        try:
+            names = {s.name for s in db.query(GameSystem).all()}
+        finally:
+            db.close()
+        assert "Ign333 Keeper" in names
+        assert not any("eaDir" in n for n in names)
+
+
 class TestReconciliation:
     def test_newly_ignored_book_marked_missing_then_restored(self):
         tmp, lib = _mk_lib()


### PR DESCRIPTION
## Summary

<!-- What does this PR do? A few sentences is fine. -->

## Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / cleanup
- [ ] Docs / configuration only

## Testing

<!-- How did you verify this works? Check all that apply. -->

- [x] Backend tests pass (`pytest -q`)
- [x] Frontend tests pass (`npm test`)
- [x] Tested manually in the browser

## Notes for reviewer

<!-- Anything that needs extra context, known limitations, or follow-up work. Delete if not needed. -->
