### PR TITLE
Enhancement: Scope duplicate-manager version kinds per collection

### DIFF
--- a/backend/indexer/media.py
+++ b/backend/indexer/media.py
@@ -20,13 +20,35 @@ from sqlalchemy.exc import IntegrityError
 from backend import indexer  # package namespace, for patch-sensitive calls
 from ._context import _ScanContext, _prune_dirs, _title_from_filename
 from ._subprocess import _run_with_timeout
-from .constants import AUDIO_EXTS, MAP_VIDEO_EXTS, MEDIA_ARCHIVE_EXTS, _DB_TIMEOUT
+from .constants import (
+    AUDIO_EXTS,
+    MAP_VIDEO_EXTS,
+    MEDIA_ARCHIVE_EXTS,
+    VTT_DATA_EXTS,
+    _DB_TIMEOUT,
+)
 from .hashing import file_signature, hash_file
 from .metadata import _find_folder_artwork, _read_audio_metadata
 from .thumbnails import archive_ext
 from ..models import Audio
 
 logger = logging.getLogger("grimoire.indexer")
+
+
+def _needs_thumbnail_backfill(existing: Any, ext: str, arc_ext: str) -> bool:
+    """True when a registered media row could have a thumbnail but does not.
+
+    Only Universal VTT maps can currently answer yes: they were registered as
+    opaque before the thumbnailer learned to read the battlemap embedded in the
+    JSON, so existing rows sit at has_thumbnail=0 with no way to recover. Videos
+    stay excluded (no decoder is shipped), and archives are opaque by design.
+
+    Guarded on the flag rather than on file state, so a genuinely un-thumbnailed
+    file is retried at most once per scan and a successful row is never redone.
+    """
+    if arc_ext or getattr(existing, "has_thumbnail", False):
+        return False
+    return ext in VTT_DATA_EXTS
 
 
 def _scan_media(
@@ -91,11 +113,35 @@ def _scan_media(
                 logger.error(f"DB hang: {e} - skipping '{filename}'")
                 stats["errors"] += 1
                 continue
+            title = _title_from_filename(filename)
+
             if existing:
+                # Backfill a thumbnail for a record registered before its format
+                # was thumbnailable. A Universal VTT map scanned by an older
+                # build sits at has_thumbnail=0 even though the battlemap is
+                # embedded in the file, and the walk would otherwise skip it
+                # forever — existing rows never re-enter the insert path below.
+                # Mirrors the same backfill for books (see books.py).
+                if _needs_thumbnail_backfill(existing, ext, arc_ext):
+                    thumb_path = ctx.thumb_path(section, title, filepath)
+                    logger.debug(f"Backfilling thumbnail: {filepath}")
+                    if indexer.generate_thumbnail(
+                        filepath, thumb_path, size=thumb_size, should_stop=ctx.should_stop
+                    ):
+                        existing.has_thumbnail = True
+                        try:
+                            _run_with_timeout(
+                                session.commit,
+                                _DB_TIMEOUT,
+                                f"commit {singular} thumbnail '{filepath}'",
+                            )
+                            stats[f"updated_{section}"] += 1
+                        except TimeoutError as e:
+                            logger.error(f"DB hang: {e} - rolling back '{filename}'")
+                            session.rollback()
+                    continue
                 logger.debug(f"Already registered, skipping: {filename}")
                 continue
-
-            title = _title_from_filename(filename)
 
             signature = file_signature(filepath)
             if signature is None:

--- a/backend/indexer/scan.py
+++ b/backend/indexer/scan.py
@@ -134,6 +134,10 @@ def scan_library(
         "new_tokens": 0,
         "new_audio": 0,
         "updated_books": 0,
+        # Media rows given a thumbnail after the fact — a format that became
+        # thumbnailable after the row was first registered (Universal VTT maps).
+        "updated_maps": 0,
+        "updated_tokens": 0,
         "indexed_pages": 0,
         # Books whose bytes changed under an unchanged path, and files recognised
         # as moved rather than deleted-and-re-added (issue #284).

--- a/backend/models/__init__.py
+++ b/backend/models/__init__.py
@@ -39,7 +39,7 @@ from .library import (
 from .media import Audio, AudioFolder, GenericMap, MapFolder, Token, TokenFolder
 from .settings import AppSetting
 from .tags import RESOURCE_TYPES, SHARED_CATEGORY, TAG_CATEGORIES, ResourceTag, Tag
-from .variants import VARIANT_KINDS
+from .variants import VARIANT_KINDS, VARIANT_KINDS_BY_TYPE, kinds_for
 from .users import AuthSession, Bookmark, Favorite, SavedFilter, User, UserTheme
 
 __all__ = [
@@ -65,6 +65,8 @@ __all__ = [
     "AudioFolder",
     # Variants / duplicates
     "VARIANT_KINDS",
+    "VARIANT_KINDS_BY_TYPE",
+    "kinds_for",
     "DuplicateGroup",
     "DuplicateDismissal",
     # Users

--- a/backend/models/variants.py
+++ b/backend/models/variants.py
@@ -10,24 +10,63 @@ Kept in its own module so ``models`` and ``services`` can both import it without
 either depending on the other.
 """
 
-# Why these and not a free-text field: the kind drives the label the UI shows in
-# the version picker and the badge, and a closed set keeps those translatable.
-# ``variant_label`` next to it stays free text for the specifics ("v1.0.1").
+# Why a closed set and not a free-text field: the kind drives the label the UI
+# shows in the version picker and the badge, and a closed set keeps those
+# translatable. ``variant_label`` next to it stays free text for the specifics
+# ("v1.0.1").
 #
 # Note that the paired kinds are two entries rather than one: in a spreads /
 # single-page pair each file carries its own kind, and the same holds for
 # gridded / gridless. A single "spreads-or-single" kind could not say which
 # member you were looking at.
-VARIANT_KINDS = frozenset(
-    {
+#
+# The vocabulary is *scoped by collection*, because most kinds only mean
+# something for one of them: a gridless token or a form-fillable audio track is
+# not a distinction a user can make, and offering it only invites mis-filing.
+# Anything that applies everywhere lives in _UNIVERSAL; the rest is listed
+# against the collections it actually describes.
+_UNIVERSAL = frozenset({"version", "other"})
+
+# What a kind means where it is not obvious from the name:
+#   universal-vtt - a .dd2vtt/.uvtt export carrying walls and lights, the same
+#                   map as the flat image beside it.
+#   video         - an animated cut of a still map.
+#   image         - the still cut of an animated one; the counterpart to
+#                   ``video``, for the same reason gridded/gridless are a pair.
+VARIANT_KINDS_BY_TYPE: dict[str, frozenset] = {
+    "book": _UNIVERSAL
+    | {
         "printer-friendly",
         "form-fillable",
         "spreads",
         "single-page",
-        "version",
+        "black-and-white",
+    },
+    "map": _UNIVERSAL
+    | {
+        "printer-friendly",
         "black-and-white",
         "gridded",
         "gridless",
-        "other",
-    }
-)
+        "universal-vtt",
+        "video",
+        "image",
+    },
+    "token": _UNIVERSAL | {"black-and-white", "color-variation"},
+    "audio": _UNIVERSAL | {"remix", "slowed", "sped-up"},
+}
+
+# Every kind any collection accepts. Used where a resource type is not in hand —
+# the ORM column comment, and the legacy path in ``validate_kind`` that lets a
+# row keep a kind its collection no longer offers.
+VARIANT_KINDS = frozenset().union(*VARIANT_KINDS_BY_TYPE.values())
+
+
+def kinds_for(resource_type: str) -> frozenset:
+    """The kinds ``resource_type`` accepts, or the full set for an unknown one.
+
+    Falling back to the full set rather than raising keeps callers that do not
+    know their collection (older clients, ad-hoc scripts) working exactly as
+    they did before the vocabulary was scoped.
+    """
+    return VARIANT_KINDS_BY_TYPE.get(resource_type or "", VARIANT_KINDS)

--- a/backend/routers/duplicates/core.py
+++ b/backend/routers/duplicates/core.py
@@ -56,7 +56,15 @@ def link_variants(
             continue
         seen.add(child.id)
         try:
-            variants.link(db, model, data.parent_id, child.id, child.kind, child.label)
+            variants.link(
+                db,
+                model,
+                data.parent_id,
+                child.id,
+                child.kind,
+                child.label,
+                resource_type=data.resource_type,
+            )
             linked.append(child.id)
         except VariantError as exc:
             errors.append({"id": child.id, "detail": exc.message})
@@ -85,7 +93,13 @@ def promote_variant(
     model = resolve_model(data.resource_type)
     try:
         moved = variants.promote(
-            db, model, data.new_parent_id, data.old_parent_id, data.kind, data.label
+            db,
+            model,
+            data.new_parent_id,
+            data.old_parent_id,
+            data.kind,
+            data.label,
+            resource_type=data.resource_type,
         )
     except VariantError as exc:
         db.rollback()

--- a/backend/services/duplicates/job.py
+++ b/backend/services/duplicates/job.py
@@ -259,7 +259,7 @@ def _persist(db: Session, scan_id: str, resource_type: str, groups: list, by_id:
         kinds = {}
         for record in members:
             other = next(m for m in members if m.id != record.id)
-            kind, label = scoring.suggest_kind(record, other)
+            kind, label = scoring.suggest_kind(record, other, resource_type)
             kinds[record.id] = {"kind": kind, "label": label}
         db.add(
             DuplicateGroup(

--- a/backend/services/duplicates/scoring.py
+++ b/backend/services/duplicates/scoring.py
@@ -8,16 +8,57 @@ never automatic.
 import re
 from typing import Any, Optional
 
+from ...indexer.constants import IMAGE_EXTS, MAP_VIDEO_EXTS, VTT_DATA_EXTS
+from ...models.variants import kinds_for
+
 # Filename tokens that name a variant kind. Ordered most-specific first, since
 # "printer friendly single page" should read as printer-friendly rather than
 # single-page. Each entry maps a regex to a kind in models.variants.VARIANT_KINDS.
+#
+# The list is shared across collections and then filtered by what the collection
+# actually accepts (see ``suggest_kind``), rather than split into four tables:
+# the same token means the same thing wherever it appears, and a per-collection
+# copy would drift.
 _KIND_PATTERNS: tuple[tuple[str, str], ...] = (
     (r"form[\s_-]?fillable|fillable|editable", "form-fillable"),
     (r"printer[\s_-]?friendly|print[\s_-]?ready|printable|\bprint\b", "printer-friendly"),
     (r"b\s*&\s*w|black[\s_-]?and[\s_-]?white|gr[ea]yscale|\bbw\b", "black-and-white"),
     (r"spreads?|two[\s_-]?page|facing", "spreads"),
     (r"single[\s_-]?page|one[\s_-]?page|1[\s_-]?page", "single-page"),
+    (r"universal[\s_-]?vtt|\buvtt\b|\bdd2vtt\b|\bdd2\b", "universal-vtt"),
+    (r"animated|\bloop(?:ing)?\b|\bvideo\b|\bmp4\b|\bwebm\b", "video"),
+    # Likewise no bare "slow" — "Slow March.mp3" names the piece.
+    (r"slowed(?:[\s_-]?down)?|half[\s_-]?speed|\bslower\b", "slowed"),
+    # No bare "fast": "Fast Travel Theme.mp3" is a track name, not a variant.
+    (r"sped[\s_-]?up|speed[\s_-]?up|double[\s_-]?speed|\bfaster\b", "sped-up"),
+    (r"\bremix(?:ed)?\b|\bedit\b|\brework\b", "remix"),
+    (r"colou?r[\s_-]?(?:variation|variant|swap|alt)|recolou?r(?:ed)?", "color-variation"),
 )
+
+# Extensions that settle a map pair on their own: a .dd2vtt beside a .png is a
+# universal-VTT export of it, and an .mp4 beside a .webp is the animated cut.
+# Checked only when the filenames themselves said nothing, since an explicit
+# marker in the name is the stronger signal.
+#
+# Taken from the indexer's own tables rather than restated, so a format added
+# there (a new video container, say) is classified here without a second edit.
+_EXT_KINDS: tuple[tuple[frozenset, str], ...] = (
+    (frozenset(VTT_DATA_EXTS), "universal-vtt"),
+    (frozenset(MAP_VIDEO_EXTS), "video"),
+    (frozenset(IMAGE_EXTS), "image"),
+)
+
+
+def _ext_kind(filename: str) -> Optional[str]:
+    """The kind a map file's extension implies, if any."""
+    dot = (filename or "").rfind(".")
+    if dot < 0:
+        return None
+    ext = filename[dot:].lower()
+    for exts, kind in _EXT_KINDS:
+        if ext in exts:
+            return kind
+    return None
 
 # A version marker anywhere in the name: v1, v1.0, v1.0.1, "rev 2", "2nd printing".
 # `\b` is no help here: an underscore is a word character, so "Book_v1.0.1"
@@ -38,17 +79,24 @@ def version_token(name: str) -> Optional[str]:
     return match.group(1) or match.group(2)
 
 
-def suggest_kind(record: Any, other: Any) -> tuple[str, str]:
+def suggest_kind(record: Any, other: Any, resource_type: str = "") -> tuple[str, str]:
     """Guess ``(kind, label)`` for ``record`` when paired against ``other``.
 
     Compared against the other member rather than read in isolation, because the
     kind is relational: the copy *without* "printer friendly" in its name is only
     the main edition relative to the one that has it.
+
+    ``resource_type`` keeps the guess inside what that collection accepts — an
+    audio file named "print.mp3" must not be pre-filled as printer-friendly,
+    because the form it pre-fills would then refuse to submit.
     """
+    allowed = kinds_for(resource_type)
     name = f"{record.filename} {getattr(record, 'title', '') or ''}".lower()
     other_name = f"{other.filename} {getattr(other, 'title', '') or ''}".lower()
 
     for pattern, kind in _KIND_PATTERNS:
+        if kind not in allowed:
+            continue
         mine = re.search(pattern, name) is not None
         theirs = re.search(pattern, other_name) is not None
         # Only a marker that distinguishes the two says anything useful.
@@ -60,8 +108,14 @@ def suggest_kind(record: Any, other: Any) -> tuple[str, str]:
 
     my_grid = grid_marker(record.filename)
     their_grid = grid_marker(other.filename)
-    if my_grid is not None and my_grid != their_grid:
+    if my_grid is not None and my_grid != their_grid and "gridded" in allowed:
         return ("gridded" if my_grid else "gridless"), ""
+
+    # Format markers, for maps: the pair is only telling when the two sides
+    # disagree, exactly as with the grid.
+    my_ext = _ext_kind(record.filename)
+    if my_ext in allowed and my_ext != _ext_kind(other.filename):
+        return my_ext, ""
 
     # An explicit version column beats anything parsed out of a filename.
     my_version = (getattr(record, "version", "") or "").strip()

--- a/backend/services/variants.py
+++ b/backend/services/variants.py
@@ -27,7 +27,7 @@ from typing import Any, Iterable, Optional, Sequence
 from sqlalchemy import func
 from sqlalchemy.orm import Query, Session
 
-from ..models.variants import VARIANT_KINDS
+from ..models.variants import VARIANT_KINDS, kinds_for
 
 
 class VariantError(Exception):
@@ -130,13 +130,29 @@ def family_for(db: Session, model: Any, record: Any) -> tuple[Any, list[Any]]:
     return parent, variants_of(db, model, parent.id)
 
 
-def validate_kind(kind: str) -> str:
-    """Normalise and check a variant kind against the closed vocabulary."""
+def validate_kind(kind: str, resource_type: str = "", current: str = "") -> str:
+    """Normalise and check a variant kind against the vocabulary for a collection.
+
+    ``resource_type`` narrows the accepted set: a map can be marked gridless, a
+    token cannot. Omitting it accepts any kind any collection defines, which is
+    what keeps callers that do not know their collection working.
+
+    ``current`` is the kind the row already carries. A row linked before the
+    vocabulary was scoped may hold a kind its collection no longer offers (a
+    token marked printer-friendly); re-saving it unchanged must not fail, or the
+    only way to touch that row would be to change the one field that is stuck.
+    Anything *else* is still refused, so the stale value can be corrected but
+    never spread.
+    """
     cleaned = (kind or "").strip().lower()
-    if cleaned not in VARIANT_KINDS:
+    allowed = kinds_for(resource_type)
+    if cleaned not in allowed:
+        if cleaned and cleaned == (current or "").strip().lower() and cleaned in VARIANT_KINDS:
+            return cleaned
         raise VariantError(
-            f"Unknown variant kind '{kind}'. Expected one of: "
-            f"{', '.join(sorted(VARIANT_KINDS))}.",
+            f"Unknown variant kind '{kind}'"
+            f"{f' for {resource_type}' if resource_type else ''}. Expected one of: "
+            f"{', '.join(sorted(allowed))}.",
             code="invalid",
         )
     return cleaned
@@ -184,12 +200,18 @@ def assert_can_parent(db: Session, model: Any, parent_id: str, child_id: str) ->
 
 
 def link(
-    db: Session, model: Any, parent_id: str, child_id: str, kind: str, label: str = ""
+    db: Session,
+    model: Any,
+    parent_id: str,
+    child_id: str,
+    kind: str,
+    label: str = "",
+    resource_type: str = "",
 ) -> Any:
     """Make ``child_id`` a variant of ``parent_id``. Does not commit."""
     parent, child = assert_can_parent(db, model, parent_id, child_id)
     child.variant_parent_id = parent.id
-    child.variant_kind = validate_kind(kind)
+    child.variant_kind = validate_kind(kind, resource_type, child.variant_kind)
     child.variant_label = (label or "").strip()[:120]
     return child
 
@@ -225,7 +247,13 @@ def unlink_children(db: Session, model: Any, parent_id: str) -> int:
 
 
 def promote(
-    db: Session, model: Any, new_parent_id: str, old_parent_id: str, kind: str, label: str = ""
+    db: Session,
+    model: Any,
+    new_parent_id: str,
+    old_parent_id: str,
+    kind: str,
+    label: str = "",
+    resource_type: str = "",
 ) -> int:
     """Make ``new_parent_id`` the main version of ``old_parent_id``'s family.
 
@@ -281,7 +309,7 @@ def promote(
         moved += 1
 
     old_parent.variant_parent_id = new_parent_id
-    old_parent.variant_kind = validate_kind(kind)
+    old_parent.variant_kind = validate_kind(kind, resource_type, old_parent.variant_kind)
     old_parent.variant_label = (label or "").strip()[:120]
     return moved + 1
 

--- a/backend/tests/test_duplicates_api.py
+++ b/backend/tests/test_duplicates_api.py
@@ -802,3 +802,125 @@ class TestListGroups:
             seen += [g["id"] for g in page["groups"]]
         assert seen == [g["id"] for g in whole["groups"]]
         assert len(set(seen)) == 12
+
+
+class TestKindVocabularyByType:
+    """A kind only offered for one collection is refused for the others.
+
+    The vocabulary is scoped so the picker cannot offer a gridless token or a
+    form-fillable audio track; these check the API enforces the same thing, since
+    the picker is not the only caller.
+    """
+
+    @pytest.fixture
+    def factories(self, system):
+        """`factory()` for each collection, with books given their system."""
+        return {
+            "book": lambda: make_book(system.id),
+            "map": make_map,
+            "token": make_token,
+            "audio": make_audio,
+        }
+
+    @pytest.mark.parametrize(
+        "rtype,kind",
+        [
+            ("map", "universal-vtt"),
+            ("map", "video"),
+            ("map", "image"),
+            ("map", "gridded"),
+            ("token", "color-variation"),
+            ("audio", "remix"),
+            ("audio", "slowed"),
+            ("audio", "sped-up"),
+            ("book", "form-fillable"),
+            ("book", "spreads"),
+        ],
+    )
+    def test_accepts_its_own_kinds(self, client, admin_headers, factories, rtype, kind):
+        factory = factories[rtype]
+        parent, child = factory(), factory()
+        res = _link(client, admin_headers, parent.id, child.id, kind, rtype=rtype)
+        assert res.status_code == 200
+        assert res.json()["linked"] == [child.id]
+
+    @pytest.mark.parametrize(
+        "rtype,kind",
+        [
+            # Map-only kinds, refused everywhere else.
+            ("book", "gridless"),
+            ("token", "gridded"),
+            ("audio", "universal-vtt"),
+            ("book", "video"),
+            ("token", "image"),
+            # Book-only kinds.
+            ("map", "form-fillable"),
+            ("token", "spreads"),
+            ("audio", "single-page"),
+            # Token-only.
+            ("book", "color-variation"),
+            # Audio-only.
+            ("map", "remix"),
+            ("book", "slowed"),
+            ("token", "sped-up"),
+            # printer-friendly is book/map; black-and-white is book/map/token.
+            ("audio", "printer-friendly"),
+            ("token", "printer-friendly"),
+            ("audio", "black-and-white"),
+        ],
+    )
+    def test_rejects_another_collections_kind(
+        self, client, admin_headers, factories, rtype, kind
+    ):
+        factory = factories[rtype]
+        parent, child = factory(), factory()
+        body = _link(client, admin_headers, parent.id, child.id, kind, rtype=rtype).json()
+        # A bad kind is a per-child error, not a failed request — same
+        # skip-and-continue contract as a bad id.
+        assert body["linked"] == []
+        assert kind in body["errors"][0]["detail"]
+
+    @pytest.mark.parametrize("rtype", ["book", "map", "token", "audio"])
+    def test_version_and_other_work_everywhere(self, client, admin_headers, factories, rtype):
+        factory = factories[rtype]
+        for kind in ("version", "other"):
+            parent, child = factory(), factory()
+            res = _link(client, admin_headers, parent.id, child.id, kind, rtype=rtype)
+            assert res.json()["linked"] == [child.id], (rtype, kind)
+
+    def test_promote_rejects_another_collections_kind(self, client, admin_headers):
+        # The demoted copy is described by `kind` too, so promote validates it
+        # against the same table.
+        first, second = make_map(), make_map()
+        res = _promote(client, admin_headers, first.id, second.id, kind="remix", rtype="map")
+        assert res.status_code == 400
+        assert "remix" in res.json()["detail"]
+
+    def test_legacy_kind_survives_a_resave(self, client, admin_headers):
+        """A row filed before the vocabulary was scoped can be re-saved as-is.
+
+        Otherwise the one field that is stuck would be the one blocking every
+        other edit to that row.
+        """
+        from backend.config import SessionLocal
+        from backend.models import Token
+
+        parent, child = make_token(), make_token()
+        assert _link(client, admin_headers, parent.id, child.id, "other",
+                     rtype="token").json()["linked"] == [child.id]
+
+        # Simulate the pre-scoping row: a token marked with a book-only kind.
+        db = SessionLocal()
+        db.query(Token).filter_by(id=child.id).update({"variant_kind": "form-fillable"})
+        db.commit()
+        db.close()
+
+        body = _link(client, admin_headers, parent.id, child.id, "form-fillable",
+                     rtype="token").json()
+        assert body["linked"] == [child.id]
+
+        # ...but it can only be kept, never spread to a second row.
+        other = make_token()
+        body = _link(client, admin_headers, parent.id, other.id, "form-fillable",
+                     rtype="token").json()
+        assert body["linked"] == []

--- a/backend/tests/test_duplicates_detection.py
+++ b/backend/tests/test_duplicates_detection.py
@@ -536,3 +536,105 @@ class TestCrossSystemMatching:
         score = signals.metadata_score(a, b)
         for level in ("low", "medium"):
             assert score >= signals.thresholds_for(level)["metadata"], level
+
+
+class _Rec:
+    """The three attributes suggest_kind reads, without touching the DB."""
+
+    def __init__(self, filename, title="", version=""):
+        self.filename = filename
+        self.title = title
+        self.version = version
+
+
+class TestSuggestKindScoping:
+    """A pre-filled kind must be one the collection's form can submit.
+
+    ``suggest_kind`` runs at scan time and its answer lands in the picker, so a
+    guess outside the collection's vocabulary would seed a form that the API then
+    refuses — the user's first click on Link would fail for no visible reason.
+    """
+
+    def test_suggests_the_new_map_kinds_from_filenames(self):
+        pairs = [
+            ("Keep_universal_vtt.dd2vtt", "Keep.png", "universal-vtt"),
+            ("Keep.uvtt", "Keep.png", "universal-vtt"),
+            ("Tavern_animated.webm", "Tavern.png", "video"),
+            ("Tavern.mp4", "Tavern.png", "video"),
+            ("Tavern.png", "Tavern.mp4", "image"),
+        ]
+        for mine, theirs, expected in pairs:
+            kind, _ = duplicates.suggest_kind(_Rec(mine), _Rec(theirs), "map")
+            assert kind == expected, (mine, theirs, kind)
+
+    def test_suggests_audio_kinds(self):
+        for mine, expected in [
+            ("Theme (Remix).mp3", "remix"),
+            ("Theme slowed.mp3", "slowed"),
+            ("Theme sped up.mp3", "sped-up"),
+        ]:
+            kind, _ = duplicates.suggest_kind(_Rec(mine), _Rec("Theme.mp3"), "audio")
+            assert kind == expected, (mine, kind)
+
+    def test_a_speed_word_in_a_track_name_is_not_a_variant(self):
+        # "Fast Travel" and "Slow March" are pieces of music, not cuts of one.
+        for name in ("Fast Travel Theme.mp3", "Slow March.mp3"):
+            kind, _ = duplicates.suggest_kind(_Rec(name), _Rec("Theme.mp3"), "audio")
+            assert kind == "other", name
+
+    def test_suggests_a_token_colour_variation(self):
+        kind, _ = duplicates.suggest_kind(
+            _Rec("Goblin_color_variant.png"), _Rec("Goblin.png"), "token"
+        )
+        assert kind == "color-variation"
+
+    def test_never_suggests_another_collections_kind(self):
+        # "print" in an audio filename must not become printer-friendly, and a
+        # gridless marker on a token must not become gridless.
+        kind, _ = duplicates.suggest_kind(
+            _Rec("Theme printable.mp3"), _Rec("Theme.mp3"), "audio"
+        )
+        assert kind == "other"
+
+        kind, _ = duplicates.suggest_kind(
+            _Rec("Goblin_nogrid.png"), _Rec("Goblin.png"), "token"
+        )
+        assert kind == "other"
+
+        kind, _ = duplicates.suggest_kind(
+            _Rec("Guide spreads.pdf"), _Rec("Guide.pdf"), "map"
+        )
+        assert kind == "other"
+
+    def test_every_suggestion_is_valid_for_its_collection(self):
+        """The property that matters, over a spread of provocative names."""
+        from backend.models.variants import kinds_for
+
+        names = [
+            "Thing printable.x", "Thing fillable.x", "Thing b&w.x", "Thing spreads.x",
+            "Thing single page.x", "Thing.dd2vtt", "Thing.mp4", "Thing.png",
+            "Thing remix.x", "Thing slowed.x", "Thing sped up.x", "Thing recolored.x",
+            "Thing_nogrid.x", "Thing v2.1.x", "Thing.x",
+        ]
+        for rtype in ("book", "map", "token", "audio"):
+            allowed = kinds_for(rtype)
+            for mine in names:
+                kind, _ = duplicates.suggest_kind(_Rec(mine), _Rec("Thing.x"), rtype)
+                assert kind in allowed, (rtype, mine, kind)
+
+    def test_version_fallback_still_works_everywhere(self):
+        for rtype in ("book", "map", "token", "audio"):
+            kind, label = duplicates.suggest_kind(
+                _Rec("Thing_v2.1.x"), _Rec("Thing_v1.0.x"), rtype
+            )
+            assert (kind, label) == ("version", "v2.1"), rtype
+
+    def test_omitting_the_type_keeps_the_old_unscoped_behaviour(self):
+        kind, _ = duplicates.suggest_kind(_Rec("Guide printable.pdf"), _Rec("Guide.pdf"))
+        assert kind == "printer-friendly"
+
+    def test_a_shared_extension_says_nothing(self):
+        # Two .png maps: the extension rule must not fire, since neither side is
+        # distinguished by it.
+        kind, _ = duplicates.suggest_kind(_Rec("Keep.png"), _Rec("Keep2.png"), "map")
+        assert kind == "other"

--- a/backend/tests/test_indexer_map_formats.py
+++ b/backend/tests/test_indexer_map_formats.py
@@ -152,6 +152,50 @@ class TestMapFormatScan:
         assert m is not None
         assert m.has_thumbnail is True
 
+    def test_existing_uvtt_row_is_backfilled_on_rescan(self):
+        """A UVTT map registered before thumbnailing must not stay coverless.
+
+        Existing rows are skipped by the walk, so without an explicit backfill
+        these would never gain a thumbnail no matter how often the user rescans.
+        """
+        import base64
+        import io as _io
+        import json as _json
+
+        buf = _io.BytesIO()
+        Image.new("RGB", (240, 180), (80, 20, 120)).save(buf, "PNG")
+        name = f"backfill_{os.path.basename(self.tmp)}.uvtt"
+        (self.map_dir / name).write_text(
+            _json.dumps({"format": 0.3, "image": base64.b64encode(buf.getvalue()).decode()})
+        )
+        self._scan()
+
+        # Simulate the pre-change state: registered, but with no thumbnail.
+        db = SessionLocal()
+        try:
+            m = db.query(GenericMap).filter(GenericMap.filename == name).first()
+            assert m is not None
+            m.has_thumbnail = False
+            db.commit()
+        finally:
+            db.close()
+
+        self._scan()
+
+        m = self._get_map(name)
+        assert m is not None
+        assert m.has_thumbnail is True, "rescan should backfill the missing UVTT thumbnail"
+
+    def test_backfill_leaves_video_maps_alone(self):
+        name = f"nobackfill_{os.path.basename(self.tmp)}.webm"
+        (self.map_dir / name).write_bytes(b"\x1a\x45\xdf\xa3fake-webm")
+        self._scan()
+        self._scan()
+
+        m = self._get_map(name)
+        assert m is not None
+        assert m.has_thumbnail is False
+
     def test_still_image_alongside_still_thumbnails(self):
         # The opaque formats must not regress normal image handling.
         stem = os.path.basename(self.tmp)

--- a/backend/tests/test_variants_model.py
+++ b/backend/tests/test_variants_model.py
@@ -439,3 +439,86 @@ class TestPromote:
                 variants.promote(db, Book, b.id, a.id, "not-a-kind")
         finally:
             db.close()
+
+
+class TestKindVocabulary:
+    """The kind vocabulary is scoped per collection (models/variants.py)."""
+
+    def test_kinds_for_returns_only_that_collections_kinds(self):
+        from backend.models.variants import kinds_for
+
+        assert "gridless" in kinds_for("map")
+        assert "gridless" not in kinds_for("token")
+        assert "form-fillable" in kinds_for("book")
+        assert "form-fillable" not in kinds_for("audio")
+        assert "remix" in kinds_for("audio")
+        assert "remix" not in kinds_for("map")
+        assert "color-variation" in kinds_for("token")
+        assert "color-variation" not in kinds_for("book")
+
+    def test_map_only_kinds_are_map_only(self):
+        from backend.models.variants import VARIANT_KINDS_BY_TYPE, kinds_for
+
+        for kind in ("universal-vtt", "video", "image", "gridded", "gridless"):
+            assert kind in kinds_for("map"), kind
+            for other in set(VARIANT_KINDS_BY_TYPE) - {"map"}:
+                assert kind not in kinds_for(other), (kind, other)
+
+    def test_version_and_other_are_universal(self):
+        from backend.models.variants import VARIANT_KINDS_BY_TYPE, kinds_for
+
+        for rtype in VARIANT_KINDS_BY_TYPE:
+            assert {"version", "other"} <= kinds_for(rtype), rtype
+
+    def test_printer_friendly_and_black_and_white_reach(self):
+        from backend.models.variants import kinds_for
+
+        # printer-friendly: book and map. black-and-white: those plus tokens.
+        assert "printer-friendly" in kinds_for("book")
+        assert "printer-friendly" in kinds_for("map")
+        assert "printer-friendly" not in kinds_for("token")
+        assert "printer-friendly" not in kinds_for("audio")
+        for rtype in ("book", "map", "token"):
+            assert "black-and-white" in kinds_for(rtype), rtype
+        assert "black-and-white" not in kinds_for("audio")
+
+    def test_unknown_resource_type_accepts_everything(self):
+        from backend.models.variants import VARIANT_KINDS, kinds_for
+
+        # Callers that do not know their collection keep pre-scoping behaviour.
+        assert kinds_for("") == VARIANT_KINDS
+        assert kinds_for("widget") == VARIANT_KINDS
+
+    def test_flat_set_is_the_union(self):
+        from backend.models.variants import VARIANT_KINDS, VARIANT_KINDS_BY_TYPE
+
+        union = set().union(*VARIANT_KINDS_BY_TYPE.values())
+        assert VARIANT_KINDS == union
+
+
+class TestValidateKind:
+    def test_normalises_case_and_whitespace(self):
+        assert variants.validate_kind("  GridLess ", "map") == "gridless"
+
+    def test_rejects_a_kind_from_another_collection(self):
+        with pytest.raises(VariantError) as excinfo:
+            variants.validate_kind("gridless", "audio")
+        # The message lists what *is* accepted, so the caller can fix it.
+        assert "remix" in excinfo.value.message
+        assert excinfo.value.code == "invalid"
+
+    def test_no_resource_type_accepts_any_kind(self):
+        assert variants.validate_kind("gridless") == "gridless"
+        assert variants.validate_kind("remix") == "remix"
+
+    def test_keeps_a_legacy_kind_the_row_already_has(self):
+        # A token filed as form-fillable before the vocabulary was scoped.
+        assert variants.validate_kind("form-fillable", "token", "form-fillable") == "form-fillable"
+
+    def test_legacy_exemption_does_not_extend_to_other_kinds(self):
+        with pytest.raises(VariantError):
+            variants.validate_kind("spreads", "token", "form-fillable")
+
+    def test_still_rejects_a_kind_no_collection_defines(self):
+        with pytest.raises(VariantError):
+            variants.validate_kind("bogus", "map", "bogus")

--- a/docs/api.md
+++ b/docs/api.md
@@ -1288,11 +1288,33 @@ the matching edge from the live results — and with it the transitive path that
 would otherwise put the rejected pair back on screen.
 
 **Variants** are how #306 collapses versions. `POST /duplicates/link` points one
-record at another via `variant_parent_id`, with a `kind` from `printer-friendly`,
-`form-fillable`, `spreads`, `single-page`, `version`, `black-and-white`,
-`gridded`, `gridless`, `other`, and a free-text `label` ("v1.0.1"). Only two
-levels are allowed — a variant cannot itself have variants — which makes cycles
-impossible and keeps the version picker flat. Deleting a record that has
+record at another via `variant_parent_id`, with a `kind` and a free-text `label`
+("v1.0.1"). The accepted kinds depend on `resource_type`, because most of them
+only mean something for one collection — a gridless token or a form-fillable
+audio track is not a distinction that exists:
+
+| `resource_type` | Accepted `kind` values |
+| --- | --- |
+| *(any)* | `version`, `other` |
+| `book` | + `printer-friendly`, `form-fillable`, `spreads`, `single-page`, `black-and-white` |
+| `map` | + `printer-friendly`, `black-and-white`, `gridded`, `gridless`, `universal-vtt`, `video`, `image` |
+| `token` | + `black-and-white`, `color-variation` |
+| `audio` | + `remix`, `slowed`, `sped-up` |
+
+`universal-vtt` is a `.dd2vtt`/`.uvtt` export carrying walls and lights;
+`video` and `image` are the animated and still cuts of one map, a pair in the
+same way `gridded`/`gridless` are.
+
+A kind outside its collection's list is rejected — as a per-child `errors` entry
+on `link` (the same skip-and-continue contract as a bad id), and as a `400` on
+`promote`, whose `kind` describes the copy being demoted. The one exception is a
+record that *already* carries such a kind, from before the vocabulary was scoped
+per collection: re-saving it unchanged is allowed, so that one stuck field does
+not block every other edit to the row. It can be corrected, but not copied to a
+second record.
+
+Only two levels are allowed — a variant cannot itself have variants — which
+makes cycles impossible and keeps the version picker flat. Deleting a record that has
 variants requires `reparent_to`: either an id naming which variant inherits the
 rest, or `""` to promote them all. A variant is never left pointing at a deleted
 parent.

--- a/docs/data-model.md
+++ b/docs/data-model.md
@@ -155,8 +155,15 @@ express anyway (two levels only, no self-parenting, no cycles) are enforced in
 
 All three media tables carry the same `variant_parent_id` / `variant_kind` /
 `variant_label` columns as `books` (see above), each with an
-`ix_<table>_variant_parent` index. Maps use them for gridded/gridless pairs, and
-any collection can use them for an alternate cut of the same file.
+`ix_<table>_variant_parent` index. Every collection uses them for an alternate
+cut of the same file, but the `variant_kind` vocabulary is *scoped per
+collection* (`VARIANT_KINDS_BY_TYPE` in `backend/models/variants.py`): maps get
+gridded/gridless plus Universal VTT and video/image, tokens get colour
+variations, audio gets remix/slowed/sped-up, and books keep the print-shape
+kinds. The column itself is unconstrained, so a row written before the
+vocabulary was scoped may hold a kind its collection no longer offers; the
+service layer lets such a row keep its value but refuses to write that pairing
+to any other row.
 
 None of these tables carry foreign keys; they are linked to campaigns polymorphically via
 `campaign_resources`.

--- a/frontend/src/components/system/BookVersionsSection.jsx
+++ b/frontend/src/components/system/BookVersionsSection.jsx
@@ -5,7 +5,7 @@ import { LuLayers, LuTrash2 } from 'react-icons/lu'
 import api, { duplicates, mediaUrl } from '../../api'
 import { useAuth } from '../../context/AuthContext'
 import { formatSize } from '../../utils'
-import { VARIANT_KINDS } from '../../constants/variantKinds'
+import { kindsFor } from '../../constants/variantKinds'
 
 /**
  * Manage the versions filed under one book, from the book itself.
@@ -180,9 +180,13 @@ export default function BookVersionsSection({ book, onChanged }) {
                   fontSize: 12,
                 }}
               >
-                {VARIANT_KINDS.map((kind) => (
+                {/* Book kinds only — this section is mounted from the book
+                    editor and details modal. `entry.kind` is passed so a
+                    version filed under an older, unscoped vocabulary still
+                    shows its own value instead of jumping to another. */}
+                {kindsFor('book', entry.kind).map((kind) => (
                   <option key={kind} value={kind}>
-                    {t(`variants.kind.${kind}`)}
+                    {t(`variants.kind.${kind}`, { defaultValue: kind })}
                   </option>
                 ))}
               </select>

--- a/frontend/src/components/system/BookVersionsSection.test.jsx
+++ b/frontend/src/components/system/BookVersionsSection.test.jsx
@@ -98,6 +98,35 @@ describe('BookVersionsSection', () => {
     )
   })
 
+  it('offers only the book kinds', async () => {
+    // Mounted from the book editor and details modal, so a map- or audio-only
+    // kind here would just be a submit the API rejects.
+    render(<BookVersionsSection book={row} />)
+    const select = await screen.findByLabelText('Change version type')
+    const values = [...select.options].map((o) => o.value)
+    expect(values).toEqual([
+      'version',
+      'printer-friendly',
+      'form-fillable',
+      'black-and-white',
+      'spreads',
+      'single-page',
+      'other',
+    ])
+  })
+
+  it('keeps a kind the book already carries but the vocabulary dropped', async () => {
+    mockGet.mockResolvedValue({
+      ...family,
+      variants: [{ ...family.variants[0], kind: 'gridless' }],
+    })
+    render(<BookVersionsSection book={row} />)
+    const select = await screen.findByLabelText('Change version type')
+    expect([...select.options].map((o) => o.value)).toContain('gridless')
+    // ...and it is what the select shows, rather than silently another kind.
+    expect(select.value).toBe('gridless')
+  })
+
   it('promotes a variant to the main version', async () => {
     render(<BookVersionsSection book={row} />)
     await userEvent.click(await screen.findByRole('button', { name: 'Make main' }))

--- a/frontend/src/constants/variantKinds.js
+++ b/frontend/src/constants/variantKinds.js
@@ -5,17 +5,76 @@
  * reaches for most often when resolving duplicates come first, and `other` sits
  * last as the fallback. Labels live in i18n under `variants.kind.*`.
  *
- * Kept in sync by hand — the list is closed and changes rarely, and fetching it
- * would cost a round trip before the picker could render.
+ * Kept in sync by hand — the lists are closed and change rarely, and fetching
+ * them would cost a round trip before the picker could render. The mirror is
+ * held to the backend by `variantKinds.test.js`, which asserts the exact
+ * per-collection membership rather than deriving it.
+ */
+
+/**
+ * Which kinds each collection accepts, mirroring `VARIANT_KINDS_BY_TYPE`.
+ *
+ * Scoped because most kinds only mean something for one collection: a gridless
+ * token or a form-fillable audio track is not a distinction a user can make,
+ * and the API rejects it. Each list is already in review order, so a picker can
+ * render it as-is.
+ */
+export const VARIANT_KINDS_BY_TYPE = {
+  book: [
+    'version',
+    'printer-friendly',
+    'form-fillable',
+    'black-and-white',
+    'spreads',
+    'single-page',
+    'other',
+  ],
+  map: [
+    'version',
+    'gridded',
+    'gridless',
+    'universal-vtt',
+    'video',
+    'image',
+    'printer-friendly',
+    'black-and-white',
+    'other',
+  ],
+  token: ['version', 'color-variation', 'black-and-white', 'other'],
+  audio: ['version', 'remix', 'slowed', 'sped-up', 'other'],
+}
+
+/**
+ * Every kind any collection accepts, in review order, deduplicated.
+ *
+ * The fallback for a caller with no resource type in hand. Prefer
+ * `kindsFor(resourceType)` wherever the collection is known — offering a token
+ * a kind the API will reject is a dead end the user only discovers on submit.
+ *
+ * `other` is pulled to the end: flattening puts it wherever the first list
+ * happened to end, and it has to stay last to read as the fallback it is.
  */
 export const VARIANT_KINDS = [
-  'version',
-  'printer-friendly',
-  'form-fillable',
-  'black-and-white',
-  'spreads',
-  'single-page',
-  'gridded',
-  'gridless',
+  ...new Set(
+    ['book', 'map', 'token', 'audio']
+      .flatMap((type) => VARIANT_KINDS_BY_TYPE[type])
+      .filter((kind) => kind !== 'other')
+  ),
   'other',
 ]
+
+/**
+ * The kinds `resourceType` accepts, plus `current` when the row already carries
+ * a kind that collection no longer offers.
+ *
+ * That second part matters for rows linked before the vocabulary was scoped: a
+ * token marked `printer-friendly` must still show what it is, and the select
+ * must hold that value, or mounting the picker would silently display — and on
+ * save, write — a different kind than the row has. The backend allows exactly
+ * this one exemption too (see `validate_kind`).
+ */
+export function kindsFor(resourceType, current = '') {
+  const kinds = VARIANT_KINDS_BY_TYPE[resourceType] || VARIANT_KINDS
+  if (current && !kinds.includes(current)) return [...kinds, current]
+  return kinds
+}

--- a/frontend/src/constants/variantKinds.test.js
+++ b/frontend/src/constants/variantKinds.test.js
@@ -1,5 +1,5 @@
 import { describe, it, expect } from 'vitest'
-import { VARIANT_KINDS } from './variantKinds'
+import { VARIANT_KINDS, VARIANT_KINDS_BY_TYPE, kindsFor } from './variantKinds'
 
 describe('VARIANT_KINDS', () => {
   it('matches the backend vocabulary exactly', () => {
@@ -8,19 +8,131 @@ describe('VARIANT_KINDS', () => {
     expect([...VARIANT_KINDS].sort()).toEqual(
       [
         'black-and-white',
+        'color-variation',
         'form-fillable',
         'gridded',
         'gridless',
+        'image',
         'other',
         'printer-friendly',
+        'remix',
         'single-page',
+        'slowed',
+        'sped-up',
         'spreads',
+        'universal-vtt',
         'version',
+        'video',
       ].sort()
     )
   })
 
   it('ends with the catch-all', () => {
     expect(VARIANT_KINDS[VARIANT_KINDS.length - 1]).toBe('other')
+  })
+
+  it('is the union of the per-type lists', () => {
+    const union = new Set(Object.values(VARIANT_KINDS_BY_TYPE).flat())
+    expect([...VARIANT_KINDS].sort()).toEqual([...union].sort())
+  })
+})
+
+describe('VARIANT_KINDS_BY_TYPE', () => {
+  // Mirrors VARIANT_KINDS_BY_TYPE in backend/models/variants.py. Kept as an
+  // explicit table rather than derived, so a change on either side shows up
+  // here as a failing assertion instead of passing silently.
+  it('matches the backend per-collection vocabulary', () => {
+    expect([...VARIANT_KINDS_BY_TYPE.book].sort()).toEqual([
+      'black-and-white',
+      'form-fillable',
+      'other',
+      'printer-friendly',
+      'single-page',
+      'spreads',
+      'version',
+    ])
+    expect([...VARIANT_KINDS_BY_TYPE.map].sort()).toEqual([
+      'black-and-white',
+      'gridded',
+      'gridless',
+      'image',
+      'other',
+      'printer-friendly',
+      'universal-vtt',
+      'version',
+      'video',
+    ])
+    expect([...VARIANT_KINDS_BY_TYPE.token].sort()).toEqual([
+      'black-and-white',
+      'color-variation',
+      'other',
+      'version',
+    ])
+    expect([...VARIANT_KINDS_BY_TYPE.audio].sort()).toEqual([
+      'other',
+      'remix',
+      'slowed',
+      'sped-up',
+      'version',
+    ])
+  })
+
+  it('offers version and other everywhere', () => {
+    for (const kinds of Object.values(VARIANT_KINDS_BY_TYPE)) {
+      expect(kinds).toContain('version')
+      expect(kinds).toContain('other')
+    }
+  })
+
+  it('keeps the map-only kinds off the other collections', () => {
+    for (const kind of ['gridded', 'gridless', 'universal-vtt', 'video', 'image']) {
+      expect(VARIANT_KINDS_BY_TYPE.map).toContain(kind)
+      for (const type of ['book', 'token', 'audio']) {
+        expect(VARIANT_KINDS_BY_TYPE[type]).not.toContain(kind)
+      }
+    }
+  })
+
+  it('keeps the book-only kinds off the other collections', () => {
+    for (const kind of ['form-fillable', 'spreads', 'single-page']) {
+      expect(VARIANT_KINDS_BY_TYPE.book).toContain(kind)
+      for (const type of ['map', 'token', 'audio']) {
+        expect(VARIANT_KINDS_BY_TYPE[type]).not.toContain(kind)
+      }
+    }
+  })
+
+  it('ends every list with the catch-all', () => {
+    for (const kinds of Object.values(VARIANT_KINDS_BY_TYPE)) {
+      expect(kinds[kinds.length - 1]).toBe('other')
+    }
+  })
+})
+
+describe('kindsFor', () => {
+  it('returns the collection list', () => {
+    expect(kindsFor('audio')).toEqual(VARIANT_KINDS_BY_TYPE.audio)
+  })
+
+  it('falls back to every kind for an unknown collection', () => {
+    expect(kindsFor('')).toEqual(VARIANT_KINDS)
+    expect(kindsFor('widget')).toEqual(VARIANT_KINDS)
+  })
+
+  it('appends a legacy kind the row already carries', () => {
+    // A token filed as form-fillable before the vocabulary was scoped: the
+    // select must be able to hold that value rather than silently showing
+    // another one.
+    const kinds = kindsFor('token', 'form-fillable')
+    expect(kinds).toContain('form-fillable')
+    expect(kinds).toEqual([...VARIANT_KINDS_BY_TYPE.token, 'form-fillable'])
+  })
+
+  it('does not duplicate a kind the collection already offers', () => {
+    expect(kindsFor('map', 'gridless')).toEqual(VARIANT_KINDS_BY_TYPE.map)
+  })
+
+  it('ignores an empty current kind', () => {
+    expect(kindsFor('token', '')).toEqual(VARIANT_KINDS_BY_TYPE.token)
   })
 })

--- a/frontend/src/locales/de-DE.json
+++ b/frontend/src/locales/de-DE.json
@@ -2326,6 +2326,13 @@
       "black-and-white": "Schwarzweiß",
       "gridded": "Mit Raster",
       "gridless": "Ohne Raster",
+      "universal-vtt": "Universal VTT",
+      "video": "Video",
+      "image": "Bild",
+      "color-variation": "Farbvariante",
+      "remix": "Remix",
+      "slowed": "Verlangsamt",
+      "sped-up": "Beschleunigt",
       "other": "Andere"
     },
     "downloadVersion": "Download version",

--- a/frontend/src/locales/en-CA.json
+++ b/frontend/src/locales/en-CA.json
@@ -2326,6 +2326,13 @@
       "black-and-white": "Black and white",
       "gridded": "Gridded",
       "gridless": "Gridless",
+      "universal-vtt": "Universal VTT",
+      "video": "Video",
+      "image": "Image",
+      "color-variation": "Colour variation",
+      "remix": "Remix",
+      "slowed": "Slowed",
+      "sped-up": "Sped up",
       "other": "Other"
     },
     "downloadVersion": "Download version",

--- a/frontend/src/locales/en-US.json
+++ b/frontend/src/locales/en-US.json
@@ -2326,6 +2326,13 @@
       "black-and-white": "Black and white",
       "gridded": "Gridded",
       "gridless": "Gridless",
+      "universal-vtt": "Universal VTT",
+      "video": "Video",
+      "image": "Image",
+      "color-variation": "Color variation",
+      "remix": "Remix",
+      "slowed": "Slowed",
+      "sped-up": "Sped up",
       "other": "Other"
     },
     "downloadVersion": "Download version",

--- a/frontend/src/locales/es-ES.json
+++ b/frontend/src/locales/es-ES.json
@@ -2326,6 +2326,13 @@
       "black-and-white": "Blanco y negro",
       "gridded": "Con cuadrícula",
       "gridless": "Sin cuadrícula",
+      "universal-vtt": "Universal VTT",
+      "video": "Vídeo",
+      "image": "Imagen",
+      "color-variation": "Variación de color",
+      "remix": "Remezcla",
+      "slowed": "Ralentizada",
+      "sped-up": "Acelerada",
       "other": "Otra"
     },
     "downloadVersion": "Download version",

--- a/frontend/src/locales/es-MX.json
+++ b/frontend/src/locales/es-MX.json
@@ -2326,6 +2326,13 @@
       "black-and-white": "Blanco y negro",
       "gridded": "Con cuadrícula",
       "gridless": "Sin cuadrícula",
+      "universal-vtt": "Universal VTT",
+      "video": "Video",
+      "image": "Imagen",
+      "color-variation": "Variación de color",
+      "remix": "Remezcla",
+      "slowed": "Ralentizada",
+      "sped-up": "Acelerada",
       "other": "Otra"
     },
     "downloadVersion": "Download version",

--- a/frontend/src/locales/fr-CA.json
+++ b/frontend/src/locales/fr-CA.json
@@ -2326,6 +2326,13 @@
       "black-and-white": "Noir et blanc",
       "gridded": "Avec grille",
       "gridless": "Sans grille",
+      "universal-vtt": "Universal VTT",
+      "video": "Vidéo",
+      "image": "Image",
+      "color-variation": "Variante de couleur",
+      "remix": "Remix",
+      "slowed": "Ralentie",
+      "sped-up": "Accélérée",
       "other": "Autre"
     },
     "downloadVersion": "Download version",

--- a/frontend/src/locales/fr-FR.json
+++ b/frontend/src/locales/fr-FR.json
@@ -2326,6 +2326,13 @@
       "black-and-white": "Noir et blanc",
       "gridded": "Avec grille",
       "gridless": "Sans grille",
+      "universal-vtt": "Universal VTT",
+      "video": "Vidéo",
+      "image": "Image",
+      "color-variation": "Variante de couleur",
+      "remix": "Remix",
+      "slowed": "Ralentie",
+      "sped-up": "Accélérée",
       "other": "Autre"
     },
     "downloadVersion": "Download version",

--- a/frontend/src/locales/nl-NL.json
+++ b/frontend/src/locales/nl-NL.json
@@ -2326,6 +2326,13 @@
       "black-and-white": "Zwart-wit",
       "gridded": "Met raster",
       "gridless": "Zonder raster",
+      "universal-vtt": "Universal VTT",
+      "video": "Video",
+      "image": "Afbeelding",
+      "color-variation": "Kleurvariant",
+      "remix": "Remix",
+      "slowed": "Vertraagd",
+      "sped-up": "Versneld",
       "other": "Overig"
     },
     "downloadVersion": "Download version",

--- a/frontend/src/locales/pt-BR.json
+++ b/frontend/src/locales/pt-BR.json
@@ -2326,6 +2326,13 @@
       "black-and-white": "Preto e branco",
       "gridded": "Com grelha",
       "gridless": "Sem grelha",
+      "universal-vtt": "Universal VTT",
+      "video": "Vídeo",
+      "image": "Imagem",
+      "color-variation": "Variação de cor",
+      "remix": "Remix",
+      "slowed": "Desacelerada",
+      "sped-up": "Acelerada",
       "other": "Outro"
     },
     "downloadVersion": "Download version",

--- a/frontend/src/locales/pt-PT.json
+++ b/frontend/src/locales/pt-PT.json
@@ -2326,6 +2326,13 @@
       "black-and-white": "Preto e branco",
       "gridded": "Com grelha",
       "gridless": "Sem grelha",
+      "universal-vtt": "Universal VTT",
+      "video": "Vídeo",
+      "image": "Imagem",
+      "color-variation": "Variação de cor",
+      "remix": "Remix",
+      "slowed": "Abrandada",
+      "sped-up": "Acelerada",
       "other": "Outro"
     },
     "downloadVersion": "Download version",

--- a/frontend/src/views/DuplicateCompareView.jsx
+++ b/frontend/src/views/DuplicateCompareView.jsx
@@ -6,7 +6,7 @@ import { LuArrowLeft, LuArrowLeftRight, LuLayers, LuTrash2, LuX } from 'react-ic
 import { duplicates as dupesApi } from '../api'
 import { useAuth } from '../context/AuthContext'
 import Spinner from '../components/Spinner'
-import { VARIANT_KINDS } from '../constants/variantKinds'
+import { kindsFor } from '../constants/variantKinds'
 import PagePreview from '../components/duplicates/PagePreview'
 import RefCounts from '../components/duplicates/RefCounts'
 import PageFlipper from '../components/duplicates/PageFlipper'
@@ -113,6 +113,22 @@ export default function DuplicateCompareView() {
   // instead. Anything else is an ordinary link.
   const childItem = childId === left?.id ? left : right
   const childHasFamily = (childItem?.variants || []).length > 0
+
+  // Only the kinds this collection accepts: a token has no gridless cut, and an
+  // audio track cannot be form-fillable. The child's stored kind is passed so a
+  // row linked before the vocabulary was scoped keeps its value in the list
+  // rather than being silently re-filed on the next save.
+  const kindOptions = useMemo(
+    () => kindsFor(resourceType, childItem?.variant_kind || ''),
+    [resourceType, childItem?.variant_kind]
+  )
+
+  // `kind` is seeded to `other`, which every collection accepts, but the user
+  // may have picked one and then flipped which side is the parent. Snap back to
+  // a valid choice rather than submitting one the API will reject.
+  useEffect(() => {
+    if (!kindOptions.includes(kind)) setKind('other')
+  }, [kindOptions, kind])
 
   const copyMetadata = async (fields) => {
     setBusy(true)
@@ -361,7 +377,7 @@ export default function DuplicateCompareView() {
                 minWidth: 190,
               }}
             >
-              {VARIANT_KINDS.map((k) => (
+              {kindOptions.map((k) => (
                 <option key={k} value={k}>
                   {t(`variants.kind.${k}`, { defaultValue: k })}
                 </option>

--- a/frontend/src/views/DuplicateCompareView.test.jsx
+++ b/frontend/src/views/DuplicateCompareView.test.jsx
@@ -13,9 +13,12 @@ vi.mock('react-i18next', () => ({
 }))
 
 const navigate = vi.fn()
+// Mutable so a test can put the view on the maps or audio route: the kind
+// picker's options depend on which collection is being reviewed.
+let resourceType = 'book'
 vi.mock('react-router-dom', () => ({
   useNavigate: () => navigate,
-  useParams: () => ({ resourceType: 'book' }),
+  useParams: () => ({ resourceType }),
   useSearchParams: () => [new URLSearchParams('left=a&right=b')],
 }))
 
@@ -76,6 +79,7 @@ describe('DuplicateCompareView', () => {
   beforeEach(() => {
     vi.clearAllMocks()
     role = 'admin'
+    resourceType = 'book'
     compare.mockResolvedValue(payload())
     link.mockResolvedValue({ linked: ['b'] })
     promote.mockResolvedValue({ moved: 2 })
@@ -254,5 +258,94 @@ describe('DuplicateCompareView', () => {
     compare.mockRejectedValue(new Error('gone'))
     render(<DuplicateCompareView />)
     await waitFor(() => expect(screen.getByText('gone')).toBeInTheDocument())
+  })
+})
+
+describe('DuplicateCompareView kind options', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    role = 'admin'
+    resourceType = 'book'
+    compare.mockResolvedValue(payload())
+    link.mockResolvedValue({ linked: ['b'] })
+  })
+
+  const kindSelect = () => screen.getAllByRole('combobox').find((el) => el.value === 'other')
+
+  const optionsOf = (select) => [...select.options].map((o) => o.value)
+
+  it('offers only book kinds on the books route', async () => {
+    render(<DuplicateCompareView />)
+    await waitFor(() => expect(screen.getByText('a.pdf')).toBeInTheDocument())
+    const values = optionsOf(kindSelect())
+    expect(values).toContain('form-fillable')
+    expect(values).toContain('spreads')
+    // Not a distinction a book can carry.
+    expect(values).not.toContain('gridless')
+    expect(values).not.toContain('universal-vtt')
+    expect(values).not.toContain('remix')
+  })
+
+  it('offers the map kinds on the maps route', async () => {
+    resourceType = 'map'
+    compare.mockResolvedValue(payload({ resource_type: 'map' }))
+    render(<DuplicateCompareView />)
+    await waitFor(() => expect(screen.getByText('a.pdf')).toBeInTheDocument())
+    const values = optionsOf(kindSelect())
+    for (const kind of ['gridded', 'gridless', 'universal-vtt', 'video', 'image']) {
+      expect(values).toContain(kind)
+    }
+    expect(values).not.toContain('form-fillable')
+    expect(values).not.toContain('remix')
+  })
+
+  it('offers the audio kinds on the audio route', async () => {
+    resourceType = 'audio'
+    compare.mockResolvedValue(payload({ resource_type: 'audio' }))
+    render(<DuplicateCompareView />)
+    await waitFor(() => expect(screen.getByText('a.pdf')).toBeInTheDocument())
+    const values = optionsOf(kindSelect())
+    expect(values).toEqual(['version', 'remix', 'slowed', 'sped-up', 'other'])
+  })
+
+  it('offers the token kinds on the tokens route', async () => {
+    resourceType = 'token'
+    compare.mockResolvedValue(payload({ resource_type: 'token' }))
+    render(<DuplicateCompareView />)
+    await waitFor(() => expect(screen.getByText('a.pdf')).toBeInTheDocument())
+    expect(optionsOf(kindSelect())).toEqual([
+      'version',
+      'color-variation',
+      'black-and-white',
+      'other',
+    ])
+  })
+
+  it('keeps a legacy kind the child already carries', async () => {
+    // A token filed as form-fillable before the vocabulary was scoped: the
+    // option has to exist, or the select would show a value the row does not
+    // have.
+    resourceType = 'token'
+    compare.mockResolvedValue(
+      payload({
+        resource_type: 'token',
+        items: [item('a'), item('b', { variant_kind: 'form-fillable' })],
+      })
+    )
+    render(<DuplicateCompareView />)
+    await waitFor(() => expect(screen.getByText('a.pdf')).toBeInTheDocument())
+    expect(optionsOf(kindSelect())).toContain('form-fillable')
+  })
+
+  it('links with a kind the collection accepts', async () => {
+    resourceType = 'map'
+    compare.mockResolvedValue(payload({ resource_type: 'map' }))
+    render(<DuplicateCompareView />)
+    await waitFor(() => expect(screen.getByText('a.pdf')).toBeInTheDocument())
+    await userEvent.selectOptions(kindSelect(), 'universal-vtt')
+    await userEvent.click(screen.getByText(/maintenance.dupes.linkAs/))
+    await waitFor(() =>
+      expect(link).toHaveBeenCalledWith('map', 'a', [{ id: 'b', kind: 'universal-vtt', label: '' }])
+    )
   })
 })

--- a/nightly.md
+++ b/nightly.md
@@ -814,7 +814,19 @@ The pairs shown are the comparisons that actually matched, not every combination
 
 - **Copy metadata** - move individual fields from the copy you are discarding onto the one you are keeping, before it goes. Keeping the better *file* should not mean keeping the worse *record*: a pristine scan often arrives with nothing but a filename while the copy you are about to delete has the title, publisher, and tags you curated. Only fields that actually differ are offered, and you tick them individually rather than copying wholesale.
 
-- **Link as versions** - collapse the two into one library entry. A radio button on each copy picks the main version, and a dropdown says what the other one *is*: a version, printer friendly, form fillable, black and white, spreads, single pages, gridded, gridless, or other - plus an optional free-text label like `v1.0.1`. The variant stops appearing separately in browsing, search, and counts.
+- **Link as versions** - collapse the two into one library entry. A radio button on each copy picks the main version, and a dropdown says what the other one *is* - plus an optional free-text label like `v1.0.1`. The variant stops appearing separately in browsing, search, and counts.
+
+  The dropdown only offers the kinds that make sense for what you are reviewing, since most of them describe one kind of file: a gridless token or a form-fillable audio track is not a real distinction. Every collection offers **version** and **other**; on top of that:
+
+  | Reviewing | Also offers |
+  | --- | --- |
+  | Books | Printer friendly, form fillable, black and white, two-page spreads, single pages |
+  | Maps | Gridded, gridless, Universal VTT, video, image, printer friendly, black and white |
+  | Tokens | Colour variation, black and white |
+  | Audio | Remix, slowed, sped up |
+
+  **Universal VTT** is a `.dd2vtt`/`.uvtt` export carrying walls and lights, and **video**/**image** are the animated and still cuts of the same map - a pair in the same way gridded and gridless are. The scan pre-fills its best guess from the filenames and extensions, and it only ever guesses something the collection actually offers.
+
 - **Delete a copy** - asks for confirmation in a dialog, and removes the file from disk by default. That default is the opposite of elsewhere in Grimoire, deliberately: you have just decided this copy is redundant, and leaving the bytes in the library folder means the next scan proposes the same pair all over again. Untick the box to drop only the library record.
 - **Not duplicates** - dismisses that pair. It disappears from the list straight away rather than lingering until the next scan, and it stays gone: the rejection is remembered per pair and survives every future rescan, including when a third copy of the same book turns up later and would otherwise drag the rejected pair back into a cluster with it. Dismissals are not final, though - **Show dismissed** at the foot of the duplicates page lists everything you have rejected, with a **Restore** button on each. Restoring one lets it be proposed again by the next scan (the list on screen was built while the dismissal still applied, so it does not reappear until you rescan).
 


### PR DESCRIPTION
## Summary

<!-- What does this PR do? A few sentences is fine. -->

## Type of change

- [ ] Bug fix
- [x] New feature
- [ ] Refactor / cleanup
- [ ] Docs / configuration only

## Testing

<!-- How did you verify this works? Check all that apply. -->

- [x] Backend tests pass (`pytest -q`)
- [x] Frontend tests pass (`npm test`)
- [x] Tested manually in the browser

## Notes for reviewer

<!-- Anything that needs extra context, known limitations, or follow-up work. Delete if not needed. -->
