### PR TITLE
Fix: Preserve thumbnails when a book, map, or token is moved

### DIFF
--- a/backend/indexer/reconcile.py
+++ b/backend/indexer/reconcile.py
@@ -14,7 +14,7 @@ import logging
 import os
 from typing import Any
 
-from ._context import _ScanContext
+from ._context import _ScanContext, _title_from_filename
 from ._subprocess import _run_with_timeout
 from .constants import _DB_TIMEOUT
 from ..metadata import export as sidecar_export
@@ -24,6 +24,64 @@ from ..models import Audio, Book, GameSystem, GenericMap, Token
 logger = logging.getLogger("grimoire.indexer")
 
 
+# Which thumbnail subdirectory each model's covers live in. Audio is absent on
+# purpose: it carries ``has_artwork``/``cover_image`` sourced from embedded tags
+# or folder artwork, not a path-keyed file this module could orphan.
+_THUMB_SECTIONS: dict[Any, str] = {GenericMap: "maps", Token: "tokens"}
+
+
+def _remove_stale_thumbnail(ctx: _ScanContext, model: Any, old: Any) -> None:
+    """Delete the thumbnail a moved map/token left behind at its old path.
+
+    Thumbnail filenames embed a hash of the *filepath*, so a move leaves the old
+    file unreferenced: the walk has already written a fresh one under the new
+    path's name, and nothing will ever serve or clean up the old one.
+
+    Named from ``_title_from_filename(old.filename)`` rather than a stored title,
+    because that is what :func:`_scan_media` used when it wrote the file — maps
+    and tokens have no ``title`` column.
+
+    Best-effort: a thumbnail that cannot be removed is wasted disk, never a
+    reason to fail the scan.
+    """
+    section = _THUMB_SECTIONS.get(model)
+    if section is None or not getattr(old, "has_thumbnail", False):
+        return
+    stale = ctx.thumb_path(section, _title_from_filename(old.filename), old.filepath)
+    try:
+        os.remove(stale)
+    except FileNotFoundError:
+        pass
+    except OSError as e:
+        logger.debug("Could not remove stale thumbnail %s: %s", stale, e)
+
+
+def _rename_thumbnail_to_title(
+    ctx: _ScanContext, rendered_title: str, kept_title: str, filepath: str
+) -> None:
+    """Rename a move's fresh cover from the rendered title to the kept one.
+
+    Thumbnails are stored as ``<slugified title>_<hash of filepath>.webp``. After
+    a move the surviving row keeps its own title — which may have been edited in
+    the UI — while the file on disk was named from the title the walk derived
+    from the filename. The serving endpoint falls back to a glob on the hash, so
+    this is a tidiness fix rather than a correctness one; doing it keeps the fast
+    exact-name path working instead of pushing every moved book onto the glob.
+
+    Best-effort by design: a failure here leaves a servable thumbnail in place,
+    so it must never interrupt the scan.
+    """
+    src = ctx.thumb_path("books", rendered_title, filepath)
+    dest = ctx.thumb_path("books", kept_title, filepath)
+    if src == dest:
+        return
+    try:
+        if os.path.isfile(src):
+            os.replace(src, dest)
+    except OSError as e:
+        logger.debug("Could not rename thumbnail %s -> %s: %s", src, dest, e)
+
+
 def _detect_moves(ctx: _ScanContext, model: Any, gone: list, present: list) -> int:
     """Re-point rows whose file moved instead of leaving them missing (issue #284).
 
@@ -31,6 +89,9 @@ def _detect_moves(ctx: _ScanContext, model: Any, gone: list, present: list) -> i
     ``is_missing`` and a brand-new row appears at the new path, silently dropping
     the tags, favorites, bookmarks, and read progress attached to the old row's id.
     Matching on content hash recovers the connection — same bytes, new location.
+
+    The surviving row also inherits the destination row's thumbnail state, since
+    the walk has already rendered a cover at the new path (issue #394).
 
     ``gone`` are rows whose file no longer exists; ``present`` are rows whose file
     does. A move is accepted only when exactly one gone row and exactly one
@@ -81,7 +142,13 @@ def _detect_moves(ctx: _ScanContext, model: Any, gone: list, present: list) -> i
 
             thumb = ctx.thumb_path("books", old.title, old.filepath) if old.has_thumbnail else None
             invalidate_book_content(old.id, old.filepath, db=session, thumb_path=thumb)
-            old.has_thumbnail = False
+        else:
+            # Maps and tokens have no page renders or search rows to drop, but
+            # their thumbnail is path-keyed just like a book's, so the file at the
+            # old path is dead weight the moment the row moves. Only books went
+            # through the invalidation above, which left one orphaned WebP per
+            # moved map or token accumulating forever (issue #394).
+            _remove_stale_thumbnail(ctx, model, old)
 
         logger.info(f"Detected move: '{old.filepath}' -> '{new.filepath}'")
         # Carry the new location onto the *old* row so its id — and everything
@@ -91,6 +158,15 @@ def _detect_moves(ctx: _ScanContext, model: Any, gone: list, present: list) -> i
         new_filepath, new_filename = new.filepath, new.filename
         new_relative, new_system = new.relative_path, getattr(new, "game_system_id", None)
         new_category = getattr(new, "category", None)
+        # The walk already rendered a cover for the file at its new path, onto
+        # the row about to be discarded. Thumbnail filenames are path-derived, so
+        # that render is the *live* one and the old row's was the stale file just
+        # deleted above; inheriting the flag hands the survivor the cover that
+        # actually exists. Leaving it False stranded a perfectly good WebP on
+        # disk that nothing would ever serve or clean up, and the book showed a
+        # blank cover until a full "Rescan and Re-index" (issue #394).
+        new_has_thumbnail = getattr(new, "has_thumbnail", False)
+        new_title = getattr(new, "title", None)
         session.delete(new)
         session.flush()
 
@@ -101,6 +177,12 @@ def _detect_moves(ctx: _ScanContext, model: Any, gone: list, present: list) -> i
         if model is Book:
             old.game_system_id = new_system
             old.category = new_category
+            old.has_thumbnail = bool(new_has_thumbnail)
+            # The cover was written as ``slugify(<new row's title>)_<hash>.webp``.
+            # A survivor whose title was customised in the UI keeps that title, so
+            # rename the file to match rather than relying on the serving glob.
+            if new_has_thumbnail and new_title and new_title != old.title:
+                _rename_thumbnail_to_title(ctx, new_title, old.title, new_filepath)
         moved += 1
 
     if moved:

--- a/backend/tests/test_content_hash.py
+++ b/backend/tests/test_content_hash.py
@@ -11,6 +11,7 @@ Covers the three behaviours that depend on hashing library files:
 """
 from __future__ import annotations
 
