### PR TITLE
Fix: Stop indexing folder cover artwork as a book

### DIFF
--- a/backend/indexer/__init__.py
+++ b/backend/indexer/__init__.py
@@ -104,6 +104,7 @@ from .metadata import (  # noqa: E402,F401
     _find_opf_meta,
     _has_embedded_art,
     _read_audio_metadata,
+    is_folder_cover_name,
     parse_opf_metadata,
     resolve_collection_dir,
     resolve_scope,

--- a/backend/indexer/books.py
+++ b/backend/indexer/books.py
@@ -54,7 +54,12 @@ from .hashing import (
     hash_file,
     signature_matches,
 )
-from .metadata import _apply_opf_to_book, _find_opf_meta, parse_opf_metadata
+from .metadata import (
+    _apply_opf_to_book,
+    _find_opf_meta,
+    is_folder_cover_name,
+    parse_opf_metadata,
+)
 from .systems import _SystemFolder, _register_system, _resolve_system_folder
 from .thumbnails import archive_ext, archive_mime
 from ..models import Book, GameSystem
@@ -132,7 +137,13 @@ def _scan_books(ctx: _ScanContext, books_dir: Path) -> None:
         # subtree; otherwise walk the whole system.
         walk_root = ctx.scope_dir if scoped else system_dir
         if _scan_books_in_system(
-            ctx, system, folder.name, system_category_off, is_special, walk_root
+            ctx,
+            system,
+            folder.name,
+            system_category_off,
+            is_special,
+            walk_root,
+            system_root=system_dir,
         ):
             return
 
@@ -345,6 +356,9 @@ def _scan_one_page_loose_files(
         ext = path.suffix.lower()
         if ext not in DOC_EXTS and ext not in IMAGE_EXTS and not archive_ext(path.name):
             continue
+        # The container's own shelf artwork, not a one-page game (issue #372).
+        if is_folder_cover_name(path.name):
+            continue
         stem = _title_from_filename(path.name)
         child_folder = _SystemFolder(
             path=path.parent,
@@ -389,6 +403,7 @@ def _scan_books_in_system(
     recurse: bool = True,
     only_filename: str | None = None,
     system_depth: int = 2,
+    system_root: Path | None = None,
 ) -> bool:
     """Walk one system's tree and register its books. Returns True if stop requested.
 
@@ -400,10 +415,16 @@ def _scan_books_in_system(
     ``only_filename`` further narrows it to a single file, for the one-page
     container's loose-file-as-a-system case. ``system_depth`` tells category
     inference how deep the system root sits (3 for a container's children).
+
+    ``system_root`` is the folder whose ``cover.*``/``folder.*`` image was
+    claimed as the system's shelf artwork, so the walk can skip that file rather
+    than registering it as a book too (issue #372). It defaults to ``walk_root``
+    and only differs when the walk is narrowed to a subtree by a scoped rescan.
     """
     session = ctx.session
     ignore = ctx.ignore
     stats = ctx.stats
+    cover_root = os.path.normpath(str(system_root if system_root is not None else walk_root))
     for root, dirs, files in os.walk(walk_root):
         dirs[:] = _prune_dirs(root, dirs, ignore)
         if not recurse:
@@ -439,6 +460,12 @@ def _scan_books_in_system(
 
             if filename in opf_cover_filenames:
                 logger.debug(f"Skipping OPF cover image: {filepath}")
+                continue
+
+            # The folder-cover convention claims a cover.*/folder.* image at the
+            # system root as shelf artwork; it is not also a book (issue #372).
+            if os.path.normpath(root) == cover_root and is_folder_cover_name(filename):
+                logger.debug(f"Skipping folder cover image: {filepath}")
                 continue
 
             ctx.scanned["books"] += 1

--- a/backend/indexer/metadata.py
+++ b/backend/indexer/metadata.py
@@ -105,14 +105,24 @@ def _extract_embedded_art(filepath: str) -> Optional[Tuple[bytes, str]]:
     return None
 
 
+def is_folder_cover_name(filename: str) -> bool:
+    """True if ``filename`` is a folder-cover image (``cover.*`` / ``folder.*``).
+
+    The folder-cover convention claims such a file as shelf artwork for the
+    folder it sits in, so collection walks skip it rather than registering it as
+    an item of its own (issue #372).
+    """
+    p = Path(filename)
+    return p.stem.lower() in _AUDIO_COVER_STEMS and p.suffix.lower() in IMAGE_EXTS
+
+
 def _find_folder_artwork(folder: str) -> Optional[str]:
     """Return the path of a ``cover.*`` / ``folder.*`` image in ``folder``, or None."""
     try:
         for entry in os.scandir(folder):
             if not entry.is_file():
                 continue
-            p = Path(entry.name)
-            if p.stem.lower() in _AUDIO_COVER_STEMS and p.suffix.lower() in IMAGE_EXTS:
+            if is_folder_cover_name(entry.name):
                 return entry.path
     except OSError:
         # Folder unreadable/missing → no artwork; genuinely expected, not an error.

--- a/backend/migrations/versions/0024_drop_folder_cover_books.py
+++ b/backend/migrations/versions/0024_drop_folder_cover_books.py
@@ -1,0 +1,93 @@
+"""remove books created from folder cover artwork (#372)
+
+A ``cover.*`` / ``folder.*`` image at a system root is shelf artwork, but the
+books walk also registered it as a 1-page book, so every system with folder
+artwork grew a bogus "cover" entry. The walk now skips those files; this clears
+the rows earlier scans already wrote.
+
+Only rows whose path *is* artwork some system actually claimed (a
+``game_systems.folder_cover_path`` value) are removed, so a real book that
+happens to be named ``cover.pdf`` — or a ``cover.jpg`` deeper in the tree, which
+the folder-cover convention never picked up — is left alone. Bookmarks,
+favorites, tags, and FTS rows for the deleted books go with them.
+
+Revision ID: b4d90c2e75af
+Revises: c72e5b81a934
+Create Date: 2026-08-21 00:00:00.000000+00:00
+
+"""
+from typing import Sequence, Union
+
+from alembic import op
+from sqlalchemy import inspect, text
+
+
+revision: str = "b4d90c2e75af"
+down_revision: Union[str, None] = "c72e5b81a934"
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    bind = op.get_bind()
+    insp = inspect(bind)
+    tables = set(insp.get_table_names())
+    if "books" not in tables or "game_systems" not in tables:
+        return
+    if "folder_cover_path" not in {c["name"] for c in insp.get_columns("game_systems")}:
+        return
+
+    covers = [
+        path
+        for (path,) in bind.execute(
+            text("SELECT folder_cover_path FROM game_systems WHERE folder_cover_path <> ''")
+        ).fetchall()
+        if path
+    ]
+    if not covers:
+        return
+
+    # folder_cover_path is library-relative; Book.filepath is absolute, so match
+    # on the tail. Separators are normalised because a library written on one
+    # platform can be read on the other.
+    tails = {"/" + path.replace("\\", "/") for path in covers}
+
+    # Matched by path rather than by owning system: under a one-page container
+    # the artwork was registered against a *child* system invented for it
+    # ("Cover"), not the container row holding folder_cover_path. That empty
+    # child is pruned by the next full scan once its only book is gone.
+    doomed = [
+        book_id
+        for book_id, filepath in bind.execute(
+            text("SELECT id, filepath FROM books WHERE filepath IS NOT NULL")
+        ).fetchall()
+        if any((filepath or "").replace("\\", "/").endswith(tail) for tail in tails)
+    ]
+
+    if not doomed:
+        return
+
+    for book_id in doomed:
+        if "bookmarks" in tables:
+            bind.execute(text("DELETE FROM bookmarks WHERE book_id = :id"), {"id": book_id})
+        if "favorites" in tables:
+            bind.execute(
+                text("DELETE FROM favorites WHERE item_type = 'book' AND item_id = :id"),
+                {"id": book_id},
+            )
+        if "resource_tags" in tables:
+            bind.execute(
+                text(
+                    "DELETE FROM resource_tags "
+                    "WHERE resource_type = 'book' AND resource_id = :id"
+                ),
+                {"id": book_id},
+            )
+        if "book_search" in tables:
+            bind.execute(text("DELETE FROM book_search WHERE book_id = :id"), {"id": book_id})
+        bind.execute(text("DELETE FROM books WHERE id = :id"), {"id": book_id})
+
+
+def downgrade() -> None:
+    # The rows were never meant to exist; there is nothing to restore.
+    pass

--- a/backend/tests/test_db_migrations.py
+++ b/backend/tests/test_db_migrations.py
@@ -503,3 +503,152 @@ class TestExpandMetadataMigration:
         assert json.loads(g[0]) == ["Fantasy"]
         assert json.loads(g[1])[0]["url"] == "http://b"
         assert json.loads(b[0])[0]["url"] == "http://p"
+
+
+class TestFolderCoverBookCleanup:
+    """Migration b4d90c2e75af: drop books that were really shelf artwork (#372)."""
+
+    def _seed(self):
+        """A DB at the revision before the cleanup, holding one system whose
+        folder artwork was double-registered as a book, plus two look-alikes
+        that must survive: a cover image in a *different* folder, and a genuine
+        book whose title happens to be "cover"."""
+        path = os.path.join(tempfile.mkdtemp(), "covers.db")
+        engine = create_engine(f"sqlite:///{path}")
+        with engine.connect() as conn:
+            from alembic import command
+
+            cfg = _alembic_config(conn)
+            command.upgrade(cfg, "c72e5b81a934")
+            conn.commit()
+        with engine.connect() as conn:
+            conn.execute(
+                text(
+                    "INSERT INTO game_systems (id, name, slug, folder_cover_path) "
+                    "VALUES ('s1','Test System','test-system','books/Test System/cover.jpg')"
+                )
+            )
+            rows = [
+                # The bogus row: exactly the file claimed as artwork.
+                ("bogus", "cover", "cover.jpg", "/lib/books/Test System/cover.jpg"),
+                # Same name, deeper in the tree — a real image book.
+                ("deep", "cover", "cover.jpg", "/lib/books/Test System/handouts/cover.jpg"),
+                # A real PDF that merely shares the title.
+                ("pdf", "cover", "cover.pdf", "/lib/books/Test System/cover.pdf"),
+            ]
+            for bid, title, filename, filepath in rows:
+                conn.execute(
+                    text(
+                        "INSERT INTO books (id, title, filename, filepath, relative_path, "
+                        "game_system_id) VALUES (:id,:t,:f,:p,:r,'s1')"
+                    ),
+                    {"id": bid, "t": title, "f": filename, "p": filepath, "r": filepath[5:]},
+                )
+            # A one-page container: the artwork was registered as a book on a
+            # *child* system invented for it, not on the row holding the cover.
+            conn.execute(
+                text(
+                    "INSERT INTO game_systems (id, name, slug, folder_cover_path) VALUES "
+                    "('s2','One-Page RPGs','one-page-rpgs','books/one-page-rpgs/cover.jpg')"
+                )
+            )
+            conn.execute(
+                text(
+                    "INSERT INTO game_systems (id, name, slug, parent_id) "
+                    "VALUES ('s3','Cover','one-page-rpgs--cover','s2')"
+                )
+            )
+            conn.execute(
+                text(
+                    "INSERT INTO books (id, title, filename, filepath, relative_path, "
+                    "game_system_id) VALUES ('onepage','cover','cover.jpg',"
+                    "'/lib/books/one-page-rpgs/cover.jpg','books/one-page-rpgs/cover.jpg','s3')"
+                )
+            )
+            conn.execute(
+                text(
+                    "INSERT INTO users (id, username, role) VALUES ('u1','u','admin')"
+                )
+            )
+            conn.execute(
+                text(
+                    "INSERT INTO bookmarks (id, user_id, book_id, page_number) "
+                    "VALUES ('bm1','u1','bogus',1)"
+                )
+            )
+            conn.execute(
+                text(
+                    "INSERT INTO favorites (id, user_id, item_type, item_id) "
+                    "VALUES ('fv1','u1','book','bogus')"
+                )
+            )
+            conn.commit()
+        engine.dispose()
+        return path
+
+    def test_the_artwork_row_is_deleted_and_look_alikes_are_kept(self):
+        path = self._seed()
+        init_db(path)
+
+        engine = create_engine(f"sqlite:///{path}")
+        with engine.connect() as conn:
+            ids = {r[0] for r in conn.execute(text("SELECT id FROM books")).fetchall()}
+        assert ids == {"deep", "pdf"}
+
+    def test_a_one_page_containers_artwork_row_is_deleted_too(self):
+        """It hangs off an invented child system, so it cannot be found by
+        joining on the row that holds folder_cover_path."""
+        path = self._seed()
+        init_db(path)
+
+        engine = create_engine(f"sqlite:///{path}")
+        with engine.connect() as conn:
+            gone = conn.execute(
+                text("SELECT count(*) FROM books WHERE id='onepage'")
+            ).scalar()
+        assert gone == 0
+
+    def test_the_deleted_book_leaves_no_bookmarks_or_favorites_behind(self):
+        path = self._seed()
+        init_db(path)
+
+        engine = create_engine(f"sqlite:///{path}")
+        with engine.connect() as conn:
+            bookmarks = conn.execute(
+                text("SELECT count(*) FROM bookmarks WHERE book_id='bogus'")
+            ).scalar()
+            favorites = conn.execute(
+                text("SELECT count(*) FROM favorites WHERE item_id='bogus'")
+            ).scalar()
+        assert (bookmarks, favorites) == (0, 0)
+
+    def test_the_system_keeps_its_folder_cover(self):
+        """The artwork itself is untouched — only the duplicate book row goes."""
+        path = self._seed()
+        init_db(path)
+
+        engine = create_engine(f"sqlite:///{path}")
+        with engine.connect() as conn:
+            cover = conn.execute(
+                text("SELECT folder_cover_path FROM game_systems WHERE id='s1'")
+            ).scalar()
+        assert cover == "books/Test System/cover.jpg"
+
+    def test_a_library_with_no_folder_covers_is_untouched(self):
+        path = _fresh_db()
+        engine = create_engine(f"sqlite:///{path}")
+        with engine.connect() as conn:
+            conn.execute(
+                text(
+                    "INSERT INTO books (id, title, filename, filepath, relative_path) "
+                    "VALUES ('b1','B','b.pdf','/b.pdf','b.pdf')"
+                )
+            )
+            conn.commit()
+        engine.dispose()
+
+        init_db(path)  # re-running must leave the row alone
+
+        engine = create_engine(f"sqlite:///{path}")
+        with engine.connect() as conn:
+            assert conn.execute(text("SELECT count(*) FROM books")).scalar() == 1

--- a/backend/tests/test_indexer_containers.py
+++ b/backend/tests/test_indexer_containers.py
@@ -216,6 +216,21 @@ class TestOnePageContainer:
         _scan(lib, tmp)
         return tmp, lib
 
+    def test_a_loose_cover_image_is_artwork_not_a_system(self):
+        """Issue #372: ``one-page-rpgs/cover.jpg`` is the shelf's artwork, so it
+        must not also become a system named "Cover" holding one book."""
+        tmp, lib = _mk_lib()
+        root = _books_dir(lib, "one-page-rpgs")
+        _touch_pdf(root, "honey-heist.pdf")
+        (root / "cover.jpg").write_bytes(b"\xff\xd8\xff\xe0")
+        _scan(lib, tmp)
+
+        # The artwork still applies to the container...
+        assert _system("one-page-rpgs").folder_cover_path == "books/one-page-rpgs/cover.jpg"
+        # ...without becoming a system, or a book on the container's own row.
+        assert _system("one-page-rpgs--cover") is None
+        assert _books_for("one-page-rpgs", lib) == []
+
     def test_container_marked_one_page(self):
         self._build()
         container = _system("one-page-rpgs")

--- a/backend/tests/test_indexer_media_systems.py
+++ b/backend/tests/test_indexer_media_systems.py
@@ -15,7 +15,7 @@ from unittest.mock import patch
 from backend.config import SessionLocal
 from backend.indexer import scan_library
 from backend.indexer.categories import slugify
-from backend.models import Audio, GameSystem, GenericMap
+from backend.models import Audio, Book, GameSystem, GenericMap
 
 
 def _mk_lib() -> tuple[str, Path]:
@@ -362,5 +362,60 @@ class TestSystemRegistrationResilience:
         db = SessionLocal()
         try:
             assert db.query(GameSystem).filter_by(id=system_id).first().folder_cover_path == ""
+        finally:
+            db.close()
+
+    def test_the_cover_file_is_not_also_registered_as_a_book(self):
+        """Issue #372: shelf artwork is artwork, not a one-page "cover" book."""
+        tmp, lib = _mk_lib()
+        stamp = uuid.uuid4().hex[:6]
+        root = lib / "books" / f"CoverBook-{stamp}"
+        (root / "core").mkdir(parents=True)
+        (root / "core" / "tome.pdf").write_bytes(b"%PDF-1.4")
+        (root / "cover.jpg").write_bytes(b"\xff\xd8\xff\xe0")
+
+        _scan(lib, tmp)
+        db = SessionLocal()
+        try:
+            system = db.query(GameSystem).filter_by(name=f"CoverBook-{stamp}").first()
+            assert system.folder_cover_path  # artwork still applied
+            titles = [b.title for b in db.query(Book).filter_by(game_system_id=system.id)]
+            assert titles == ["tome"]
+        finally:
+            db.close()
+
+    def test_a_cover_image_below_the_system_root_is_still_a_book(self):
+        """The convention only claims the system root, so a category-folder
+        ``cover.jpg`` remains an ordinary image book."""
+        tmp, lib = _mk_lib()
+        stamp = uuid.uuid4().hex[:6]
+        root = lib / "books" / f"DeepCover-{stamp}"
+        (root / "handouts").mkdir(parents=True)
+        (root / "handouts" / "cover.jpg").write_bytes(b"\xff\xd8\xff\xe0")
+
+        _scan(lib, tmp)
+        db = SessionLocal()
+        try:
+            system = db.query(GameSystem).filter_by(name=f"DeepCover-{stamp}").first()
+            assert system.folder_cover_path == ""
+            titles = [b.title for b in db.query(Book).filter_by(game_system_id=system.id)]
+            assert titles == ["cover"]
+        finally:
+            db.close()
+
+    def test_a_real_book_named_cover_pdf_at_the_root_is_kept(self):
+        """Only image extensions are folder artwork; ``cover.pdf`` is a book."""
+        tmp, lib = _mk_lib()
+        stamp = uuid.uuid4().hex[:6]
+        root = lib / "books" / f"CoverPdf-{stamp}"
+        root.mkdir(parents=True)
+        (root / "cover.pdf").write_bytes(b"%PDF-1.4")
+
+        _scan(lib, tmp)
+        db = SessionLocal()
+        try:
+            system = db.query(GameSystem).filter_by(name=f"CoverPdf-{stamp}").first()
+            titles = [b.title for b in db.query(Book).filter_by(game_system_id=system.id)]
+            assert titles == ["cover"]
         finally:
             db.close()

--- a/backend/tests/test_indexer_opf.py
+++ b/backend/tests/test_indexer_opf.py
@@ -494,9 +494,18 @@ class TestCalibrePerBookFolderStructure:
 
         self._scan()
 
+        # Scoped to this test's library: the module-wide DB is shared, and a
+        # cover.jpg registered by another test's library is not this one's.
         db = SessionLocal()
         try:
-            cover_book = db.query(Book).filter(Book.filename == "cover.jpg").first()
+            cover_book = (
+                db.query(Book)
+                .filter(
+                    Book.filename == "cover.jpg",
+                    Book.filepath.like(f"{self.lib}%"),
+                )
+                .first()
+            )
         finally:
             db.close()
         assert cover_book is None

--- a/nightly.md
+++ b/nightly.md
@@ -392,7 +392,7 @@ books/
     └── 5e/
 ```
 
-Or set one from the container's page (**Cover image**, GM/admin only) - upload a file, paste an image from your clipboard, or pick one Grimoire already has (see [Setting images](#setting-images)). A `cover.*`/`folder.*` file in the library folder takes precedence over an upload, and both beat the book thumbnail an ordinary system falls back to. This works for any system, not just containers.
+Or set one from the container's page (**Cover image**, GM/admin only) - upload a file, paste an image from your clipboard, or pick one Grimoire already has (see [Setting images](#setting-images)). A `cover.*`/`folder.*` file in the library folder takes precedence over an upload, and both beat the book thumbnail an ordinary system falls back to. This works for any system, not just containers. A `cover.*`/`folder.*` image at a system's folder root is artwork only - it is not also indexed as a book.
 
 **Grouping toggle.** Containers are a way to organize the grid, not a cage. The **Group collections** switch beside the "Your Collection" heading (shown only when you actually have a container) flattens them: the container cards drop out and their child systems take their place, so you get a plain A-Z list of every real system with the usual sorting and filters applied. Switch it back on to return to the drill-down view. Your choice is remembered across sessions.
 


### PR DESCRIPTION
## Summary

<!-- What does this PR do? A few sentences is fine. -->

## Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / cleanup
- [ ] Docs / configuration only

## Testing

<!-- How did you verify this works? Check all that apply. -->

- [x] Backend tests pass (`pytest -q`)
- [x] Frontend tests pass (`npm test`)
- [x] Tested manually in the browser

## Notes for reviewer

<!-- Anything that needs extra context, known limitations, or follow-up work. Delete if not needed. -->
