### PR TITLE
Fix: Declare element types on response model array fields

### DIFF
--- a/backend/routers/_json_list_coercion.py
+++ b/backend/routers/_json_list_coercion.py
@@ -1,0 +1,89 @@
+"""Coercion helpers for the free-form JSON list columns (issue #356).
+
+``books.authors``/``artists``/``genres``/``urls`` and the game-system equivalents
+are plain ``JSON`` columns, so SQLite will hand back whatever was written. Every
+write path in the app produces the declared shape — ``list[str]`` for the name
+lists, ``{label, url}`` for link lists, ``{name, url}`` for publishers — but the
+column itself does not enforce that, and a row written by an older build, a
+community add-on, or a direct DB edit can hold something else.
+
+The response models declare the real element types so generated clients get a
+usable shape instead of an untyped node. These validators run ``mode="before"``
+so an off-shape legacy row is normalized on the way out rather than raising and
+turning a plain ``GET`` into a 500.
+"""
+from typing import Any
+
+from pydantic import BaseModel
+
+
+class PublisherRef(BaseModel):
+    """A publisher on a game system: a name with an optional link.
+
+    Mirrors ``systems._schemas.PublisherEntry`` (the request-side model) for use
+    by the response models that surface the ``publishers`` column.
+    """
+
+    name: str = ""
+    url: str = ""
+
+
+def coerce_str_list(v: Any) -> Any:
+    """Normalize a value from a ``list[str]``-shaped JSON column.
+
+    Drops nulls and blanks, and stringifies scalars so a row holding e.g. a bare
+    number still serializes. A non-list is treated as a single element.
+    """
+    if v is None:
+        return []
+    items = v if isinstance(v, list) else [v]
+    out: list[str] = []
+    for item in items:
+        if item is None or isinstance(item, (dict, list)):
+            # No meaningful string form — a stringified dict is worse than a drop.
+            continue
+        text = str(item).strip()
+        if text:
+            out.append(text)
+    return out
+
+
+def coerce_link_list(v: Any) -> Any:
+    """Normalize a value from a ``list[LinkEntry]``-shaped JSON column.
+
+    A bare string becomes ``{"label": "", "url": <string>}``, which is how the
+    0004 migration already folded the legacy single-value URL columns in.
+    """
+    return _coerce_entry_list(v, "url")
+
+
+def coerce_publisher_list(v: Any) -> Any:
+    """Normalize a value from a ``list[PublisherEntry]``-shaped JSON column.
+
+    A bare string becomes ``{"name": <string>, "url": ""}``, matching what the
+    scanner writes when it infers a publisher from the folder structure.
+    """
+    return _coerce_entry_list(v, "name")
+
+
+def _coerce_entry_list(v: Any, text_key: str) -> Any:
+    """Shared body for the two object-list coercions.
+
+    ``text_key`` is the field a bare string maps onto; the entry model supplies
+    the default for the other one.
+    """
+    if v is None:
+        return []
+    items = v if isinstance(v, list) else [v]
+    out: list[Any] = []
+    for item in items:
+        if isinstance(item, dict):
+            # Already the right shape (or close enough for the model to judge).
+            out.append(item)
+            continue
+        if item is None or isinstance(item, list):
+            continue
+        text = str(item).strip()
+        if text:
+            out.append({text_key: text})
+    return out

--- a/backend/routers/books/_schemas.py
+++ b/backend/routers/books/_schemas.py
@@ -1,9 +1,10 @@
 """Pydantic schemas for the books API."""
-from typing import Any, Optional
+from typing import Optional
 
 from pydantic import BaseModel, field_validator
 
 from .._bulk_schemas import bulk_update_model
+from .._json_list_coercion import coerce_link_list, coerce_str_list
 
 
 class LinkEntry(BaseModel):
@@ -143,12 +144,12 @@ class BookDetail(BaseModel):
     page_count: Optional[int] = None
     file_size: Optional[int] = None
     # The handler coalesces every list field to `[]`.
-    authors: list[Any]
-    artists: list[Any]
-    genres: list[Any]
+    authors: list[str]
+    artists: list[str]
+    genres: list[str]
     publisher: Optional[str] = None
     publisher_url: Optional[str] = None
