### PR TITLE
FIx: Cancelled/failed scans no longer cause systems to not be registered

### DIFF
--- a/backend/indexer/scan.py
+++ b/backend/indexer/scan.py
@@ -446,6 +446,10 @@ def _scan_books(ctx: _ScanContext, books_dir: Path) -> None:
     else:
         # Whole library, or scope == "books" root: iterate every system.
         system_dirs = sorted(books_dir.iterdir())
+    # Same two-pass split as ``_scan_container`` (issue #352): register every
+    # top-level system first, so a stop while indexing one system's books cannot
+    # leave the systems after it in the walk unregistered.
+    registered: list[tuple[Path, _SystemFolder, GameSystem]] = []
     for system_dir in system_dirs:
         if not system_dir.is_dir() or not _keep_entry(system_dir, ctx.ignore, is_dir=True):
             continue
@@ -454,7 +458,18 @@ def _scan_books(ctx: _ScanContext, books_dir: Path) -> None:
         system = _register_system(ctx, folder)
         if system is None:
             continue
+        registered.append((system_dir, folder, system))
 
+    if registered:
+        try:
+            _run_with_timeout(session.commit, _DB_TIMEOUT, "commit top-level systems")
+        except (TimeoutError, Exception) as e:
+            logger.error(f"DB error saving top-level systems: {e}")
+            session.rollback()
+            ctx.stats["errors"] += 1
+            return
+
+    for system_dir, folder, system in registered:
         if folder.container_kind:
             # The folder holds systems, not categories — recurse one level.
             if _scan_container(ctx, system, folder, category_inference_off, scope_parts):
@@ -505,8 +520,14 @@ def _scan_container(
     category_inference_off: bool,
     scope_parts: tuple[str, ...],
     depth: int = 1,
+    register_only: bool = False,
 ) -> bool:
     """Register a container folder's children as systems. True if stop requested.
+
+    ``register_only`` runs the registration half alone — every child (and, for a
+    nested container, every grandchild) gets its row, and no books are indexed.
+    ``_scan_books`` uses it as a pre-pass so an interrupted scan still leaves a
+    complete set of systems behind (issue #352).
 
     Each immediate subdirectory becomes a system whose own tree is then scanned
     with ordinary category inference (so ``cbr+pnk/core/`` and
@@ -548,6 +569,15 @@ def _scan_container(
         return False
 
     child_dirs = [d for d in entries if d.is_dir() and _keep_entry(d, ctx.ignore, is_dir=True)]
+
+    # Pass 1 — register every child system before indexing any books (issue #352).
+    # Registering and indexing in one loop meant a stop partway through the first
+    # edition's books returned before the later editions had rows at all, so an
+    # interrupted scan left a half-populated shelf. Registration is cheap (one row
+    # per folder, no file reads), so doing all of it up front makes the set of
+    # editions complete as soon as the container is walked, however early the
+    # indexing is cut short.
+    registered: list[tuple[Path, _SystemFolder, GameSystem]] = []
     for child_dir in child_dirs:
         if scoped_child and child_dir.name != scoped_child:
             continue
@@ -564,14 +594,52 @@ def _scan_container(
         )
         if child is None:
             continue
+        registered.append((child_dir, child_folder, child))
+        if child_folder.container_kind and not register_only:
+            # A nested container holds systems of its own. Register that whole
+            # subtree now, while still in the registration pass, so an
+            # interrupted scan leaves every level of the shelf complete.
+            _scan_container(
+                ctx,
+                child,
+                child_folder,
+                category_inference_off,
+                scope_parts[1:],
+                depth + 1,
+                register_only=True,
+            )
+
+    # Persist the rows now, so a stop (or a crash) during pass 2 still leaves the
+    # shelf complete rather than rolling the registrations back with it.
+    if registered:
+        try:
+            _run_with_timeout(
+                ctx.session.commit, _DB_TIMEOUT, f"commit child systems of '{container.name}'"
+            )
+        except (TimeoutError, Exception) as e:
+            logger.error(f"DB error saving child systems of '{container.name}': {e}")
+            ctx.session.rollback()
+            ctx.stats["errors"] += 1
+            return False
+
+    # Pass 2 — index each child's books (the expensive part, and the one that stops).
+    for child_dir, child_folder, child in registered:
         if child_folder.container_kind:
             # Nested container (e.g. a parent-system inside a family). Recurse
             # so its own children register as systems rather than treating the
             # edition folders as book categories.
             if _scan_container(
-                ctx, child, child_folder, category_inference_off, scope_parts[1:], depth + 1
+                ctx,
+                child,
+                child_folder,
+                category_inference_off,
+                scope_parts[1:],
+                depth + 1,
+                register_only=register_only,
             ):
                 return True
+            continue
+        if register_only:
             continue
         child_category_off = category_inference_off or (
             child_dir / NO_AUTO_CATEGORY_MARKER
@@ -592,7 +660,15 @@ def _scan_container(
 
     loose_files = [f for f in entries if f.is_file() and _keep_entry(f, ctx.ignore, is_dir=False)]
     if kind == CONTAINER_ONE_PAGE:
-        return _scan_one_page_loose_files(ctx, container, container_folder, loose_files)
+        # Each loose file is a system of its own, so this belongs in the
+        # registration pass as much as the child folders do.
+        return _scan_one_page_loose_files(
+            ctx, container, container_folder, loose_files, register_only=register_only
+        )
+    if register_only:
+        # Loose files here are ordinary books on the container's own row; no
+        # system to create, so nothing for the registration pass to do.
+        return False
     # Every other container kind: loose files belong to the container itself.
     return _scan_books_in_system(
         ctx,
@@ -610,12 +686,16 @@ def _scan_one_page_loose_files(
     container: GameSystem,
     container_folder: _SystemFolder,
     loose_files: list[Path],
+    register_only: bool = False,
 ) -> bool:
     """Register each loose file under a one-page container as its own system.
 
     ``one-page-rpgs/honey-heist.pdf`` becomes the system "Honey Heist" holding
     that single book, so it carries its own metadata, tags, and system filters
     exactly like a folder-backed game.