+import hashlib
 import os
 import tempfile
 import time
@@ -19,6 +20,7 @@ from unittest.mock import patch
 
 from backend.config import SessionLocal
 from backend.indexer import hashing, scan_library
+from backend.indexer.categories import slugify
 from backend.models import Book, GameSystem, Token
 
 
@@ -33,6 +35,39 @@ def _scan(lib: Path, tmp: str, db) -> dict:
     """Run a scan with thumbnail generation stubbed out (no real PDFs here)."""
     with patch("backend.indexer.generate_thumbnail", return_value=False):
         return scan_library(str(lib), tmp, db)
+
+
+def _fake_thumbnail_task(filepath, output_path, size, result, exc) -> None:
+    """Stand in for the real renderer: write a file where a cover would go."""
+    os.makedirs(os.path.dirname(output_path), exist_ok=True)
+    with open(output_path, "wb") as fh:
+        fh.write(b"WEBP-test-cover")
+    result[0] = True
+
+
+def _scan_with_thumbs(lib: Path, tmp: str, db) -> dict:
+    """Run a scan where thumbnail generation "succeeds" and leaves a file.
+
+    Patches the render worker rather than ``generate_thumbnail`` itself, so the
+    timeout wrapper still runs and the stub writes a real file on disk — these
+    tests assert on the *cover file*, not just the flag. The fixtures are not
+    valid PDFs, so the true renderer would fail on them.
+    """
+    with patch(
+        "backend.indexer.thumbnails._generate_thumbnail_task",
+        side_effect=_fake_thumbnail_task,
+    ):
+        return scan_library(str(lib), tmp, db)
+
+
+def _thumb_for(tmp: str, title: str, filepath: str, section: str = "books") -> str:
+    """The thumbnail path the indexer writes for a title at a given filepath."""
+    return os.path.join(
+        tmp,
+        "thumbnails",
+        section,
+        f"{slugify(title)}_{hashlib.md5(filepath.encode()).hexdigest()[:8]}.webp",
+    )
 
 
 def _touch_future(path: Path) -> None:
@@ -296,6 +331,85 @@ class TestMoveDetection:
         finally:
             db.close()
 