-    urls: list[Any]
+    urls: list[LinkEntry]
     # Coalesced with `or ""` by the handler.
     isbn: str
     version: str
@@ -173,6 +174,13 @@ class BookDetail(BaseModel):
     # a year). Null until the scanner has hashed the book.
     content_token: Optional[str] = None
     game_system: Optional[BookSystemRef] = None
+
+    # These columns are free-form JSON; normalize legacy shapes rather than
+    # failing the response. See `_json_list_coercion`.
+    _coerce_names = field_validator("authors", "artists", "genres", mode="before")(
+        coerce_str_list
+    )
+    _coerce_urls = field_validator("urls", mode="before")(coerce_link_list)
 
 
 class StatusResponse(BaseModel):

--- a/backend/routers/favorites/_schemas.py
+++ b/backend/routers/favorites/_schemas.py
@@ -1,7 +1,9 @@
 """Pydantic schemas for the favorites API."""
-from typing import Annotated, Any, Literal, Optional, Union
+from typing import Annotated, Literal, Optional, Union
 
-from pydantic import BaseModel, Field
+from pydantic import BaseModel, Field, field_validator
+
+from .._json_list_coercion import PublisherRef, coerce_publisher_list
 
 
 class FavoriteIn(BaseModel):
@@ -72,14 +74,19 @@ class FavoriteSystemItem(BaseModel):
     name: str
     # Free-form JSON on the model, and in practice a list of
     # ``{"name": ..., "url": ...}`` objects (which is what the UI renders — see
-    # `SystemFavorite.jsx` reading `p.name`). Typed `list[Any]` to match
-    # `SystemSummary.publishers` rather than `list[str]`, which rejected every
-    # real row and made the whole favorites response 500.
-    publishers: list[Any]
+    # `SystemFavorite.jsx` reading `p.name`). Declaring the element type keeps
+    # generated clients usable (issue #356); the coercion below folds a bare
+    # string into ``{"name": ...}`` so an off-shape legacy row does not 500 the
+    # whole favorites response, as a plain `list[str]` once did.
+    publishers: list[PublisherRef]
     # Null for container folders (issues #261, #262), which own no books.
     cover_book_id: Optional[str] = None
     has_cover: bool
     container_kind: str
+
+    _coerce_publishers = field_validator("publishers", mode="before")(
+        coerce_publisher_list
+    )
 
 
 class FavoriteTagItem(BaseModel):

--- a/backend/routers/systems/_schemas.py
+++ b/backend/routers/systems/_schemas.py
@@ -1,10 +1,16 @@
 """Pydantic schemas for the systems API."""
-from typing import Any, Optional
+from typing import Optional
 
 from pydantic import BaseModel, field_validator
 
 from ...services import tag_service
 from .._bulk_schemas import bulk_update_model
+from .._json_list_coercion import (
+    PublisherRef,
+    coerce_link_list,
+    coerce_publisher_list,
+    coerce_str_list,
+)
 
 
 class PublisherEntry(BaseModel):
@@ -132,12 +138,12 @@ class BookOut(BaseModel):
     file_size: Optional[int] = None
     mime_type: Optional[str] = None
     # The serializer coalesces every list field to `[]`.
-    authors: list[Any]
-    artists: list[Any]
-    genres: list[Any]
+    authors: list[str]
+    artists: list[str]
+    genres: list[str]
     publisher: Optional[str] = None
     publisher_url: Optional[str] = None
-    urls: list[Any]
+    urls: list[LinkEntry]
     # Coalesced with `or ""` by the serializer.
     isbn: str
     version: str
@@ -158,6 +164,13 @@ class BookOut(BaseModel):
     is_explicit: bool
     is_missing: bool
 
+    # These columns are free-form JSON; normalize legacy shapes rather than
+    # failing the response. See `_json_list_coercion`.
+    _coerce_names = field_validator("authors", "artists", "genres", mode="before")(
+        coerce_str_list
+    )
+    _coerce_urls = field_validator("urls", mode="before")(coerce_link_list)
+
 
 class SystemSummary(BaseModel):
     """A game system, as built by `_serializers.serialize_system_summary`."""