+
+    ``register_only`` creates the rows without indexing the books, for the
+    registration pre-pass described in :func:`_scan_container`.
     """
     for path in loose_files:
         ext = path.suffix.lower()
@@ -638,6 +718,8 @@ def _scan_one_page_loose_files(
             attribute_parent=False,
         )
         if child is None:
+            continue
+        if register_only:
             continue
         if _scan_books_in_system(
             ctx,

--- a/backend/tests/test_indexer_containers.py
+++ b/backend/tests/test_indexer_containers.py
@@ -851,18 +851,52 @@ class TestInterruptedScanStillRegistersSystems:
         for slug in ("stop352-aaa", "stop352-bbb", "stop352-ccc"):
             assert _system(slug) is not None, f"{slug} was never registered"
 
-    def test_interrupted_scan_is_completed_by_a_later_full_scan(self):
-        """Indexing still resumes: the cancel costs books, not systems."""
+    def test_editions_added_to_an_indexed_container_survive_a_cancel(self):
+        """The reported sequence, on an already-indexed library.
+
+        1. a container with one edition, scanned to completion
+        2. two more editions added, scan cancelled once the first edition's
+           files have been checked
+        3. a full rescan
+
+        Step 2 is what the bug ruins. The stop counter ticks once per file the
+        walk *visits*, and an already-indexed edition is visited (then skipped
+        by the mtime/size gate) before the check runs — so the budget is spent
+        on files that need no work, and the new editions sit behind the wall.
+        An interruption that recurs at the same point never gets past it, which
+        is why the reporter saw the editions stay missing across rescans.
+
+        Step 3 pins the other half: a scan that is allowed to finish indexes
+        their books, so the cancel costs books, never systems.
+        """
         tmp, lib = _mk_lib()
-        root = _books_dir(lib, "Stop352 Resume")
+        root = _books_dir(lib, "Stop352 Seq")
         (root / ".parent-system-container").write_text("")
-        for edition in ("1e", "2e"):
-            _touch_pdf(_books_dir(lib, "Stop352 Resume", edition, "core"), f"{edition}.pdf")
 
-        _scan(lib, tmp, should_stop=_stop_after(1))
+        # 1 — one edition, indexed completely.
+        first = _books_dir(lib, "Stop352 Seq", "1e", "core")
+        for i in range(10):
+            _touch_pdf(first, f"1e-{i}.pdf")
         _scan(lib, tmp)
+        assert len(_books_for("stop352-seq--1e", lib)) == 10
 
-        for edition in ("1e", "2e"):
-            slug = f"stop352-resume--{edition}"
+        # 2 — two more editions, cancelled once 1e's files have been walked.
+        for edition in ("2e", "3e"):
+            core = _books_dir(lib, "Stop352 Seq", edition, "core")
+            for i in range(10):
+                _touch_pdf(core, f"{edition}-{i}.pdf")
+        _scan(lib, tmp, should_stop=_stop_after(10))
+
+        for edition in ("2e", "3e"):
+            assert (
+                _system(f"stop352-seq--{edition}") is not None
+            ), f"{edition} must register even though the scan never indexed it"
+        # The already-indexed edition is untouched by the interrupted pass.
+        assert len(_books_for("stop352-seq--1e", lib)) == 10
+
+        # 3 — a completed rescan fills in the books behind those systems.
+        _scan(lib, tmp)
+        for edition in ("1e", "2e", "3e"):
+            slug = f"stop352-seq--{edition}"
             assert _system(slug) is not None
-            assert [b.category for b in _books_for(slug, lib)] == ["core"]
+            assert len(_books_for(slug, lib)) == 10

--- a/backend/tests/test_indexer_containers.py
+++ b/backend/tests/test_indexer_containers.py
@@ -39,12 +39,27 @@ def _touch_pdf(folder: Path, name: str = "book.pdf") -> Path:
     return p
 
 
-def _scan(lib: Path, tmp: str):
+def _scan(lib: Path, tmp: str, **kw):
     db = SessionLocal()
     try:
-        scan_library(str(lib), tmp, db)
+        return scan_library(str(lib), tmp, db, **kw)
     finally:
         db.close()
+
+
+def _stop_after(n: int):
+    """A ``should_stop`` that returns True from the (n+1)th call onwards.
+
+    The scan polls it once per file processed, so this cancels partway through
+    the first system's books — the point at which issue #352 bites.
+    """
+    calls = {"n": 0}
+
+    def should_stop() -> bool:
+        calls["n"] += 1
+        return calls["n"] > n
+
+    return should_stop
 
 
 def _system(slug: str):
@@ -772,3 +787,82 @@ class TestGenericContainer:
         assert edition is not None
         assert edition.edition == "2e"
         assert [b.category for b in _books_for("gen-outer--inner-game--2e", lib)] == ["core"]
+
+
+class TestInterruptedScanStillRegistersSystems:
+    """Issue #352 — a cancelled scan must not leave a half-populated shelf.
+
+    Registration used to be interleaved with book indexing, so a stop partway
+    through the first edition's files returned before the later editions had
+    rows at all. Registering every system first makes the set of editions
+    complete as soon as the folder is walked, however early indexing is cut off.
+    """
+
+    def test_cancelled_scan_registers_every_edition_of_a_container(self):
+        tmp, lib = _mk_lib()
+        root = _books_dir(lib, "Stop352 Game")
+        (root / ".parent-system-container").write_text("")
+        for edition in ("2nd Edition", "3rd Edition", "4th Edition", "5th Edition"):
+            core = _books_dir(lib, "Stop352 Game", edition, "core")
+            for i in range(3):
+                _touch_pdf(core, f"{edition}-{i}.pdf")
+
+        # Cancel a couple of files in — long before the later editions.
+        _scan(lib, tmp, should_stop=_stop_after(2))
+
+        db = SessionLocal()
+        try:
+            editions = {
+                s.edition
+                for s in db.query(GameSystem).filter_by(parent_system="Stop352 Game").all()
+            }
+        finally:
+            db.close()
+        assert {"2nd Edition", "3rd Edition", "4th Edition", "5th Edition"} <= editions
+
+    def test_cancelled_scan_registers_nested_container_children(self):
+        """The same guarantee through a family -> parent-system -> editions chain."""
+        tmp, lib = _mk_lib()
+        family = _books_dir(lib, "Stop352 d20")
+        (family / ".system-family-container").write_text("")
+        inner = _books_dir(lib, "Stop352 d20", "Stop352 Pathfinder")
+        (inner / ".parent-system-container").write_text("")
+        for edition in ("1e", "2e", "3e"):
+            core = _books_dir(lib, "Stop352 d20", "Stop352 Pathfinder", edition, "core")
+            for i in range(3):
+                _touch_pdf(core, f"{edition}-{i}.pdf")
+
+        _scan(lib, tmp, should_stop=_stop_after(2))
+
+        for edition in ("1e", "2e", "3e"):
+            slug = f"stop352-d20--stop352-pathfinder--{edition}"
+            assert _system(slug) is not None, f"{edition} was never registered"
+
+    def test_cancelled_scan_registers_later_top_level_systems(self):
+        """Top-level systems have the same problem as container children."""
+        tmp, lib = _mk_lib()
+        for name in ("Stop352 AAA", "Stop352 BBB", "Stop352 CCC"):
+            core = _books_dir(lib, name, "core")
+            for i in range(3):
+                _touch_pdf(core, f"{name}-{i}.pdf")
+
+        _scan(lib, tmp, should_stop=_stop_after(2))
+
+        for slug in ("stop352-aaa", "stop352-bbb", "stop352-ccc"):
+            assert _system(slug) is not None, f"{slug} was never registered"
+
+    def test_interrupted_scan_is_completed_by_a_later_full_scan(self):
+        """Indexing still resumes: the cancel costs books, not systems."""
+        tmp, lib = _mk_lib()
+        root = _books_dir(lib, "Stop352 Resume")
+        (root / ".parent-system-container").write_text("")
+        for edition in ("1e", "2e"):
+            _touch_pdf(_books_dir(lib, "Stop352 Resume", edition, "core"), f"{edition}.pdf")
+
+        _scan(lib, tmp, should_stop=_stop_after(1))
+        _scan(lib, tmp)
+
+        for edition in ("1e", "2e"):
+            slug = f"stop352-resume--{edition}"
+            assert _system(slug) is not None
+            assert [b.category for b in _books_for(slug, lib)] == ["core"]

--- a/backend/tests/test_indexer_ignore.py
+++ b/backend/tests/test_indexer_ignore.py
@@ -327,6 +327,49 @@ class TestSystemPruning:
         assert stats["removed_systems"] == 0
         assert {"Ign354 Scoped", "Ign354 Untouched"} <= names
 
+    def test_cancelled_scan_prunes_nothing(self):
+        """A stopped scan must not delete the systems it never got to.
+
+        Pruning keys off "this scan didn't walk here", and a cancelled scan
+        stops walking partway — so without the stop check before the prune, a
+        user hitting Cancel would lose every system below the stopping point.
+        That turns issue #352 (editions missing until the next full scan) into
+        actual data loss, so the guard is pinned here rather than left implicit.
+        """
+        tmp, lib = _mk_lib()
+        container = _mkdir(lib, "books", "Ign354 Cancelled")
+        (container / ".parent-system-container").write_text("")
+        for edition in ("2e", "3e", "4e", "5e"):
+            _touch_pdf(_mkdir(container, edition, "core"), f"{edition}-core.pdf")
+
+        _scan(lib, tmp)
+
+        def _editions():
+            db = SessionLocal()
+            try:
+                return {
+                    c.edition
+                    for c in db.query(GameSystem)
+                    .filter_by(parent_system="Ign354 Cancelled")
+                    .all()
+                }
+            finally:
+                db.close()
+
+        assert {"2e", "3e", "4e", "5e"} <= _editions()
+
+        # Cancel a few files in, so most of the container goes unwalked.
+        calls = {"n": 0}
+
+        def stop_after_a_few():
+            calls["n"] += 1
+            return calls["n"] > 3
+
+        stats = _scan(lib, tmp, should_stop=stop_after_a_few)
+
+        assert stats.get("removed_systems", 0) == 0
+        assert {"2e", "3e", "4e", "5e"} <= _editions(), "cancel must not delete systems"
+
     def test_container_with_surviving_children_is_kept(self):
         """Deleting a container would orphan the children still on disk."""
         tmp, lib = _mk_lib()

--- a/nightly.md
+++ b/nightly.md
@@ -605,6 +605,10 @@ When a system's folder is deleted — or newly excluded by a [`.grimoireignore`]
 
 Removal is deliberately cautious. A system is kept if it still holds any book that is present on disk, if it is the parent of a system that does, or if you have adapted it yourself by renaming it or giving it a description or cover. Scoped rescans (a single folder) never remove systems, since they only look at one corner of the library.
 
+### Interrupted scans
+
+Cancelling a scan (or restarting the server mid-scan) no longer leaves a partly-populated shelf. Every system folder is registered before any book is indexed, so a container's editions all appear as soon as the folder is walked, however early the scan stops — you may be missing *books* until the next full rescan, but never whole systems. Nothing is removed by an interrupted scan either.
+
 ---
 
 ## Configuration


### PR DESCRIPTION
## Summary

<!-- What does this PR do? A few sentences is fine. -->

## Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / cleanup
- [ ] Docs / configuration only

## Testing

<!-- How did you verify this works? Check all that apply. -->

- [x] Backend tests pass (`pytest -q`)
- [x] Frontend tests pass (`npm test`)
- [x] Tested manually in the browser

## Notes for reviewer

<!-- Anything that needs extra context, known limitations, or follow-up work. Delete if not needed. -->
