### PR TITLE
Fix: Keep category moves inside the system folder under a container

### DIFF
--- a/backend/services/library_fs/placement.py
+++ b/backend/services/library_fs/placement.py
@@ -17,6 +17,7 @@ from ...config import logger
 from ...indexer.categories import (
     UNCATEGORIZED,
     agnostic_category,
+    detect_container_kind,
     guess_category,
     is_special_collection_folder,
     slugify,
@@ -38,6 +39,45 @@ def _system_folder_name(raw_name: str) -> str:
     name = re.sub(r"\s*\(nsfw\)\s*", "", raw_name, flags=re.IGNORECASE).strip()
     name, _ = strip_container_suffix(name)
     return strip_sort_prefix(name)
+
+
+def _system_depth_for(db: Session, parts: list[str]) -> int:
+    """How many path segments precede the category folder: 2, or 3 under a container.
+
+    ``parts`` is the library-relative path split on "/", starting with ``books``.
+
+    The folder at ``parts[1]`` is a *container* rather than a system when it is
+    marked as one on disk — the same test the scanner applies (issue #395). The
+    DB cannot answer this on its own: a container has its own ``GameSystem`` row
+    whose ``parent_id`` is None, so asking whether the row at ``parts[1]`` has a
+    parent says "no" for the container itself and yields depth 2, which is how a
+    re-categorised book escaped its system folder and landed in the container
+    root.
+
+    The marker file is authoritative; the DB is a fallback for a container
+    declared by a name suffix (``(parent-system)``), where the folder carries no
+    marker but the nested system row does record a parent.
+    """
+    if len(parts) < 3:
+        return 2
+    container_dir = library_root() / parts[0] / parts[1]
+    if detect_container_kind(container_dir, parts[1]):
+        return 3
+    # A suffix-declared container leaves no marker on disk. Its child systems do
+    # carry ``parent_id``, so look the *nested* folder up directly — but only
+    # believe it when that parent is the folder at ``parts[1]``. In a standard
+    # layout ``parts[2]`` is the *category* folder, and a system elsewhere in the
+    # library that happens to share its name ("Core") must not be mistaken for a
+    # nested system here.
+    nested = (
+        db.query(GameSystem).filter(GameSystem.name == _system_folder_name(parts[2])).first()
+    )
+    parent_id = getattr(nested, "parent_id", None) if nested is not None else None
+    if parent_id:
+        parent = db.query(GameSystem).filter(GameSystem.id == parent_id).first()
+        if parent is not None and parent.name == _system_folder_name(parts[1]):
+            return 3
+    return 2
 
 
 def resolve_book_placement(db: Session, dest_file: Path) -> tuple[Optional[str], str]:
@@ -68,17 +108,20 @@ def resolve_book_placement(db: Session, dest_file: Path) -> tuple[Optional[str],
 
     # A system nested one level inside a container folder shifts every
     # subsequent segment right by one; the scanner expresses that as
-    # `system_depth`. Detect it by asking whether the matched system has a
-    # parent, which is what a container membership records.
-    depth = 2
-    if system is not None and getattr(system, "parent_id", None):
-        depth = 3
+    # `system_depth`. Shared with ``_system_root_for`` so both agree on where the
+    # category folder starts — asking whether the row at ``parts[1]`` has a
+    # parent got this wrong for a marker-declared container, whose own row has
+    # no parent (issue #395).
+    depth = _system_depth_for(db, parts)
+    if depth == 3:
         # The real system folder is the second segment inside the container.
-        if len(parts) > 2:
-            nested_name = _system_folder_name(parts[2])
-            nested = db.query(GameSystem).filter(GameSystem.name == nested_name).first()
-            if nested is not None:
-                system = nested
+        nested_name = _system_folder_name(parts[2])
+        nested = (
+            db.query(GameSystem).filter(GameSystem.name == nested_name).first()
+            or db.query(GameSystem).filter(GameSystem.slug == slugify(nested_name)).first()
+        )
+        if nested is not None:
+            system = nested
 
     if is_special_collection_folder(system_folder):
         return (system.id if system else None), agnostic_category(rel)
@@ -105,12 +148,7 @@ def _system_root_for(db: Session, book_path: Path) -> Optional[Path]:
     if len(parts) < 3:
         return None
 
-    system = (
-        db.query(GameSystem).filter(GameSystem.name == _system_folder_name(parts[1])).first()
-    )
-    depth = 2
-    if system is not None and getattr(system, "parent_id", None):
-        depth = 3
+    depth = _system_depth_for(db, parts)
     if len(parts) <= depth:
         return None
     return library_root().joinpath(*parts[:depth])

--- a/backend/tests/test_files.py
+++ b/backend/tests/test_files.py
@@ -1713,6 +1713,123 @@ class TestCategoryRelocation:
         assert os.path.exists(src), "a title edit must not move anything"
 
 
+class TestCategoryRelocationInContainer:
+    """Issue #395 — a container folder shifts the system one segment right.
+
+    Layout: ``books/<container>/<system>/<category>/``. The container declares
+    itself with a ``.parent-system-container`` marker and owns a GameSystem row
+    of its own whose ``parent_id`` is None — which is exactly why "does the row
+    at parts[1] have a parent?" was the wrong question to ask.
+    """
+
+    @pytest.fixture
+    def container_tree(self):
+        import shutil
+
+        stamp = str(uuid.uuid4())[:8]
+        container, system = f"Container-{stamp}", f"System-{stamp}"
+        os.makedirs(os.path.join(LIB, f"books/{container}/{system}/core"), exist_ok=True)
+        # The marker is what makes this folder a container of systems.
+        open(os.path.join(LIB, f"books/{container}/.parent-system-container"), "wb").close()
+        yield stamp, container, system
+        shutil.rmtree(os.path.join(LIB, f"books/{container}"), ignore_errors=True)
+
+    def _book(self, tree):
+        stamp, container, system = tree
+        parent = make_game_system(name=container, slug=f"container-{stamp}")
+        child = make_game_system(name=system, slug=f"system-{stamp}", parent_id=parent.id)
+        rel = f"books/{container}/{system}/core/tome.pdf"
+        src = _write(rel)
+        book = make_book(
+            child.id,
+            filename="tome.pdf",
+            filepath=src,
+            relative_path=rel,
+            category="core",
+        )
+        return parent, child, book, src
+
+    def test_relocation_stays_inside_the_system_folder(self, container_tree):
+        """The file must land under the *system*, not in the container root."""
+        _stamp, container, system = container_tree
+        _parent, _child, book, src = self._book(container_tree)
+        book_id = book.id
+
+        db = SessionLocal()
+        book = db.query(Book).filter(Book.id == book_id).first()
+        moved = fs.relocate_book_for_category(db, book, "adventure")
+        db.commit()
+        db.close()
+
+        assert moved is not None
+        landed = os.path.join(LIB, f"books/{container}/{system}/Adventures/tome.pdf")
+        assert os.path.exists(landed)
+        assert not os.path.exists(src)
+        # The bug: the book escaped its system and landed in the container root.
+        assert not os.path.exists(os.path.join(LIB, f"books/{container}/Adventures/tome.pdf"))
+
+    def test_placement_matches_what_the_scanner_would_infer(self, container_tree):
+        """A move must agree with the scanner, or the next rescan rewrites it.
+
+        Under a container the category folder is at index 3, so reading it at
+        index 2 returned the *system folder's* name as the category and pinned
+        the book to the container row.
+        """
+        from backend.indexer.categories import guess_category
+
+        _stamp, container, system = container_tree
+        _parent, child, _book, src = self._book(container_tree)
+
+        db = SessionLocal()
+        system_id, category = fs.resolve_book_placement(db, Path(src))
+        db.close()
+
+        assert category == guess_category(
+            f"books/{container}/{system}/core/tome.pdf", system_depth=3
+        )
+        assert category == "core"
+        assert system_id == child.id, "the nested system owns the book, not the container"
+
+    def test_suffix_declared_container_has_no_marker_file(self):
+        """A container declared by name suffix carries no marker on disk.
+
+        The depth then has to come from the DB — the nested system's ``parent_id``
+        — so this exercises the fallback the marker test never reaches.
+        """
+        import shutil
+
+        stamp = str(uuid.uuid4())[:8]
+        folder = f"Publisher-{stamp} (parent-system)"
+        system = f"System-{stamp}"
+        rel = f"books/{folder}/{system}/core/tome.pdf"
+        src = _write(rel)
+        try:
+            # The scanner strips the suffix, so the stored parent name lacks it.
+            parent = make_game_system(name=f"Publisher-{stamp}", slug=f"pub-{stamp}")
+            child = make_game_system(
+                name=system, slug=f"sys-{stamp}", parent_id=parent.id
+            )
+            book = make_book(
+                child.id,
+                filename="tome.pdf",
+                filepath=src,
+                relative_path=rel,
+                category="core",
+            )
+            book_id = book.id
+
+            db = SessionLocal()
+            book = db.query(Book).filter(Book.id == book_id).first()
+            moved = fs.relocate_book_for_category(db, book, "adventure")
+            db.commit()
+            db.close()
+
+            assert moved == f"books/{folder}/{system}/Adventures/tome.pdf"
+            assert not os.path.exists(os.path.join(LIB, f"books/{folder}/Adventures/tome.pdf"))
+        finally:
+            shutil.rmtree(os.path.join(LIB, "books", folder), ignore_errors=True)
+
+
 # ---------------------------------------------------------------------------
 # Read-only library
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

<!-- What does this PR do? A few sentences is fine. -->

## Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / cleanup
- [ ] Docs / configuration only

## Testing

<!-- How did you verify this works? Check all that apply. -->

- [x] Backend tests pass (`pytest -q`)
- [ ] Frontend tests pass (`npm test`)
- [x] Tested manually in the browser

## Notes for reviewer

<!-- Anything that needs extra context, known limitations, or follow-up work. Delete if not needed. -->