@@ -167,14 +180,16 @@ class SystemSummary(BaseModel):
     name: str
     slug: str
     description: Optional[str] = None
-    publishers: list[Any]
+    # `PublisherRef`, not the stricter request-side `PublisherEntry`: a stored
+    # row may predate the current shape, and a response model must not reject it.
+    publishers: list[PublisherRef]
     character_builder_url: Optional[str] = None
-    character_builder_urls: list[Any]
-    urls: list[Any]
+    character_builder_urls: list[LinkEntry]
+    urls: list[LinkEntry]
     tags: list[str]
     genre: Optional[str] = None
-    genres: list[Any]
-    dice_materials: list[Any]
+    genres: list[str]
+    dice_materials: list[str]
     # Coalesced with `or ""` by the serializer.
     system_family: str
     parent_system: str
@@ -196,6 +211,17 @@ class SystemSummary(BaseModel):
     parent_is_one_page: bool
     name_is_custom: bool
     child_count: int
+
+    # As on `BookOut` — free-form JSON columns, normalized on the way out.
+    _coerce_names = field_validator("genres", "dice_materials", mode="before")(
+        coerce_str_list
+    )
+    _coerce_urls = field_validator("urls", "character_builder_urls", mode="before")(
+        coerce_link_list
+    )
+    _coerce_publishers = field_validator("publishers", mode="before")(
+        coerce_publisher_list
+    )
 
 
 class SystemDetail(SystemSummary):

--- a/backend/routers/tags/_schemas.py
+++ b/backend/routers/tags/_schemas.py
@@ -1,7 +1,9 @@
 """Pydantic schemas for the tags API (issue #235)."""
-from typing import Annotated, Any, Literal, Optional, Union
+from typing import Annotated, Literal, Optional, Union
 
-from pydantic import BaseModel, Field
+from pydantic import BaseModel, Field, field_validator
+
+from .._json_list_coercion import PublisherRef, coerce_publisher_list
 
 
 class TagDisplayUpdate(BaseModel):
@@ -92,9 +94,13 @@ class TaggedSystemItem(BaseModel):
     name: str
     # Free-form JSON holding {"name", "url"} objects, not strings — same column
     # and same reasoning as `FavoriteSystemItem.publishers`.
-    publishers: list[Any]
+    publishers: list[PublisherRef]
     # Null for container folders and for systems with no cover-worthy book.
     cover_book_id: Optional[str] = None
