### PR TITLE
Fix: Let guests open public campaign resources

### DIFF
--- a/frontend/src/components/AppShell.jsx
+++ b/frontend/src/components/AppShell.jsx
@@ -134,11 +134,21 @@ export default function AppShell() {
           {!isGuest && <PendingInvitesBanner />}
           {isGuest ? (
             // Guests are scoped to their campaign(s); everything else redirects.
+            // The by-id detail routes are included because a campaign resource
+            // row links straight to one (issue #361) — without them the link
+            // fell through to the catch-all and bounced back to the campaign
+            // list. Library *browsing* stays closed: there is no list route
+            // here, and the backend authorises each by-id read against the
+            // guest's campaign shares (`user_can_access_resource`).
             <Routes>
               <Route path="/campaigns" element={<CampaignsView />} />
               <Route path="/campaigns/:campaignId" element={<Navigate to="overview" replace />} />
               <Route path="/campaigns/:campaignId/notes" element={<CampaignNotesView />} />
               <Route path="/campaigns/:campaignId/:tab" element={<CampaignDetailView />} />
+              <Route path="/library/book/:bookId" element={<BookReader />} />
+              <Route path="/maps/:mapId" element={<MapDetailView />} />
+              <Route path="/tokens/:tokenId" element={<TokenDetailView />} />
+              <Route path="/audio/:audioId" element={<AudioDetailView />} />
               <Route path="*" element={<Navigate to="/campaigns" replace />} />
             </Routes>
           ) : (

--- a/frontend/src/components/AppShell.test.jsx
+++ b/frontend/src/components/AppShell.test.jsx
@@ -7,8 +7,9 @@ vi.mock('../api', () => ({
   default: { get: vi.fn().mockResolvedValue({ books: 1 }) },
   settings: { getUi: vi.fn().mockResolvedValue({ hide_audio: false }) },
 }))
+let role = 'admin'
 vi.mock('../context/AuthContext', () => ({
-  useAuth: () => ({ user: { role: 'admin' }, logout: vi.fn() }),
+  useAuth: () => ({ user: { role }, logout: vi.fn() }),
 }))
 let queue = []
 vi.mock('../context/AudioPlayerContext', () => ({
@@ -52,6 +53,7 @@ const renderAt = (path) =>
 beforeEach(() => {
   vi.clearAllMocks()
   queue = []
+  role = 'admin'
   window.innerWidth = 1200 // desktop
 })
 
@@ -78,5 +80,37 @@ describe('AppShell', () => {
     queue = [{ id: 'a' }]
     renderAt('/search')
     await waitFor(() => expect(screen.getByTestId('global-player')).toBeInTheDocument())
+  })
+
+  // Issue #361: a guest clicking a public campaign resource fell through to the
+  // catch-all and was bounced back to the campaign list instead of opening it.
+  describe('guest routes', () => {
+    beforeEach(() => {
+      role = 'guest'
+    })
+
+    it.each([
+      ['/library/book/b1', 'reader'],
+      ['/maps/m1', 'map-detail'],
+      ['/tokens/t1', 'token-detail'],
+      ['/audio/a1', 'audio-detail'],
+    ])('opens %s for a guest', async (path, expected) => {
+      renderAt(path)
+      await waitFor(() => expect(screen.getByText(expected)).toBeInTheDocument())
+      expect(screen.queryByText('campaigns')).not.toBeInTheDocument()
+    })
+
+    it.each(['/library', '/maps', '/tokens', '/audio', '/search', '/settings/account'])(
+      'still redirects a guest away from %s',
+      async (path) => {
+        renderAt(path)
+        await waitFor(() => expect(screen.getByText('campaigns')).toBeInTheDocument())
+      }
+    )
+
+    it('still renders the guest campaign detail view', async () => {
+      renderAt('/campaigns/c1/overview')
+      await waitFor(() => expect(screen.getByText('campaign-detail')).toBeInTheDocument())
+    })
   })
 })

--- a/frontend/src/components/audio/AudioDetailView.jsx
+++ b/frontend/src/components/audio/AudioDetailView.jsx
@@ -1,5 +1,5 @@
-import { useState, useEffect } from 'react'
-import { useParams, useNavigate } from 'react-router-dom'
+import { useState, useEffect, useRef } from 'react'
+import { useParams, useNavigate, useLocation } from 'react-router-dom'
 import { useTranslation } from 'react-i18next'
 import { LuArrowLeft, LuDownload, LuInfo, LuChevronDown, LuMusic } from 'react-icons/lu'
 import api, { mediaUrl } from '../../api'
@@ -17,6 +17,11 @@ import useIsMobile from '../../hooks/useIsMobile'
 export default function AudioDetailView() {
   const { audioId } = useParams()
   const navigate = useNavigate()
+  const location = useLocation()
+  // See MapDetailView: guests reach this view from a campaign resource row and
+  // have no /audio browse route to go back to (issue #361).
+  const backPathRef = useRef(location.state?.from ?? null)
+  const goBack = () => (backPathRef.current ? navigate(backPathRef.current) : navigate('/audio'))
   const { t } = useTranslation()
   const isMobilePhone = useIsMobile(640)
   const [track, setTrack] = useState(null)
@@ -72,7 +77,7 @@ export default function AudioDetailView() {
         }}
       >
         <button
-          onClick={() => navigate('/audio')}
+          onClick={goBack}
           aria-label={t('audio.detail.back')}
           style={{
             background: 'none',

--- a/frontend/src/components/audio/AudioDetailView.test.jsx
+++ b/frontend/src/components/audio/AudioDetailView.test.jsx
@@ -9,9 +9,12 @@ vi.mock('../../api', () => ({
   mediaUrl: (p) => `http://localhost${p}`,
 }))
 
+let locationState = null
+const navigate = vi.fn()
 vi.mock('react-router-dom', () => ({
   useParams: () => ({ audioId: 'a1' }),
-  useNavigate: () => vi.fn(),
+  useNavigate: () => navigate,
+  useLocation: () => ({ pathname: '/audio/a1', state: locationState }),
 }))
 
 // AudioPlayer is a context controller; stub it to a button so we don't need the provider.
@@ -32,7 +35,10 @@ vi.mock('../TagSection', () => ({
   default: ({ label, onEdit }) => <button onClick={onEdit}>{`edit-${label}`}</button>,
 }))
 
-beforeEach(() => vi.clearAllMocks())
+beforeEach(() => {
+  vi.clearAllMocks()
+  locationState = null
+})
 
 const detail = (over = {}) => ({
   id: 'a1',
@@ -55,6 +61,24 @@ describe('AudioDetailView', () => {
     api.get.mockReturnValue(new Promise(() => {}))
     render(<AudioDetailView />)
     expect(document.querySelector('svg')).toBeInTheDocument()
+  })
+
+  // Issue #361: guests open tracks from a campaign and have no /audio route.
+  it('returns to the referring path when one was passed in navigation state', async () => {
+    locationState = { from: '/campaigns/c1/resources' }
+    api.get.mockResolvedValue(detail())
+    render(<AudioDetailView />)
+    await waitFor(() => expect(screen.getByText('Bardcore')).toBeInTheDocument())
+    await userEvent.click(screen.getByLabelText('Back to audio'))
+    expect(navigate).toHaveBeenCalledWith('/campaigns/c1/resources')
+  })
+
+  it('falls back to the audio list when there is no referring path', async () => {
+    api.get.mockResolvedValue(detail())
+    render(<AudioDetailView />)
+    await waitFor(() => expect(screen.getByText('Bardcore')).toBeInTheDocument())
+    await userEvent.click(screen.getByLabelText('Back to audio'))
+    expect(navigate).toHaveBeenCalledWith('/audio')
   })
 
   it('renders track metadata once loaded', async () => {

--- a/frontend/src/components/maps/MapDetailView.jsx
+++ b/frontend/src/components/maps/MapDetailView.jsx
@@ -1,5 +1,5 @@
 import { useState, useEffect, useRef, useCallback } from 'react'
-import { useParams, useNavigate } from 'react-router-dom'
+import { useParams, useNavigate, useLocation } from 'react-router-dom'
 import { useTranslation } from 'react-i18next'
 import {
   LuArrowLeft,
@@ -46,6 +46,12 @@ const navButtonStyle = {
 export default function MapDetailView() {
   const { mapId } = useParams()
   const navigate = useNavigate()
+  const location = useLocation()
+  // Return to wherever the map was opened from (a campaign resource row passes
+  // `state.from`). Guests have no /maps browse route, so a hardcoded '/maps'
+  // would bounce them off the catch-all back to the campaign list (issue #361).
+  const backPathRef = useRef(location.state?.from ?? null)
+  const goBack = () => (backPathRef.current ? navigate(backPathRef.current) : navigate('/maps'))
   const { t } = useTranslation()
   const isMobilePhone = useIsMobile(640)
   const [map, setMap] = useState(null)
@@ -150,7 +156,7 @@ export default function MapDetailView() {
         }}
       >
         <button
-          onClick={() => navigate('/maps')}
+          onClick={goBack}
           aria-label={t('maps.detail.back')}
           style={{
             background: 'none',

--- a/frontend/src/components/maps/MapDetailView.test.jsx
+++ b/frontend/src/components/maps/MapDetailView.test.jsx
@@ -10,10 +10,12 @@ vi.mock('../../api', () => ({
 }))
 
 let currentMapId = 'm2'
+let locationState = null
 const navigate = vi.fn()
 vi.mock('react-router-dom', () => ({
   useParams: () => ({ mapId: currentMapId }),
   useNavigate: () => navigate,
+  useLocation: () => ({ pathname: `/maps/${currentMapId}`, state: locationState }),
 }))
 
 vi.mock('../campaigns/AddToCampaignButton', () => ({ default: () => null }))
@@ -62,6 +64,7 @@ const mockApi = (currentId, over = {}) => {
 beforeEach(() => {
   vi.clearAllMocks()
   currentMapId = 'm2'
+  locationState = null
 })
 
 describe('MapDetailView', () => {
@@ -76,6 +79,24 @@ describe('MapDetailView', () => {
     render(<MapDetailView />)
     await waitFor(() => expect(screen.getByText('m2.png')).toBeInTheDocument())
     expect(screen.getByText('Dungeons')).toBeInTheDocument()
+  })
+
+  // Issue #361: guests open maps from a campaign and have no /maps route.
+  it('returns to the referring path when one was passed in navigation state', async () => {
+    locationState = { from: '/campaigns/c1/resources' }
+    mockApi('m2')
+    render(<MapDetailView />)
+    await waitFor(() => expect(screen.getByText('m2.png')).toBeInTheDocument())
+    await userEvent.click(screen.getByLabelText('Back to maps'))
+    expect(navigate).toHaveBeenCalledWith('/campaigns/c1/resources')
+  })
+
+  it('falls back to the maps list when there is no referring path', async () => {
+    mockApi('m2')
+    render(<MapDetailView />)
+    await waitFor(() => expect(screen.getByText('m2.png')).toBeInTheDocument())
+    await userEvent.click(screen.getByLabelText('Back to maps'))
+    expect(navigate).toHaveBeenCalledWith('/maps')
   })
 
   it('fetches siblings scoped to the folder', async () => {

--- a/frontend/src/components/tokens/TokenDetailView.jsx
+++ b/frontend/src/components/tokens/TokenDetailView.jsx
@@ -1,5 +1,5 @@
 import { useState, useEffect, useRef, useCallback } from 'react'
-import { useParams, useNavigate } from 'react-router-dom'
+import { useParams, useNavigate, useLocation } from 'react-router-dom'
 import { useTranslation } from 'react-i18next'
 import { LuArrowLeft, LuDownload, LuInfo, LuChevronDown } from 'react-icons/lu'
 import { useAuth } from '../../context/AuthContext'
@@ -22,6 +22,11 @@ import { isArchiveMedia } from '../../constants'
 export default function TokenDetailView() {
   const { tokenId } = useParams()
   const navigate = useNavigate()
+  const location = useLocation()
+  // See MapDetailView: guests reach this view from a campaign resource row and
+  // have no /tokens browse route to go back to (issue #361).
+  const backPathRef = useRef(location.state?.from ?? null)
+  const goBack = () => (backPathRef.current ? navigate(backPathRef.current) : navigate('/tokens'))
   const { t } = useTranslation()
   const { user } = useAuth()
   const isMobilePhone = useIsMobile(640)
@@ -121,7 +126,7 @@ export default function TokenDetailView() {
         }}
       >
         <button
-          onClick={() => navigate('/tokens')}
+          onClick={goBack}
           aria-label={t('tokens.detail.back')}
           style={{
             background: 'none',

--- a/frontend/src/components/tokens/TokenDetailView.test.jsx
+++ b/frontend/src/components/tokens/TokenDetailView.test.jsx
@@ -10,10 +10,12 @@ vi.mock('../../api', () => ({
 }))
 
 let currentTokenId = 't2'
+let locationState = null
 const navigate = vi.fn()
 vi.mock('react-router-dom', () => ({
   useParams: () => ({ tokenId: currentTokenId }),
   useNavigate: () => navigate,
+  useLocation: () => ({ pathname: `/tokens/${currentTokenId}`, state: locationState }),
 }))
 
 vi.mock('../../context/AuthContext', () => ({
@@ -62,6 +64,7 @@ const mockApi = (currentId, over = {}) => {
 beforeEach(() => {
   vi.clearAllMocks()
   currentTokenId = 't2'
+  locationState = null
 })
 
 describe('TokenDetailView', () => {
@@ -76,6 +79,24 @@ describe('TokenDetailView', () => {
     render(<TokenDetailView />)
     await waitFor(() => expect(screen.getByText('t2.png')).toBeInTheDocument())
     expect(screen.getByText('Goblins')).toBeInTheDocument()
+  })
+
+  // Issue #361: guests open tokens from a campaign and have no /tokens route.
+  it('returns to the referring path when one was passed in navigation state', async () => {
+    locationState = { from: '/campaigns/c1/resources' }
+    mockApi('t2')
+    render(<TokenDetailView />)
+    await waitFor(() => expect(screen.getByText('t2.png')).toBeInTheDocument())
+    await userEvent.click(screen.getByLabelText('Back to tokens'))
+    expect(navigate).toHaveBeenCalledWith('/campaigns/c1/resources')
+  })
+
+  it('falls back to the tokens list when there is no referring path', async () => {
+    mockApi('t2')
+    render(<TokenDetailView />)
+    await waitFor(() => expect(screen.getByText('t2.png')).toBeInTheDocument())
+    await userEvent.click(screen.getByLabelText('Back to tokens'))
+    expect(navigate).toHaveBeenCalledWith('/tokens')
   })
 
   it('renders the archive placeholder instead of an <img> for an archive token', async () => {


### PR DESCRIPTION
## Summary

<!-- What does this PR do? A few sentences is fine. -->

## Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / cleanup
- [ ] Docs / configuration only

## Testing

<!-- How did you verify this works? Check all that apply. -->

- [x] Backend tests pass (`pytest -q`)
- [x] Frontend tests pass (`npm test`)
- [x] Tested manually in the browser

## Notes for reviewer

<!-- Anything that needs extra context, known limitations, or follow-up work. Delete if not needed. -->
