### PR TITLE
Fix: Fix non-authors being unable to save wiki pages they may edit

### DIFF
--- a/backend/routers/campaigns/wiki.py
+++ b/backend/routers/campaigns/wiki.py
@@ -709,7 +709,12 @@ def update_page(
         page.session_date = data.session_date or None
     if data.page_type is not None and data.page_type in ("note", "session"):
         page.page_type = data.page_type
-    if data.parent_id is not None:
+    # Only an actual *re-nest* is validated. _resolve_parent requires write
+    # access to the destination, so re-checking a parent the page already sits
+    # under would refuse an edit to a child whose parent the user cannot write —
+    # a group page under a GM-only parent, say — even though nothing moved
+    # (issue #386, same shape as the sharing gate below).
+    if data.parent_id is not None and (data.parent_id or None) != page.parent_id:
         page.parent_id = _resolve_parent(
             db,
             campaign_id,
@@ -724,8 +729,6 @@ def update_page(
         page.icon_color = data.icon_color or None
 
     if (data.shared_user_ids is not None or data.shared_write_user_ids is not None):
-        if not is_author:
-            raise HTTPException(403, "Only the page's author can change its sharing")
         # Either list alone is a full replacement of the pair, so fall back to
         # what's stored for whichever one the client didn't send.
         existing = db.query(WikiPageShare).filter_by(page_id=page.id).all()
@@ -739,7 +742,28 @@ def update_page(
             if data.shared_write_user_ids is not None
             else [s.user_id for s in existing if s.can_write]
         )
-        _apply_shares(db, page, reads, writes)
+        # Gate on an actual *change*, not on the fields merely being present:
+        # the editor resends both lists on every save, so a non-author with
+        # legitimate write access (a group page, or a members page they were
+        # granted write on) would otherwise be refused their own edit — the
+        # exact collaboration issue #233 opened up (issue #386). The visibility
+        # check above compares against the stored value for the same reason.
+        #
+        # Normalise both sides the way _apply_shares stores them before
+        # comparing: write implies read, and the author never gets a row of
+        # their own. Without that, a client faithfully echoing back what it was
+        # given reads as a diff and trips the 403 it was meant to avoid.
+        def _normalised(read_ids, write_ids):
+            writers = set(write_ids or [])
+            readers = (set(read_ids or []) | writers) - {page.created_by_id}
+            return readers, writers - {page.created_by_id}
+
+        if _normalised(reads, writes) != _normalised(
+            [s.user_id for s in existing], [s.user_id for s in existing if s.can_write]
+        ):
+            if not is_author:
+                raise HTTPException(403, "Only the page's author can change its sharing")
+            _apply_shares(db, page, reads, writes)
     # If no longer members-visibility, drop any stale shares.
     if page.visibility != "members":
         db.query(WikiPageShare).filter_by(page_id=page.id).delete()

--- a/backend/tests/test_campaign_wiki.py
+++ b/backend/tests/test_campaign_wiki.py
@@ -335,12 +335,20 @@ class TestWikiVisibility:
             headers=player_headers,
         )
         assert resp.status_code == 403
+        # A share list that differs from what's stored is refused as well. (Note
+        # a *matching* list is a no-op and does save — see issue #386.)
         resp = client.patch(
             f"/api/campaigns/{cid}/wiki/{page['id']}",
-            json={"shared_user_ids": []},
+            json={"shared_user_ids": [], "shared_write_user_ids": ["someone-else"]},
             headers=player_headers,
         )
         assert resp.status_code == 403
+        assert (
+            client.get(f"/api/campaigns/{cid}/wiki/{page['id']}", headers=gm_headers).json()[
+                "visibility"
+            ]
+            == "group"
+        )
 
     def test_member_cannot_delete_a_page_they_did_not_author(
         self, client, gm_headers, player_headers, campaign_with_member
@@ -386,6 +394,125 @@ class TestWikiVisibility:
         assert client.patch(
             f"/api/campaigns/{cid}/wiki/{rw['id']}", json={"body": "yes"}, headers=player_headers
         ).status_code == 200
+
+    def test_writer_resending_unchanged_shares_may_still_save(
+        self, client, gm_headers, player_headers, player_id, campaign_with_member
+    ):
+        # The editor resends classification only on change, but an older client
+        # (or any caller) echoing back the stored lists is a no-op, not an
+        # attempt to reclassify, and must not cost them their edit (issue #386).
+        cid = campaign_with_member
+        rw = _create(
+            client, gm_headers, cid, title="Writable", visibility="members",
+            shared_write_user_ids=[player_id],
+        ).json()
+        resp = client.patch(
+            f"/api/campaigns/{cid}/wiki/{rw['id']}",
+            json={
+                "body": "player edit",
+                "visibility": "members",
+                "shared_user_ids": [player_id],
+                "shared_write_user_ids": [player_id],
+            },
+            headers=player_headers,
+        )
+        assert resp.status_code == 200
+        detail = client.get(f"/api/campaigns/{cid}/wiki/{rw['id']}", headers=gm_headers).json()
+        assert detail["body"] == "player edit"
+        # The share rows are untouched by the pass-through save.
+        assert detail["shared_write_user_ids"] == [player_id]
+
+    def test_group_page_save_carrying_empty_shares_is_allowed(
+        self, client, gm_headers, player_headers, campaign_with_member
+    ):
+        # The issue #233 case: a player contributing to a GM-authored group
+        # page. The page has no shares, and the payload carries [] for both.
+        cid = campaign_with_member
+        page = _create(client, gm_headers, cid, title="Party KB", visibility="group").json()
+        resp = client.patch(
+            f"/api/campaigns/{cid}/wiki/{page['id']}",
+            json={
+                "body": "player contribution",
+                "visibility": "group",
+                "shared_user_ids": [],
+                "shared_write_user_ids": [],
+            },
+            headers=player_headers,
+        )
+        assert resp.status_code == 200
+
+    def test_non_author_still_cannot_actually_change_shares(
+        self, client, gm_headers, player_headers, player_id, admin_id, campaign_with_member
+    ):
+        # The no-op allowance must not become a way in: a real diff to the share
+        # lists is still the author's alone.
+        cid = campaign_with_member
+        rw = _create(
+            client, gm_headers, cid, title="Writable", visibility="members",
+            shared_write_user_ids=[player_id],
+        ).json()
+        resp = client.patch(
+            f"/api/campaigns/{cid}/wiki/{rw['id']}",
+            json={"shared_user_ids": [player_id, admin_id]},
+            headers=player_headers,
+        )
+        assert resp.status_code == 403
+        # Demoting themselves to read-only is a change too, and equally refused.
+        assert client.patch(
+            f"/api/campaigns/{cid}/wiki/{rw['id']}",
+            json={"shared_write_user_ids": []},
+            headers=player_headers,
+        ).status_code == 403
+
+    def test_author_can_still_change_shares(
+        self, client, gm_headers, player_id, admin_id, campaign_with_member
+    ):
+        cid = campaign_with_member
+        rw = _create(
+            client, gm_headers, cid, title="Writable", visibility="members",
+            shared_write_user_ids=[player_id],
+        ).json()
+        resp = client.patch(
+            f"/api/campaigns/{cid}/wiki/{rw['id']}",
+            json={"shared_user_ids": [player_id, admin_id]},
+            headers=gm_headers,
+        )
+        assert resp.status_code == 200
+        detail = client.get(f"/api/campaigns/{cid}/wiki/{rw['id']}", headers=gm_headers).json()
+        assert sorted(detail["shared_user_ids"]) == sorted([player_id, admin_id])
+
+    def test_resending_an_unchanged_unwritable_parent_is_allowed(
+        self, client, gm_headers, player_headers, campaign_with_member
+    ):
+        # Same shape as the sharing gate: re-nesting under a parent you may not
+        # write is refused, but leaving the page where it already sits is not a
+        # re-nest and must not block an otherwise legitimate edit (issue #386).
+        cid = campaign_with_member
+        parent = _create(client, gm_headers, cid, title="GM Only", visibility="gm").json()
+        child = _create(
+            client, gm_headers, cid, title="Public Child", visibility="group",
+            parent_id=parent["id"],
+        ).json()
+        resp = client.patch(
+            f"/api/campaigns/{cid}/wiki/{child['id']}",
+            json={"body": "player edit", "parent_id": parent["id"]},
+            headers=player_headers,
+        )
+        assert resp.status_code == 200
+
+    def test_moving_under_an_unwritable_parent_is_still_refused(
+        self, client, gm_headers, player_headers, campaign_with_member
+    ):
+        cid = campaign_with_member
+        parent = _create(client, gm_headers, cid, title="GM Only", visibility="gm").json()
+        loose = _create(client, gm_headers, cid, title="Loose", visibility="group").json()
+        # An unreadable parent reports "invalid" rather than "forbidden" so the
+        # response doesn't confirm the hidden page exists.
+        assert client.patch(
+            f"/api/campaigns/{cid}/wiki/{loose['id']}",
+            json={"parent_id": parent["id"]},
+            headers=player_headers,
+        ).status_code == 400
 
     def test_share_lists_are_not_exposed_to_readers(
         self, client, gm_headers, player_headers, player_id, campaign_with_member

--- a/frontend/src/components/campaigns/PageEditor.jsx
+++ b/frontend/src/components/campaigns/PageEditor.jsx
@@ -37,6 +37,14 @@ import {
   visLabelKey,
 } from './wikiShared'
 
+// Compare two id lists as sets: order and duplicates carry no meaning in a share
+// list, and treating a reorder as a change would send a needless write.
+const sameIds = (a = [], b = []) => {
+  const x = new Set(a)
+  const y = new Set(b ?? [])
+  return x.size === y.size && [...x].every((id) => y.has(id))
+}
+
 /** Full create/edit form for a wiki page: metadata, markdown toolbar, live preview. */
 export default function PageEditor({
   campaign,
@@ -263,12 +271,33 @@ export default function PageEditor({
       const payload = {
         title: title.trim() || t('wiki.untitled'),
         body,
-        visibility,
-        shared_user_ids: visibility === 'members' ? sharedIds : [],
-        shared_write_user_ids: visibility === 'members' ? writeIds : [],
-        parent_id: parentId || '',
         icon: icon || '',
         icon_color: iconColor || '',
+      }
+      // Nesting travels on change only, for the same reason as classification:
+      // the server checks write access to the *destination*, so resending the
+      // parent a page already sits under would refuse an edit to a child whose
+      // parent the user cannot write (#386).
+      if (isNew || (parentId || '') !== (page.parent_id || '')) {
+        payload.parent_id = parentId || ''
+      }
+      // Classification travels only when it actually changed. Resending the
+      // stored values on an ordinary body edit is what locked non-authors out
+      // of pages they may edit — the server refuses a *change* to visibility or
+      // sharing from anyone but the author, and an unchanged resend still read
+      // as an attempt (#386). A new page has nothing to diff against, so it
+      // sends the fields outright.
+      const nextShared = visibility === 'members' ? sharedIds : []
+      const nextWrite = visibility === 'members' ? writeIds : []
+      if (isNew) {
+        payload.visibility = visibility
+        payload.shared_user_ids = nextShared
+        payload.shared_write_user_ids = nextWrite
+      } else {
+        if (visibility !== page.visibility) payload.visibility = visibility
+        if (!sameIds(nextShared, page.shared_user_ids)) payload.shared_user_ids = nextShared
+        if (!sameIds(nextWrite, page.shared_write_user_ids))
+          payload.shared_write_user_ids = nextWrite
       }
       const result = isNew
         ? await campaigns.createWikiPage(campaign.id, payload)

--- a/frontend/src/components/campaigns/PageEditor.test.jsx
+++ b/frontend/src/components/campaigns/PageEditor.test.jsx
@@ -176,6 +176,46 @@ describe('PageEditor', () => {
     )
   })
 
+  // Resending unchanged classification on an ordinary body edit is what locked
+  // non-authors out of pages they may edit (#386), so it travels only on change.
+  it('omits visibility and share lists when they did not change', async () => {
+    const user = userEvent.setup()
+    renderEditor({
+      page: { ...existing, is_mine: false, visibility: 'group', created_by_id: 'u1' },
+    })
+    await user.click(screen.getByRole('button', { name: 'Save' }))
+    await waitFor(() => expect(campaigns.updateWikiPage).toHaveBeenCalled())
+    const payload = campaigns.updateWikiPage.mock.calls[0][2]
+    expect(payload).not.toHaveProperty('visibility')
+    expect(payload).not.toHaveProperty('shared_user_ids')
+    expect(payload).not.toHaveProperty('shared_write_user_ids')
+    // The body edit itself still goes through.
+    expect(payload).toMatchObject({ title: 'Dragons' })
+  })
+
+  it('omits parent_id when the nesting did not change', async () => {
+    const user = userEvent.setup()
+    renderEditor({ page: { ...existing, parent_id: 'p9' } })
+    await user.click(screen.getByRole('button', { name: 'Save' }))
+    await waitFor(() => expect(campaigns.updateWikiPage).toHaveBeenCalled())
+    expect(campaigns.updateWikiPage.mock.calls[0][2]).not.toHaveProperty('parent_id')
+  })
+
+  // The same rule applies to the author: only a real change is sent.
+  it('sends the share list when the author actually changes it', async () => {
+    const user = userEvent.setup()
+    renderEditor({
+      page: { ...existing, visibility: 'members', shared_user_ids: [], shared_write_user_ids: [] },
+    })
+    await user.click(screen.getByRole('checkbox', { name: 'Read access for alice' }))
+    await user.click(screen.getByRole('button', { name: 'Save' }))
+    await waitFor(() => expect(campaigns.updateWikiPage).toHaveBeenCalled())
+    const payload = campaigns.updateWikiPage.mock.calls[0][2]
+    expect(payload.shared_user_ids).toEqual(['u2'])
+    // Visibility was untouched, so it stays out of the payload.
+    expect(payload).not.toHaveProperty('visibility')
+  })
+
   it('clears the share list when visibility moves away from members', async () => {
     const user = userEvent.setup()
     renderEditor({ page: { ...existing, visibility: 'members', shared_user_ids: ['u2'] } })


### PR DESCRIPTION
## Summary

<!-- What does this PR do? A few sentences is fine. -->

## Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / cleanup
- [ ] Docs / configuration only

## Testing

<!-- How did you verify this works? Check all that apply. -->

- [x] Backend tests pass (`pytest -q`)
- [x] Frontend tests pass (`npm test`)
- [x] Tested manually in the browser

## Notes for reviewer

<!-- Anything that needs extra context, known limitations, or follow-up work. Delete if not needed. -->