+
+    _coerce_publishers = field_validator("publishers", mode="before")(
+        coerce_publisher_list
+    )
 
 
 TaggedItem = Annotated[

--- a/backend/tests/test_json_list_coercion.py
+++ b/backend/tests/test_json_list_coercion.py
@@ -1,0 +1,252 @@
+"""Tests for the response-model coercion of free-form JSON list columns (issue #356).
+
+The response models declare real element types (`list[str]`, `list[LinkEntry]`,
+`list[PublisherRef]`) so generated clients get a usable shape instead of an
+untyped node. Those columns are plain JSON though, so these tests pin the two
+halves of that contract: the declared shape survives untouched, and a row
+holding something else is normalized rather than raising — a response model that
+rejects a stored row turns a plain GET into a 500.
+"""
+from backend.routers._json_list_coercion import (
+    coerce_link_list,
+    coerce_publisher_list,
+    coerce_str_list,
+)
+from backend.routers.books._schemas import BookDetail
+from backend.routers.favorites._schemas import FavoriteSystemItem
+from backend.routers.systems._schemas import BookOut, SystemSummary
+from backend.routers.tags._schemas import TaggedSystemItem
+
+
+class TestCoerceStrList:
+    def test_passes_through_a_plain_string_list(self):
+        assert coerce_str_list(["Gygax", "Arneson"]) == ["Gygax", "Arneson"]
+
+    def test_none_becomes_empty_list(self):
+        assert coerce_str_list(None) == []
+
+    def test_stringifies_scalars_and_trims(self):
+        assert coerce_str_list([5, "  x  ", True]) == ["5", "x", "True"]
+
+    def test_drops_nulls_blanks_and_containers(self):
+        # A stringified dict/list would be worse than dropping it.
+        assert coerce_str_list([None, "", "  ", {"a": 1}, ["b"]]) == []
+
+    def test_wraps_a_bare_scalar(self):
+        assert coerce_str_list("Solo") == ["Solo"]
+
+
+class TestCoerceLinkList:
+    def test_passes_through_link_dicts(self):
+        entries = [{"label": "Publisher", "url": "https://example.com"}]
+        assert coerce_link_list(entries) == entries
+
+    def test_bare_string_becomes_a_labelless_url(self):
+        assert coerce_link_list(["https://example.com"]) == [
+            {"url": "https://example.com"}
+        ]
+
+    def test_none_becomes_empty_list(self):
+        assert coerce_link_list(None) == []
+
+    def test_drops_blanks_and_nulls(self):
+        assert coerce_link_list([None, "", "   "]) == []
+
+
+class TestCoercePublisherList:
+    def test_passes_through_publisher_dicts(self):
+        entries = [{"name": "TSR", "url": "https://tsr.example"}]
+        assert coerce_publisher_list(entries) == entries
+
+    def test_bare_string_becomes_a_named_publisher(self):
+        assert coerce_publisher_list(["TSR"]) == [{"name": "TSR"}]
+
+    def test_none_becomes_empty_list(self):
+        assert coerce_publisher_list(None) == []
+
+    def test_scanner_shape_without_url_is_preserved(self):
+        # `indexer/scan.py` writes exactly this when it infers a publisher.
+        assert coerce_publisher_list([{"name": "TSR"}]) == [{"name": "TSR"}]
+
+
+def _book_payload(**overrides):
+    payload = {
+        "id": "b1",
+        "title": "Player's Handbook",
+        "filename": "phb.pdf",
+        "relative_path": "D&D/Core/phb.pdf",
+        "authors": [],
+        "artists": [],
+        "genres": [],
+        "urls": [],
+        "isbn": "",
+        "version": "",
+        "language": "",
+        "license": "",
+        "ocr_indexed": False,
+        "ocr_pending": False,
+        "tags": [],
+        "is_explicit": False,
+        "is_missing": False,
+    }
+    payload.update(overrides)
+    return payload
+
+
+class TestBookResponseModels:
+    def test_book_out_keeps_well_formed_values(self):
+        book = BookOut.model_validate(
+            _book_payload(
+                authors=["Gygax"],
+                genres=["Fantasy"],
+                urls=[{"label": "Publisher", "url": "https://example.com"}],
+            )
+        )
+        assert book.authors == ["Gygax"]
+        assert book.genres == ["Fantasy"]
+        assert book.urls[0].label == "Publisher"
+
+    def test_book_out_normalizes_legacy_shapes(self):
+        book = BookOut.model_validate(
+            _book_payload(authors=[5, None], urls=["https://example.com"])
+        )
+        assert book.authors == ["5"]
+        assert book.urls[0].url == "https://example.com"
+        # A bare URL has no label to recover, so it comes back blank.
+        assert book.urls[0].label == ""
+
+    def test_book_detail_normalizes_legacy_shapes(self):
+        book = BookDetail.model_validate(
+            _book_payload(artists=["  Elmore  "], urls=["https://example.com"])
+        )
+        assert book.artists == ["Elmore"]
+        assert book.urls[0].url == "https://example.com"
+
+
+def _system_payload(**overrides):
+    payload = {
+        "id": "s1",
+        "name": "D&D",
+        "slug": "dnd",
+        "publishers": [],
+        "character_builder_urls": [],
+        "urls": [],
+        "tags": [],
+        "genres": [],
+        "dice_materials": [],
+        "system_family": "",
+        "parent_system": "",
+        "edition": "",
+        "license": "",
+        "book_count": 0,
+        "total_page_count": 0,
+        "has_cover": False,
+        "is_explicit": False,
+        "is_system_agnostic": False,
+        "is_one_page": False,
+        "container_kind": "",
+        "parent_name": "",
+        "parent_is_one_page": False,
+        "name_is_custom": False,
+        "child_count": 0,
+    }
+    payload.update(overrides)
+    return payload
+
+
+class TestSystemSummary:
+    def test_keeps_well_formed_values(self):
+        system = SystemSummary.model_validate(
+            _system_payload(
+                publishers=[{"name": "TSR", "url": "https://tsr.example"}],
+                genres=["Fantasy"],
+                dice_materials=["Resin"],
+                character_builder_urls=[{"label": "Builder", "url": "https://b.example"}],
+            )
+        )
+        assert system.publishers[0].name == "TSR"
+        assert system.genres == ["Fantasy"]
+        assert system.dice_materials == ["Resin"]
+        assert system.character_builder_urls[0].label == "Builder"
+
+    def test_normalizes_legacy_shapes(self):
+        system = SystemSummary.model_validate(
+            _system_payload(
+                publishers=["TSR"],
+                genres=[7],
+                urls=["https://example.com"],
+            )
+        )
+        assert system.publishers[0].name == "TSR"
+        assert system.publishers[0].url == ""
+        assert system.genres == ["7"]
+        assert system.urls[0].url == "https://example.com"
+
+    def test_scanner_publisher_shape_validates(self):
+        # `indexer/scan.py` writes `[{"name": publisher}]` with no `url` key.
+        system = SystemSummary.model_validate(
+            _system_payload(publishers=[{"name": "Wizards"}])
+        )
+        assert system.publishers[0].name == "Wizards"
+        assert system.publishers[0].url == ""
+
+
+class TestTaggedAndFavoriteSystemItems:
+    """These two once used `list[str]`, which 500'd on every real row."""
+
+    @staticmethod
+    def _favorite_payload(publishers):
+        return {
+            "item_type": "system",
+            "item_id": "s1",
+            "name": "D&D",
+            "publishers": publishers,
+            "has_cover": False,
+            "container_kind": "",
+        }
+
+    def test_favorite_system_item_accepts_publisher_objects(self):
+        item = FavoriteSystemItem.model_validate(
+            self._favorite_payload([{"name": "TSR", "url": "https://tsr.example"}])
+        )
+        assert item.publishers[0].name == "TSR"
+        assert item.publishers[0].url == "https://tsr.example"
+
+    def test_favorite_system_item_normalizes_a_bare_string(self):
+        item = FavoriteSystemItem.model_validate(self._favorite_payload(["TSR"]))
+        assert item.publishers[0].name == "TSR"
+
+    def test_tagged_system_item_accepts_publisher_objects(self):
+        item = TaggedSystemItem.model_validate(
+            {
+                "item_type": "system",
+                "item_id": "s1",
+                "name": "D&D",
+                "publishers": [{"name": "TSR"}],
+            }
+        )
+        assert item.publishers[0].name == "TSR"
+
+
+def test_openapi_arrays_all_declare_an_element_type():
+    """The regression the issue reports: `"items": {}` in the generated spec.
+
+    Guards every array property in the spec, not just the ones fixed here, so a
+    future `list[Any]` response field is caught at the point it is introduced.
+    """
+    from backend.main import app
+
+    spec = app.openapi()
+    untyped = []
+    for name, schema in spec["components"]["schemas"].items():
+        for prop, detail in (schema.get("properties") or {}).items():
+            branches = (
+                [detail]
+                if detail.get("type") == "array"
+                else [b for b in detail.get("anyOf", []) if b.get("type") == "array"]
+            )
+            for branch in branches:
+                if not branch.get("items"):
+                    untyped.append(f"{name}.{prop}")
+
+    assert untyped == []


### PR DESCRIPTION
## Summary

<!-- What does this PR do? A few sentences is fine. -->

## Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / cleanup
- [ ] Docs / configuration only

## Testing

<!-- How did you verify this works? Check all that apply. -->

- [x] Backend tests pass (`pytest -q`)
- [ ] Frontend tests pass (`npm test`)
- [ ] Tested manually in the browser

## Notes for reviewer

<!-- Anything that needs extra context, known limitations, or follow-up work. Delete if not needed. -->
