### PR TITLE
Fix: Sidecar files are written owner-only and ignore UMASK

### DIFF
--- a/backend/config.py
+++ b/backend/config.py
@@ -54,6 +54,29 @@ DISABLE_VERSION_CHECKING = (
 )
 
 
+def _read_umask() -> int:
+    """The process umask, read once at import.
+
+    ``os.umask`` is a set-and-return with no pure getter, so reading it means
+    setting it and putting it back. That is a process-global mutation and it is
+    not thread-safe, which is exactly why this runs once at import — before any
+    worker threads exist — rather than per file write.
+    """
+    current = os.umask(0o022)
+    os.umask(current)
+    return current
+
+
+UMASK = _read_umask()
+
+# Mode for files Grimoire creates *inside the library*, where other tools and
+# other users are expected to reach them (issue #387: sidecars landed 0600 and
+# locked out Syncthing and Unraid's share user). 0666 before umask matches what
+# a plain ``open()`` would produce, so these files get the same permissions as
+# an uploaded one and the container's UMASK actually governs them.
+LIBRARY_FILE_MODE = 0o666 & ~UMASK
+
+
 def _read_ocr_concurrency() -> int:
     """Parallel-OCR worker count. 0 = OCR disabled; negatives clamp to 0; bad
     values fall back to the serial default of 1."""

--- a/backend/metadata/export.py
+++ b/backend/metadata/export.py
@@ -26,7 +26,7 @@ from typing import Optional
 
 from sqlalchemy.orm import Session
 
-from ..config import THUMB_DIR
+from ..config import LIBRARY_FILE_MODE, THUMB_DIR
 from ..indexer.categories import slugify
 from ..models import Book
 from . import settings as export_settings
@@ -92,12 +92,20 @@ def _atomic_write(path: str, text: str) -> None:
     a complete file into place makes the swap atomic. The temp file must share
     the destination's directory or the rename becomes a cross-device copy and
     loses that property.
+
+    ``mkstemp`` hardcodes 0600 and deliberately ignores umask — correct for the
+    scratch files it is meant for, wrong here, because this one is renamed into
+    the user's library and keeps that mode. Left alone it produces a sidecar
+    only the container's own user can read, which is invisible to anything else
+    sharing the volume. Chmod before the rename so the file is never briefly
+    visible at the wrong mode.
     """
     directory = os.path.dirname(path) or "."
     fd, tmp = tempfile.mkstemp(dir=directory, prefix=".grimoire-", suffix=".tmp")
     try:
         with os.fdopen(fd, "w", encoding="utf-8") as fh:
             fh.write(text)
+        os.chmod(tmp, LIBRARY_FILE_MODE)
         os.replace(tmp, path)
     except BaseException:
         try:
@@ -136,6 +144,10 @@ def _write_cover(book: Book, result: ExportResult, *, overwrite_foreign: bool) -
         return os.path.basename(dest)
     try:
         shutil.copyfile(source, dest)
+        # copyfile truncates an existing destination in place and keeps its old
+        # mode, so re-exporting over a cover written before #387 would otherwise
+        # leave it unreadable. Setting it explicitly makes a re-export a repair.
+        os.chmod(dest, LIBRARY_FILE_MODE)
         result.covers += 1
     except OSError as exc:
         _record_failure(result, dest, exc)

--- a/backend/tests/test_metadata_export.py
+++ b/backend/tests/test_metadata_export.py
@@ -19,7 +19,7 @@ from backend.metadata.export import (
     refresh_existing,
     refresh_existing_safe,
 )
-from backend.metadata.formats import sidecar_path
+from backend.metadata.formats import COVER_SUFFIX, sidecar_path
 from backend.models import AppSetting, Book
 
 
@@ -411,3 +411,108 @@ class TestExportNewBook:
         )
 
         export_new_book(db, book)  # must not raise
+
+
+class TestSidecarPermissions:
+    """Issue #387: sidecars must be readable by other users on the volume.
+
+    ``tempfile.mkstemp`` creates 0600 and ignores umask by design. Renaming that
+    file into the library handed the user a sidecar only the container's own
+    user could read, which is invisible to Syncthing, to Unraid's share user,
+    and to anything else sharing the mount.
+    """
+
+    def test_a_written_sidecar_is_not_owner_only(self, db, tmp_path):
+        book = _make_book(db, tmp_path, book_id="sidecar-perm")
+
+        export_book(db, book, ["json"])
+
+        mode = os.stat(sidecar_path(book.filepath, "json")).st_mode & 0o777
+        assert mode & 0o044, f"sidecar is not group/other readable: {oct(mode)}"
+
+    def test_the_mode_follows_the_configured_umask(self, db, tmp_path, monkeypatch):
+        """The container's UMASK governs the result, rather than a hardcoded mode."""
+        monkeypatch.setattr("backend.metadata.export.LIBRARY_FILE_MODE", 0o640)
+        book = _make_book(db, tmp_path, book_id="sidecar-perm-umask")
+
+        export_book(db, book, ["json"])
+
+        mode = os.stat(sidecar_path(book.filepath, "json")).st_mode & 0o777
+        assert mode == 0o640
+
+    def test_it_matches_what_a_plain_open_would_produce(self, db, tmp_path):
+        """Sidecars get the same permissions as an uploaded file in the same dir."""
+        book = _make_book(db, tmp_path, book_id="sidecar-perm-parity")
+        reference = tmp_path / "uploaded.pdf"
+        with open(reference, "w") as fh:
+            fh.write("x")
+
+        export_book(db, book, ["json"])
+
+        sidecar_mode = os.stat(sidecar_path(book.filepath, "json")).st_mode & 0o777
+        assert sidecar_mode == os.stat(reference).st_mode & 0o777
+
+    def test_rewriting_an_existing_sidecar_repairs_its_mode(self, db, tmp_path):
+        """A sidecar written before the fix is healed by the next export."""
+        book = _make_book(db, tmp_path, book_id="sidecar-perm-repair")
+        export_book(db, book, ["json"])
+        path = sidecar_path(book.filepath, "json")
+        os.chmod(path, 0o600)
+
+        export_book(db, book, ["json"], overwrite_foreign=True)
+
+        assert os.stat(path).st_mode & 0o044
+
+
+class TestCoverPermissions:
+    """The exported cover is a library file too, and gets the same treatment."""
+
+    @staticmethod
+    def _stub_thumbnail(monkeypatch, tmp_path):
+        """Stand in for the scanner's cached thumbnail."""
+        source = tmp_path / "cached.webp"
+        source.write_bytes(b"RIFF....WEBP")
+        monkeypatch.setattr(
+            "backend.metadata.export._thumbnail_source", lambda book: str(source)
+        )
+
+    def test_an_exported_cover_is_not_owner_only(self, db, tmp_path, monkeypatch):
+        self._stub_thumbnail(monkeypatch, tmp_path)
+        book = _make_book(db, tmp_path, book_id="sidecar-cover-perm")
+
+        result = export_book(db, book, ["json"], covers=True)
+
+        assert result.covers == 1
+        cover = os.path.splitext(book.filepath)[0] + COVER_SUFFIX
+        assert os.stat(cover).st_mode & 0o044
+
+    def test_overwriting_an_existing_cover_repairs_its_mode(
+        self, db, tmp_path, monkeypatch
+    ):
+        """copyfile keeps the destination's old mode, so it is set explicitly."""
+        self._stub_thumbnail(monkeypatch, tmp_path)
+        book = _make_book(db, tmp_path, book_id="sidecar-cover-repair")
+        cover = os.path.splitext(book.filepath)[0] + COVER_SUFFIX
+        with open(cover, "wb") as fh:
+            fh.write(b"old")
+        os.chmod(cover, 0o600)
+
+        export_book(db, book, ["json"], covers=True, overwrite_foreign=True)
+
+        assert os.stat(cover).st_mode & 0o044
+
+
+class TestUmaskHelper:
+    def test_it_reports_the_process_umask_without_changing_it(self):
+        from backend.config import _read_umask
+
+        before = os.umask(0o027)
+        os.umask(before)
+        try:
+            os.umask(0o027)
+            assert _read_umask() == 0o027
+            # Reading it must leave the process umask where it was.
+            restored = os.umask(0o022)
+            assert restored == 0o027
+        finally:
+            os.umask(before)

