### PR TITLE
Fix: Apply a note template to an already-open page editor

### DIFF
--- a/frontend/src/components/campaigns/WikiView.jsx
+++ b/frontend/src/components/campaigns/WikiView.jsx
@@ -87,6 +87,13 @@ export default function WikiView({ campaign, isOwner, onViewingNoteChange }) {
   // Content for a page started from a template: an unsaved draft PageEditor
   // opens with. Null for an ordinary blank New Page.
   const [draft, setDraft] = useState(null)
+  // Bumped every time a draft is applied. PageEditor seeds its fields from
+  // `page` in useState initialisers, so swapping the prop on an editor that is
+  // already open would leave the old (usually empty) body on screen — the
+  // editor has to remount. Keyed on a counter rather than the draft itself
+  // because a draft has no id, and picking the same template twice must still
+  // reset the box.
+  const [draftToken, setDraftToken] = useState(0)
   const [query, setQuery] = useState('')
   const [importing, setImporting] = useState(false)
   const [browsingTemplates, setBrowsingTemplates] = useState(false)
@@ -297,6 +304,9 @@ export default function WikiView({ campaign, isOwner, onViewingNoteChange }) {
 
   const startCreate = (parentId = '') => {
     setDraft(null)
+    // Same remount, the other way round: New Page while a template-filled
+    // editor is open must come up blank rather than keeping that body.
+    setDraftToken((n) => n + 1)
     setCreateParentId(parentId)
     setCreating(true)
     setEditing(false)
@@ -841,6 +851,8 @@ export default function WikiView({ campaign, isOwner, onViewingNoteChange }) {
         )}
         {creating ? (
           <PageEditor
+            // Remount on each applied draft so the fields re-seed from it.
+            key={draftToken}
             campaign={campaign}
             isOwner={isOwner}
             // A draft has no `id`, so PageEditor still treats it as a new page
@@ -1071,6 +1083,7 @@ export default function WikiView({ campaign, isOwner, onViewingNoteChange }) {
             setPage(null)
             setSelectedId(null)
             setDraft(draft)
+            setDraftToken((n) => n + 1)
             setCreating(true)
           }}
         />

--- a/frontend/src/components/campaigns/WikiView.test.jsx
+++ b/frontend/src/components/campaigns/WikiView.test.jsx
@@ -919,6 +919,29 @@ describe('WikiView community note templates', () => {
     expect(campaigns.deleteWikiPage).not.toHaveBeenCalled()
   })
 
+  it('fills the editor when a template is picked with the editor already open', async () => {
+    campaigns.getWikiTemplate.mockResolvedValue({
+      id: '5e-spell',
+      name: 'Spell',
+      body: '*2nd-level transmutation*',
+      defaults: { title: 'New Spell' },
+    })
+
+    renderView()
+    // The order a GM hits on a fresh campaign: start a blank page first, then
+    // reach for a template. The editor is already mounted at that point, so a
+    // draft that only swaps the prop would never reach the fields.
+    fireEvent.click(await screen.findByRole('button', { name: /New Page/i }))
+    await screen.findByPlaceholderText(/Write in Markdown/i)
+
+    fireEvent.click(screen.getByRole('button', { name: /Templates/ }))
+    fireEvent.click(await screen.findByText('A 5e spell.'))
+
+    expect(await screen.findByDisplayValue('*2nd-level transmutation*')).toBeTruthy()
+    expect(screen.getByDisplayValue('New Spell')).toBeTruthy()
+    expect(campaigns.createWikiPage).not.toHaveBeenCalled()
+  })
+
   it('does not carry a template draft into a blank New Page', async () => {
     campaigns.getWikiTemplate.mockResolvedValue({
       id: '5e-spell',


### PR DESCRIPTION
## Summary

<!-- What does this PR do? A few sentences is fine. -->

## Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / cleanup
- [ ] Docs / configuration only

## Testing

<!-- How did you verify this works? Check all that apply. -->

- [ ] Backend tests pass (`pytest -q`)
- [x] Frontend tests pass (`npm test`)
- [x] Tested manually in the browser

## Notes for reviewer

<!-- Anything that needs extra context, known limitations, or follow-up work. Delete if not needed. -->
