### PR TITLE
Fix: Let script-backed add-ons declare search without ranking fields

### DIFF
--- a/backend/addons/manifest.py
+++ b/backend/addons/manifest.py
@@ -206,7 +206,11 @@ class SearchField(_Strict):
 
 
 class SearchSpec(_Strict):
-    fields: list[SearchField] = Field(min_length=1)
+    # Ranking rules for a declaratively-fetched document.  A script-backed
+    # add-on does its own searching, so it may declare a ``search`` block purely
+    # to carry ``identity_pattern`` and leave this empty; the requirement is
+    # enforced on the manifest, where ``source`` is visible.
+    fields: list[SearchField] = Field(default_factory=list)
     min_score: float = Field(default=DEFAULT_MIN_SCORE, ge=0, le=1)
     limit: int = Field(default=DEFAULT_SEARCH_LIMIT, ge=1, le=MAX_SEARCH_LIMIT)
     label: Optional[ValueSpec] = None
@@ -285,7 +289,19 @@ class MappingEntry(_Strict):
         return self
 
 
-class AddonManifest(_Strict):
+class AddonManifest(BaseModel):
+    """A single add-on definition.
+
+    Deliberately *not* ``_Strict``: the community repo may add top-level fields
+    ahead of this client, and an older server must skip what it does not
+    understand rather than refuse to load the add-on entirely — the same
+    reasoning ``IndexEntry`` documents. Typo protection is retained where the
+    schema is intricate: every nested spec stays strict, and ``map`` keys are
+    checked against the per-target allowlist below.
+    """
+
+    model_config = ConfigDict(extra="ignore")
+
     id: str
     name: str
     version: str
@@ -338,8 +354,15 @@ class AddonManifest(_Strict):
     def needs_a_backend(self) -> "AddonManifest":
         if self.source is None and self.script is None:
             raise ValueError("manifest needs either 'source' or 'script'")
-        if self.source is not None and self.search is None:
-            raise ValueError("a 'source' manifest needs a 'search' block")
+        if self.source is not None:
+            if self.search is None:
+                raise ValueError("a 'source' manifest needs a 'search' block")
+            if not self.search.fields:
+                # Only the declarative path ranks records itself, so this is
+                # required here rather than on SearchSpec — a script-backed
+                # add-on has nothing to rank and would otherwise be forced to
+                # declare a field it never uses just to enable link pasting.
+                raise ValueError("a 'source' manifest needs 'search.fields'")
         return self
 
     @property

--- a/backend/tests/test_addons_registry.py
+++ b/backend/tests/test_addons_registry.py
@@ -72,10 +72,45 @@ class TestManifestValidation:
     def test_valid_manifest_loads(self):
         assert AddonManifest(**VALID).id == "demo"
 
-    def test_unknown_keys_are_rejected(self):
-        """A typo must be an error, not a silently ignored no-op."""
-        with pytest.raises(ValidationError):
-            AddonManifest(**{**VALID, "sauce": {}})
+    def test_unknown_top_level_keys_are_ignored(self):
+        """The community repo may add fields ahead of this client.
+
+        An older server must skip what it does not understand rather than
+        refuse the whole add-on, which would make any new manifest field a
+        breaking change for everyone not yet upgraded.
+        """
+        manifest = AddonManifest(**{**VALID, "author": "Someone", "sauce": {}})
+        assert manifest.id == "demo"
+
+    def test_unknown_keys_inside_a_nested_spec_are_rejected(self):
+        """Leniency stops at the top level: a typo here is still an error."""
+        with pytest.raises(ValidationError, match="tymeout"):
+            AddonManifest(
+                **{**VALID, "source": None, "script": {"entry": "x.py", "tymeout": 60}}
+            )
+
+    def test_script_addon_may_declare_search_without_fields(self):
+        """A script-backed add-on searches for itself, so it has nothing to rank.
+
+        It still needs a ``search`` block to carry ``identity_pattern``, which
+        is what enables the "paste a link or ID" input.
+        """
+        manifest = AddonManifest(
+            **{
+                **VALID,
+                "source": None,
+                "script": {"entry": "demo.py"},
+                "search": {"identity_pattern": r"example\.com/(\d+)"},
+            }
+        )
+        assert manifest.search is not None
+        assert manifest.search.fields == []
+        assert manifest.requires_script
+
+    def test_source_addon_still_requires_search_fields(self):
+        """The declarative path ranks records itself, so it cannot go without."""
+        with pytest.raises(ValidationError, match="search.fields"):
+            AddonManifest(**{**VALID, "search": {"identity": {"from": "name"}}})
 
     def test_map_to_an_unknown_field_is_rejected(self):
         with pytest.raises(ValidationError, match="not valid for target"):


### PR DESCRIPTION
## Summary

<!-- What does this PR do? A few sentences is fine. -->

## Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / cleanup
- [ ] Docs / configuration only

## Testing

<!-- How did you verify this works? Check all that apply. -->

- [x] Backend tests pass (`pytest -q`)
- [x] Frontend tests pass (`npm test`)
- [x] Tested manually in the browser

## Notes for reviewer

<!-- Anything that needs extra context, known limitations, or follow-up work. Delete if not needed. -->