--- a/docs/sidecars.md
+++ b/docs/sidecars.md
@@ -153,6 +153,28 @@ reports `read_only: true` with an actionable message and stops early instead of
 producing one identical error per book. Metadata edits keep working normally -
 only the sidecar refresh is skipped.
 
+## File permissions
+
+Sidecars and exported covers are created with the process umask applied, so they
+land at `0666 & ~umask` - `rw-r--r--` under the usual `022`, the same mode a
+plain upload into the library gets. The mode is computed once at startup in
+`backend/config.py` as `LIBRARY_FILE_MODE`, and setting `UMASK` on the container
+changes it.
+
+This is deliberate rather than incidental. `tempfile.mkstemp`, which the atomic
+write uses to stage the file, hardcodes `0600` and ignores umask - correct for
+the private scratch files it is designed for, wrong for a file that is about to
+be renamed into a shared library. Left alone it produced sidecars only the
+container's own user could read, invisible to Syncthing, to Unraid's share user,
+and to anything else on the volume (issue #387). The temp file is chmodded
+before the rename, so it is never briefly visible at the wrong mode, and covers
+are chmodded after the copy because `shutil.copyfile` preserves an existing
+destination's mode - which makes a re-export repair a file written before the
+fix.
+
+Internal scratch files - add-on IPC, the OCR subprocess, backup staging - keep
+`mkstemp`'s `0600`. They never enter the library, and private is right for them.
+
 ## Interaction with sidecar import
 
 Export and import have to agree, or a scan will fight the exporter: export

--- a/nightly.md
+++ b/nightly.md
@@ -541,6 +541,8 @@ Sidecars are hidden in the **File Manager** - they describe your content rather 
 
 > Sidecar export writes into your library folder, so it needs the library mounted **writable** - the default. If you have mounted it `:ro`, export reports that clearly and your metadata edits keep working; only the sidecar write is skipped. See [Read-only or writable?](#read-only-or-writable).
 
+Exported sidecars and covers are created with the container's `UMASK` applied, exactly like an uploaded file - with the default `022` that means `rw-r--r--`, readable by other users and other tools sharing the volume. Set `UMASK` on the container if your setup needs something different (Unraid users typically want `000` to get `rw-rw-rw-`).
+
 See [`docs/sidecars.md`](docs/sidecars.md) for the full field mapping per format and how export precedence pairs with the refresh modes above.
 
 ### Maps - organize by creator or collection


### PR DESCRIPTION
## Summary

<!-- What does this PR do? A few sentences is fine. -->

## Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / cleanup
- [ ] Docs / configuration only

## Testing

<!-- How did you verify this works? Check all that apply. -->

- [x] Backend tests pass (`pytest -q`)
- [ ] Frontend tests pass (`npm test`)
- [ ] Tested manually in the browser

## Notes for reviewer

<!-- Anything that needs extra context, known limitations, or follow-up work. Delete if not needed. -->