+    def test_moved_book_keeps_its_thumbnail(self):
+        """Issue #394 — a move must not blank the cover the walk just rendered.
+
+        Thumbnail filenames are path-derived, so the move's destination row gets a
+        freshly rendered cover during the walk. Move detection then discards that
+        row in favour of the original id; before the fix it also reset
+        ``has_thumbnail`` to False, stranding a valid WebP on disk that nothing
+        would serve and leaving a blank cover until a full re-index.
+        """
+        tmp, lib = _mk_lib()
+        src = lib / "books" / "OldSystem" / "core"
+        src.mkdir(parents=True)
+        f = src / "tome.pdf"
+        f.write_bytes(b"%PDF-1.4 a book with a cover")
+
+        db = SessionLocal()
+        try:
+            _scan_with_thumbs(lib, tmp, db)
+            book = db.query(Book).filter_by(filepath=str(f)).first()
+            assert book.has_thumbnail is True
+            original_id = book.id
+            old_thumb = _thumb_for(tmp, "tome", str(f))
+            assert os.path.isfile(old_thumb)
+
+            dest = lib / "books" / "NewSystem" / "core"
+            dest.mkdir(parents=True)
+            moved_to = dest / "tome.pdf"
+            f.rename(moved_to)
+
+            stats = _scan_with_thumbs(lib, tmp, db)
+            assert stats.get("moved_books", 0) == 1
+
+            db.expire_all()
+            survivor = db.query(Book).filter_by(id=original_id).first()
+            assert survivor.has_thumbnail is True
+            # The cover serving the new path exists; the old path's is cleaned up.
+            assert os.path.isfile(_thumb_for(tmp, "tome", str(moved_to)))
+            assert not os.path.isfile(old_thumb)
+        finally:
+            db.close()
+
+    def test_moved_book_with_custom_title_renames_its_thumbnail(self):
+        """A survivor keeps its edited title, so the cover is renamed to match.
+
+        The walk names the destination cover from the filename-derived title. The
+        row that survives carries the user's title, so the file is renamed onto
+        the name the fast serving path looks for.
+        """
+        tmp, lib = _mk_lib()
+        src = lib / "books" / "OldSystem" / "core"
+        src.mkdir(parents=True)
+        f = src / "tome.pdf"
+        f.write_bytes(b"%PDF-1.4 a renamed book with a cover")
+
+        db = SessionLocal()
+        try:
+            _scan_with_thumbs(lib, tmp, db)
+            book = db.query(Book).filter_by(filepath=str(f)).first()
+            original_id = book.id
+            book.title = "Player Handbook"
+            db.commit()
+
+            dest = lib / "books" / "NewSystem" / "core"
+            dest.mkdir(parents=True)
+            moved_to = dest / "tome.pdf"
+            f.rename(moved_to)
+
+            _scan_with_thumbs(lib, tmp, db)
+
+            db.expire_all()
+            survivor = db.query(Book).filter_by(id=original_id).first()
+            assert survivor.title == "Player Handbook"
+            assert survivor.has_thumbnail is True
+            # Stored under the kept title, not the one derived from the filename.
+            assert os.path.isfile(_thumb_for(tmp, "Player Handbook", str(moved_to)))
+            assert not os.path.isfile(_thumb_for(tmp, "tome", str(moved_to)))
+        finally:
+            db.close()
+
     def test_moved_token_keeps_its_row(self):
         tmp, lib = _mk_lib()
         src = lib / "tokens" / "Old"
@@ -321,6 +435,48 @@ class TestMoveDetection:
             assert survivor is not None
             assert survivor.filepath == str(moved_to)
             assert survivor.is_missing is False
+        finally:
+            db.close()
+
+    def test_moved_token_removes_its_stale_thumbnail(self):
+        """Issue #394 — a move must not leave the old path's thumbnail behind.
+
+        Maps and tokens keep their row (and their ``has_thumbnail`` flag) across a
+        move, and the walk writes a fresh cover under the new path's name. The old
+        path's file is then unreachable — nothing serves it, nothing cleans it up —
+        so every move used to leak one WebP.
+        """
+        tmp, lib = _mk_lib()
+        src = lib / "tokens" / "Old"
+        src.mkdir(parents=True)
+        f = src / "goblin.png"
+        f.write_bytes(b"\x89PNG token-thumbnail-fixture")
+
+        db = SessionLocal()
+        try:
+            _scan_with_thumbs(lib, tmp, db)
+            tok = db.query(Token).filter_by(filepath=str(f)).first()
+            assert tok.has_thumbnail is True
+            original_id = tok.id
+            old_thumb = _thumb_for(tmp, "goblin", str(f), section="tokens")
+            assert os.path.isfile(old_thumb)
+
+            dest = lib / "tokens" / "New"
+            dest.mkdir(parents=True)
+            moved_to = dest / "goblin.png"
+            f.rename(moved_to)
+
+            stats = _scan_with_thumbs(lib, tmp, db)
+            assert stats.get("moved_tokens", 0) == 1
+
+            db.expire_all()
+            survivor = db.query(Token).filter_by(id=original_id).first()
+            assert survivor.has_thumbnail is True
+            # The new path's cover is there, and the old one is not left behind.
+            assert os.path.isfile(_thumb_for(tmp, "goblin", str(moved_to), section="tokens"))
+            assert not os.path.isfile(old_thumb)
+            leftovers = list((Path(tmp) / "thumbnails" / "tokens").glob("*.webp"))
+            assert len(leftovers) == 1, f"leaked thumbnails: {leftovers}"
         finally:
             db.close()
 


### PR DESCRIPTION
## Summary

<!-- What does this PR do? A few sentences is fine. -->

## Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / cleanup
- [ ] Docs / configuration only

## Testing

<!-- How did you verify this works? Check all that apply. -->

- [x] Backend tests pass (`pytest -q`)
- [ ] Frontend tests pass (`npm test`)
- [x] Tested manually in the browser

## Notes for reviewer

<!-- Anything that needs extra context, known limitations, or follow-up work. Delete if not needed. -->
