### PR TITLE
Fix: Speed up map and token galleries on large libraries

### DIFF
--- a/backend/config.py
+++ b/backend/config.py
@@ -168,6 +168,16 @@ _PAGE_CACHE_HEADERS = {"Cache-Control": "max-age=31536000, immutable"}
 # holding hundreds of megabytes of originals.
 _MEDIA_FILE_CACHE_HEADERS = {"Cache-Control": "private, max-age=300"}
 
+# Media thumbnails (map/token grid cards). Unlike rendered pages these are NOT
+# content-addressed — the URL is /maps/{id}/thumbnail and stays the same when the
+# underlying image is replaced — so they must not be "immutable", or a browser
+# would never re-check and a replaced map would show its old thumbnail forever.
+# "no-cache" still caches the bytes; it just requires a revalidation, which the
+# ETag then answers with a cheap 304. They are also access-controlled (guests see
+# only what is shared with them; tokens can be flagged explicit), so the entry is
+# "private" — a shared proxy must never hand one user's thumbnail to another.
+_THUMBNAIL_CACHE_HEADERS = {"Cache-Control": "private, no-cache"}
+
 # Optional override for password authentication. When the env var is set,
 # it pins the value and the admin UI shows a read-only state. When unset,
 # the corresponding DB setting (password_auth_enabled) is used.

--- a/backend/routers/maps/core.py
+++ b/backend/routers/maps/core.py
@@ -3,21 +3,25 @@ import hashlib
 import io
 import os
 from pathlib import Path
-from typing import Optional
+from typing import Any, Optional
 
-from fastapi import APIRouter, Depends, HTTPException, Query
+from fastapi import APIRouter, Depends, HTTPException, Query, Request
+from sqlalchemy import or_, true
 from sqlalchemy.orm import Session
-from fastapi.responses import FileResponse, StreamingResponse
+from fastapi.responses import FileResponse, Response, StreamingResponse
 
 from ...config import (
     _MEDIA_FILE_CACHE_HEADERS,
     _PAGE_CACHE_HEADERS,
+    _THUMBNAIL_CACHE_HEADERS,
     THUMB_DIR,
     get_db,
     logger,
 )
 from ...models import GenericMap, MapFolder
 from ...services import bulk_service, tag_service, variants
+from ...services.content_cache import content_token
+from ...file_cache import etag_matches
 from ...auth import require_gm_or_admin, get_current_user, CurrentUser
 from ...indexer import MAP_OPAQUE_EXTS, archive_ext, archive_mime, is_vtt_data, slugify
 from .._bulk_schemas import BulkAddTags, BulkFolderTags
@@ -43,6 +47,31 @@ def _folder_path(relative_path: str) -> str:
     return "/".join(Path(relative_path.replace("\\", "/")).parts[1:-1])
 
 
+def _folder_prefix_filter(model: Any, folder: str) -> Any:
+    """SQL clause narrowing to rows whose relative_path could sit in ``folder``.
+
+    A relative_path is ``<system>/<folder…>/<file>``, so a row in ``folder`` has
+    it somewhere after the first segment. This is a cheap superset — it also
+    admits deeper descendants and any folder whose name merely starts with the
+    same text — which is why callers keep the exact :func:`_folder_path` check.
+    The empty (root) folder has no prefix to match on, so it is not narrowed.
+
+    ``escape="!"`` keeps a literal %, _ or ! in a real folder name from acting as
+    a LIKE wildcard. A backslash is not escaped and the escape character is not
+    one: :func:`_folder_path` normalises separators, so the folder string itself
+    never contains a backslash — only the stored path does, which is why the
+    Windows-separator variant is matched separately.
+    """
+    if not folder:
+        return true()
+    escaped = folder.replace("!", "!!").replace("%", "!%").replace("_", "!_")
+    win = escaped.replace("/", "\\")
+    return or_(
+        model.relative_path.like(f"%/{escaped}/%", escape="!"),
+        model.relative_path.like(f"%\\{win}\\%", escape="!"),
+    )
+
+
 def list_maps(
     map_type: Optional[str] = None,
     folder: Optional[str] = None,
@@ -50,16 +79,21 @@ def list_maps(
     offset: int = 0,
     db: Session = Depends(get_db),
 ):
-    # Applied before the folder branch below, which materialises the query with
-    # .all() and filters in Python — a variant must never reach that list
-    # (issues #304, #306).
+    # Applied before the folder branch below — a variant must never reach the
+    # list (issues #304, #306).
     q = variants.parents_only(db.query(GenericMap), GenericMap)
     if map_type:
         q = q.filter_by(map_type=map_type)
     q = q.order_by(GenericMap.filename)
     if folder is not None:
-        # Folder is derived from relative_path, not a column, so filter in
-        # Python. Paginate the filtered result.
+        # Folder is derived from relative_path rather than stored as a column, so
+        # it cannot be compared directly. Narrowing on the path prefix in SQL
+        # first means only that folder's subtree is materialised, instead of the
+        # whole table (which on a large library was the cost of opening a
+        # folder); the exact per-row check below still decides membership, since
+        # the prefix also matches deeper descendants and sibling folders sharing
+        # a name prefix.
+        q = q.filter(_folder_prefix_filter(GenericMap, folder))
         filtered = [m for m in q.all() if _folder_path(m.relative_path) == folder]
         total = len(filtered)
         maps = filtered[offset : offset + limit]
@@ -298,6 +332,7 @@ def get_map_vtt_data(
 
 def serve_map_thumbnail(
     map_id: str,
+    request: Request,
     current_user: CurrentUser = Depends(get_current_user),
     db: Session = Depends(get_db),
 ):
@@ -305,12 +340,21 @@ def serve_map_thumbnail(
     if not m:
         raise HTTPException(404)
     assert_media_access(db, current_user, "map", m.id)
+    # A gallery of thousands of maps hits this route once per visible card, so an
+    # uncached response means the whole grid is re-downloaded on every visit and
+    # every scroll back. The ETag carries the content token (not the path-derived
+    # filename, which cannot tell a replaced image from the original), so a client
+    # holding a stale thumbnail still finds out — mirroring books' cover route.
+    etag = f'"{content_token(m.content_hash, m.filepath)}"'
+    if etag_matches(request, etag):
+        return Response(status_code=304, headers={"ETag": etag, **_THUMBNAIL_CACHE_HEADERS})
+    headers = {**_THUMBNAIL_CACHE_HEADERS, "ETag": etag}
     title = Path(m.filename).stem.replace("_", " ").replace("-", " ")
     slug = slugify(title)
     fhash = hashlib.md5(m.filepath.encode()).hexdigest()[:8]
     thumb_path = os.path.join(THUMB_DIR, "maps", f"{slug}_{fhash}.webp")
     if os.path.exists(thumb_path):
-        return FileResponse(thumb_path, media_type="image/webp")
+        return FileResponse(thumb_path, media_type="image/webp", headers=headers)
     raise HTTPException(404)
 
 

--- a/backend/routers/tokens/core.py
+++ b/backend/routers/tokens/core.py
@@ -5,13 +5,15 @@ from pathlib import Path
 
 from PIL import Image as PILImage  # type: ignore[import-untyped]
 
-from fastapi import APIRouter, Depends, HTTPException, Query
+from fastapi import APIRouter, Depends, HTTPException, Query, Request
 from sqlalchemy.orm import Session
-from fastapi.responses import FileResponse
+from fastapi.responses import FileResponse, Response
 
-from ...config import THUMB_DIR, get_db
+from ...config import _THUMBNAIL_CACHE_HEADERS, THUMB_DIR, get_db
 from ...models import Token, TokenFolder
 from ...services import bulk_service, tag_service, variants
+from ...services.content_cache import content_token
+from ...file_cache import etag_matches
 from ...auth import require_gm_or_admin, get_current_user, CurrentUser
 from ...indexer import archive_ext, archive_mime, slugify
 from .._bulk_schemas import BulkAddTags, BulkFolderTags
@@ -152,6 +154,7 @@ def serve_token_file(
 
 def serve_token_thumbnail(
     token_id: str,
+    request: Request,
     current_user: CurrentUser = Depends(get_current_user),
     db: Session = Depends(get_db),
 ):
@@ -159,12 +162,18 @@ def serve_token_thumbnail(
     if not t:
         raise HTTPException(404)
     assert_media_access(db, current_user, "token", t.id, is_explicit=bool(t.is_explicit))
+    # See the note on maps' thumbnail route: a token grid is denser still, so an
+    # uncached response is the dominant cost of opening the page.
+    etag = f'"{content_token(t.content_hash, t.filepath)}"'
+    if etag_matches(request, etag):
+        return Response(status_code=304, headers={"ETag": etag, **_THUMBNAIL_CACHE_HEADERS})
+    headers = {**_THUMBNAIL_CACHE_HEADERS, "ETag": etag}
     title = Path(t.filename).stem.replace("_", " ").replace("-", " ")
     slug = slugify(title)
     fhash = hashlib.md5(t.filepath.encode()).hexdigest()[:8]
     thumb_path = os.path.join(THUMB_DIR, "tokens", f"{slug}_{fhash}.webp")
     if os.path.exists(thumb_path):
-        return FileResponse(thumb_path, media_type="image/webp")
+        return FileResponse(thumb_path, media_type="image/webp", headers=headers)
     raise HTTPException(404)
 
 

--- a/backend/tests/test_maps.py
+++ b/backend/tests/test_maps.py
@@ -86,6 +86,51 @@ class TestListMapsByFolder:
         assert resp.json()["total"] == 0
 
 
+class TestListMapsByFolderEdgeCases:
+    """The folder filter narrows on a path prefix in SQL before checking exactly.
+
+    The prefix is a deliberate superset, so these pin the cases where it admits
+    rows the exact check must then reject — a regression here would silently show
+    maps from the wrong folder.
+    """
+
+    @pytest.fixture(scope="class")
+    def tricky(self):
+        return {
+            # Exact match.
+            "town": make_map(filename="t.png", relative_path="DnD/Town/t.png"),
+            # A descendant: its folder is "Town/Inn", not "Town".
+            "inn": make_map(filename="i.png", relative_path="DnD/Town/Inn/i.png"),
+            # Shares a name prefix with "Town" but is a different folder.
+            "township": make_map(filename="s.png", relative_path="DnD/Township/s.png"),
+            # LIKE metacharacters that must be treated literally.
+            "pct": make_map(filename="p.png", relative_path="DnD/100%_Maps/p.png"),
+            "under": make_map(filename="u.png", relative_path="DnD/a_b/u.png"),
+            "other": make_map(filename="o.png", relative_path="DnD/a1b/o.png"),
+        }
+
+    def test_descendant_folder_not_returned_for_parent(self, client, admin_headers, tricky):
+        ids = {m["id"] for m in client.get("/api/maps?folder=Town", headers=admin_headers).json()["maps"]}
+        assert ids == {tricky["town"].id}
+
+    def test_name_prefix_sibling_not_returned(self, client, admin_headers, tricky):
+        ids = {m["id"] for m in client.get("/api/maps?folder=Township", headers=admin_headers).json()["maps"]}
+        assert ids == {tricky["township"].id}
+
+    def test_nested_folder_matches_exactly(self, client, admin_headers, tricky):
+        ids = {m["id"] for m in client.get("/api/maps?folder=Town/Inn", headers=admin_headers).json()["maps"]}
+        assert ids == {tricky["inn"].id}
+
+    def test_percent_in_folder_name_is_literal(self, client, admin_headers, tricky):
+        ids = {m["id"] for m in client.get("/api/maps?folder=100%25_Maps", headers=admin_headers).json()["maps"]}
+        assert ids == {tricky["pct"].id}
+
+    def test_underscore_in_folder_name_is_literal(self, client, admin_headers, tricky):
+        """"a_b" must not match "a1b" — the underscore is a LIKE single-char wildcard."""
+        ids = {m["id"] for m in client.get("/api/maps?folder=a_b", headers=admin_headers).json()["maps"]}
+        assert ids == {tricky["under"].id}
+
+
 class TestGetMap:
     def test_get_existing_map(self, client, admin_headers, map_entry):
         resp = client.get(f"/api/maps/{map_entry.id}", headers=admin_headers)
@@ -386,3 +431,40 @@ class TestServeMapThumbnail:
     def test_unknown_map_returns_404(self, client, admin_headers):
         resp = client.get("/api/maps/nope/thumbnail", headers=admin_headers)
         assert resp.status_code == 404
+
+    def test_thumbnail_is_cacheable_and_revalidates(
+        self, client, admin_headers, tmp_path, monkeypatch
+    ):
+        """A gallery of thousands of maps must not refetch every thumbnail per visit."""
+        from backend.routers.maps import core
+
+        thumb_root = tmp_path / "thumbs"
+        (thumb_root / "maps").mkdir(parents=True)
+        monkeypatch.setattr(core, "THUMB_DIR", str(thumb_root))
+
+        m = make_map(filename="etag-map.png", filepath=str(tmp_path / "etag-map.png"))
+        fhash = hashlib.md5(m.filepath.encode()).hexdigest()[:8]
+        (thumb_root / "maps" / f"{slugify('etag map')}_{fhash}.webp").write_bytes(b"webp")
+
+        first = client.get(f"/api/maps/{m.id}/thumbnail", headers=admin_headers)
+        assert first.status_code == 200
+        cache_control = first.headers["cache-control"]
+        # Private: thumbnails are access-controlled, so a shared proxy must never
+        # serve one user's to another. Not "immutable": this URL is not
+        # content-addressed, so the browser has to revalidate (cheaply, via the
+        # ETag) or a replaced image would never appear.
+        assert "private" in cache_control
+        assert "immutable" not in cache_control
+        etag = first.headers["etag"]
+
+        again = client.get(
+            f"/api/maps/{m.id}/thumbnail",
+            headers={**admin_headers, "If-None-Match": etag},
+        )
+        assert again.status_code == 304
+
+        stale = client.get(
+            f"/api/maps/{m.id}/thumbnail",
+            headers={**admin_headers, "If-None-Match": '"outdated"'},
+        )
+        assert stale.status_code == 200

--- a/backend/tests/test_tokens.py
+++ b/backend/tests/test_tokens.py
@@ -161,6 +161,43 @@ class TestServeTokenThumbnail:
         assert resp.status_code == 200
         assert resp.headers["content-type"] == "image/webp"
 
+    def test_thumbnail_is_cacheable_and_revalidates(
+        self, client, admin_headers, tmp_path, monkeypatch
+    ):
+        """A dense token grid must not refetch every thumbnail on every visit."""
+        from backend.routers.tokens import core
+
+        thumb_root = tmp_path / "thumbs"
+        (thumb_root / "tokens").mkdir(parents=True)
+        monkeypatch.setattr(core, "THUMB_DIR", str(thumb_root))
+
+        t = make_token(filename="etag-token.png", filepath=str(tmp_path / "etag-token.png"))
+        fhash = hashlib.md5(t.filepath.encode()).hexdigest()[:8]
+        (thumb_root / "tokens" / f"{slugify('etag token')}_{fhash}.webp").write_bytes(b"webp")
+
+        first = client.get(f"/api/tokens/{t.id}/thumbnail", headers=admin_headers)
+        assert first.status_code == 200
+        cache_control = first.headers["cache-control"]
+        # Private: thumbnails are access-controlled, so a shared proxy must never
+        # serve one user's to another. Not "immutable": this URL is not
+        # content-addressed, so the browser has to revalidate (cheaply, via the
+        # ETag) or a replaced image would never appear.
+        assert "private" in cache_control
+        assert "immutable" not in cache_control
+        etag = first.headers["etag"]
+
+        again = client.get(
+            f"/api/tokens/{t.id}/thumbnail",
+            headers={**admin_headers, "If-None-Match": etag},
+        )
+        assert again.status_code == 304
+
+        stale = client.get(
+            f"/api/tokens/{t.id}/thumbnail",
+            headers={**admin_headers, "If-None-Match": '"outdated"'},
+        )
+        assert stale.status_code == 200
+
     def test_missing_thumbnail_returns_404(self, client, admin_headers, tmp_path, monkeypatch):
         from backend.routers.tokens import core
 

--- a/frontend/src/components/tokens/TokenDetailView.test.jsx
+++ b/frontend/src/components/tokens/TokenDetailView.test.jsx
@@ -56,7 +56,7 @@ const detail = (id, over = {}) => ({
 // Route api.get by URL: the full token list vs a single token fetch.
 const mockApi = (currentId, over = {}) => {
   api.get.mockImplementation((url) => {
-    if (url === '/tokens') return Promise.resolve(SIBLINGS)
+    if (url.split('?')[0] === '/tokens') return Promise.resolve(SIBLINGS)
     return Promise.resolve(detail(currentId, over))
   })
 }

--- a/frontend/src/hooks/useMediaGallery.js
+++ b/frontend/src/hooks/useMediaGallery.js
@@ -1,4 +1,4 @@
-import { useState, useEffect } from 'react'
+import { useState, useEffect, useMemo, useRef } from 'react'
 import api, { bulk as bulkApi } from '../api'
 import useSessionState from './useSessionState'
 import useViewMode from './useViewMode'
@@ -9,6 +9,14 @@ import { useFavorites } from '../context/FavoritesContext'
 // (getUserPrefs no longer needed — sort now comes from the shared sortFilter state)
 import { getEffectiveTags, getTopFolder, getSubPath } from '../components/media/mediaConfig'
 import { splitSpecial, isSpecialFilter } from '../components/library/specialFilters'
+
+// Page size for the progressive load below. Large enough that a modest library
+// arrives in one request, small enough that the first paint is quick on a big one.
+const PAGE_SIZE = 500
+
+// Stable empty array: a fresh `[]` per render would invalidate every useMemo
+// that depends on `items` before the first page lands.
+const EMPTY_ITEMS = []
 
 /**
  * All shared data, filtering, grouping, and bulk-edit logic for a media gallery
@@ -31,6 +39,8 @@ export default function useMediaGallery(config) {
   const [collapsed, setCollapsed] = useSessionState(sessionKey, new Set())
   const [editingFolder, setEditingFolder] = useState(null)
   const [bulkApplying, setBulkApplying] = useState(false)
+  const [loadingMore, setLoadingMore] = useState(false)
+  const [loadedCount, setLoadedCount] = useState(0)
 
   const savedFilters = useSavedFilters(collection)
   // Persisted for the session so returning from a detail view keeps the filters
@@ -41,7 +51,10 @@ export default function useMediaGallery(config) {
   const activeFilters = sortFilter.filters || {}
   const filter = activeFilters.search || ''
   const favOnly = activeFilters.favorites === true
-  const rawSelectedTags = activeFilters.tags || []
+  // Falls back to the shared empty array rather than a fresh `[]`: this feeds the
+  // `filtered` memo's dependencies, and a new identity per render would rebuild
+  // the whole filtered set on every render.
+  const rawSelectedTags = activeFilters.tags || EMPTY_ITEMS
   // The inline tag chips only know about real tags — the special sentinels are
   // kept out of this set so they never render as a highlighted chip.
   const selectedTags = new Set(
@@ -64,36 +77,114 @@ export default function useMediaGallery(config) {
   const bulk = useBulkSelection()
   const { selectedIds, selectedFolderPaths, count: totalSelected } = bulk
 
-  // Items helper — `data` holds the collection under config.collection.
-  const items = data ? data[collection] : []
+  // Items helper — `data` holds the collection under config.collection. The
+  // empty fallback is a module-level constant rather than a fresh `[]`, so the
+  // memoised derived data below is not invalidated on every pre-load render.
+  const items = data ? data[collection] : EMPTY_ITEMS
 
   useEffect(() => {
-    Promise.all([api.get(listUrl), api.get(foldersUrl)]).then(([listData, foldersData]) => {
-      setData(listData)
+    // Loading a library of thousands of items in one request meant the view sat
+    // on a spinner until the last row arrived, and then parsed and laid out the
+    // whole set at once. Fetching in pages and appending lets the first page
+    // render almost immediately while the rest streams in behind it; filtering
+    // and grouping stay client-side over the accumulated set, so search and
+    // folder grouping still see the whole library once loading settles.
+    let cancelled = false
+
+    const loadPage = async (offset) => {
+      const page = await api.get(`${listUrl}?limit=${PAGE_SIZE}&offset=${offset}`)
+      if (cancelled) return
+      const rows = page[collection] || []
+      setData((prev) =>
+        prev && offset > 0
+          ? { ...page, [collection]: [...prev[collection], ...rows] }
+          : { ...page, [collection]: rows }
+      )
+      setLoadedCount((prev) => (offset > 0 ? prev + rows.length : rows.length))
+      // `total` is the server's count before pagination; stop when a short page
+      // arrives too, so a mid-load change on the server cannot spin forever.
+      const seen = offset + rows.length
+      if (rows.length === PAGE_SIZE && seen < page.total) await loadPage(seen)
+      else if (!cancelled) setLoadingMore(false)
+    }
+
+    api.get(foldersUrl).then((foldersData) => {
+      if (cancelled) return
       const ft = {}
       for (const f of foldersData.folders) ft[f.path] = f.tags
       setFolderTags(ft)
-      // Only set the default collapsed state (all collapsed) when no saved state exists.
-      const hasSaved = sessionStorage.getItem(sessionKey) !== null
-      if (!hasSaved) {
-        const keys = new Set()
-        listData[collection].forEach((item) => {
-          const folder = getTopFolder(item)
-          const subPath = getSubPath(item)
-          keys.add(folder)
-          if (subPath) keys.add(`${folder}::${subPath}`)
-        })
-        setCollapsed(keys)
-      }
     })
+
+    setLoadingMore(true)
+    loadPage(0).catch(() => {
+      if (!cancelled) setLoadingMore(false)
+    })
+
+    return () => {
+      cancelled = true
+    }
     // Load once on mount; the config values are stable for a given view.
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [])
 
+  // Default the collapsed state (everything collapsed) once, after the first
+  // page lands — deferring the whole grid's mount, which is what makes a large
+  // library render at all quickly. Later pages must not re-collapse folders the
+  // user has since opened, hence the one-shot ref.
+  const openedFolders = useRef(new Set())
+  const collapsedSeeded = useRef(false)
+  useEffect(() => {
+    if (collapsedSeeded.current || !data) return
+    collapsedSeeded.current = true
+    if (sessionStorage.getItem(sessionKey) !== null) return
+    const keys = new Set()
+    items.forEach((item) => {
+      const folder = getTopFolder(item)
+      const subPath = getSubPath(item)
+      keys.add(folder)
+      if (subPath) keys.add(`${folder}::${subPath}`)
+    })
+    setCollapsed(keys)
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [data])
+
+  // Folders discovered in later pages start collapsed too, so a folder never
+  // pops open mid-load and mounts hundreds of cards behind the user's back.
+  useEffect(() => {
+    if (!collapsedSeeded.current || !loadingMore) return
+    setCollapsed((prev) => {
+      let added = false
+      const next = new Set(prev)
+      for (const item of items) {
+        const folder = getTopFolder(item)
+        const subPath = getSubPath(item)
+        if (!next.has(folder) && !openedFolders.current.has(folder)) {
+          next.add(folder)
+          added = true
+        }
+        const key = subPath ? `${folder}::${subPath}` : null
+        if (key && !next.has(key) && !openedFolders.current.has(key)) {
+          next.add(key)
+          added = true
+        }
+      }
+      return added ? next : prev
+    })
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [items, loadingMore])
+
   const toggleCollapse = (key) =>
     setCollapsed((prev) => {
       const next = new Set(prev)
-      next.has(key) ? next.delete(key) : next.add(key)
+      if (next.has(key)) {
+        next.delete(key)
+        // Remember the user opened this one, so the auto-collapse of folders
+        // arriving in later pages does not shut it again under them.
+        openedFolders.current.add(key)
+      } else {
+        next.add(key)
+        openedFolders.current.delete(key)
+      }
       return next
     })
 
@@ -152,71 +243,102 @@ export default function useMediaGallery(config) {
 
   // ----- Derived view data (only meaningful once `data` has loaded) -----
 
-  const allTags = data
-    ? [
-        ...new Set(
-          items.flatMap((item) => getEffectiveTags(item, folderTags).map((t) => t.toLowerCase()))
-        ),
-      ].sort()
-    : []
-
-  const filtered = items.filter((item) => {
-    const q = filter.toLowerCase()
-    const textMatch =
-      !filter ||
-      item.filename.toLowerCase().includes(q) ||
-      getTopFolder(item).toLowerCase().includes(q) ||
-      getSubPath(item).toLowerCase().includes(q) ||
-      getEffectiveTags(item, folderTags).some((tag) => tag.toLowerCase().includes(q))
-    const tagMatch =
-      rawSelectedTags.length === 0 ||
-      (() => {
-        // An item's effective tags are its own plus those of every folder
-        // above it, so the special "untagged"/"tagged" sentinels test that
-        // combined set.
+  // On a large library (thousands of maps/tokens) the derived data below is the
+  // dominant cost of every render, and it used to be rebuilt on all of them —
+  // so a single keystroke in the search box re-split every item's path and
+  // re-walked its folder ancestry. Each stage is memoised on exactly what it
+  // reads, and the per-item values that never change with the filters (lowercased
+  // search haystack, effective tags, folder segments) are computed once here and
+  // reused by filtering, grouping, and the tag list.
+  const decorated = useMemo(
+    () =>
+      items.map((item) => {
         const effective = getEffectiveTags(item, folderTags)
-        const { values, pass } = splitSpecial(rawSelectedTags, effective)
-        if (!pass) return false
-        if (values.length === 0) return true
-        const effectiveSet = new Set(effective.map((t) => t.toLowerCase()))
-        return values.some((tag) => effectiveSet.has(String(tag).toLowerCase()))
-      })()
-    const favMatch = !favOnly || isFavorite(type, item.id)
-    return textMatch && tagMatch && favMatch
-  })
+        const topFolder = getTopFolder(item)
+        const subPath = getSubPath(item)
+        return {
+          item,
+          topFolder,
+          subPath,
+          effective,
+          effectiveLower: effective.map((t) => t.toLowerCase()),
+          // NUL-joined: the separator must be something a search term can never
+          // contain, or a query could match across two adjacent fields.
+          haystack: [item.filename || '', topFolder, subPath, ...effective]
+            .join('\0')
+            .toLowerCase(),
+        }
+      }),
+    [items, folderTags]
+  )
+
+  const allTags = useMemo(
+    () => (data ? [...new Set(decorated.flatMap((d) => d.effectiveLower))].sort() : []),
+    [data, decorated]
+  )
+
+  const filtered = useMemo(() => {
+    const q = filter.toLowerCase()
+    return decorated
+      .filter((d) => {
+        const textMatch = !filter || d.haystack.includes(q)
+        const tagMatch =
+          rawSelectedTags.length === 0 ||
+          (() => {
+            // An item's effective tags are its own plus those of every folder
+            // above it, so the special "untagged"/"tagged" sentinels test that
+            // combined set.
+            const { values, pass } = splitSpecial(rawSelectedTags, d.effective)
+            if (!pass) return false
+            if (values.length === 0) return true
+            const effectiveSet = new Set(d.effectiveLower)
+            return values.some((tag) => effectiveSet.has(String(tag).toLowerCase()))
+          })()
+        const favMatch = !favOnly || isFavorite(type, d.item.id)
+        return textMatch && tagMatch && favMatch
+      })
+      .map((d) => d.item)
+  }, [decorated, filter, rawSelectedTags, favOnly, type, isFavorite])
 
   // Item comparator from the sort/order state. `name` sorts by filename; `size`
   // by file size (audio also supports `duration` and `title`).
   const { sort = 'name', order = 'asc' } = sortFilter
   const dir = order === 'desc' ? -1 : 1
-  const itemCmp = {
-    name: (a, b) => (a.filename || '').localeCompare(b.filename || ''),
-    title: (a, b) => (a.title || a.filename || '').localeCompare(b.title || b.filename || ''),
-    size: (a, b) => (a.file_size || 0) - (b.file_size || 0),
-    duration: (a, b) => (a.duration || 0) - (b.duration || 0),
-  }
-  const sortItems = (arr) => [...arr].sort((a, b) => dir * (itemCmp[sort] || itemCmp.name)(a, b))
-
-  const byFolder = {}
-  filtered.forEach((item) => {
-    const folder = getTopFolder(item)
-    const subPath = getSubPath(item)
-    if (!byFolder[folder]) byFolder[folder] = {}
-    if (!byFolder[folder][subPath]) byFolder[folder][subPath] = []
-    byFolder[folder][subPath].push(item)
-  })
+  // A shared collator: String.prototype.localeCompare builds one per call, which
+  // is the single most expensive part of sorting thousands of items.
+  const collator = useMemo(() => new Intl.Collator(undefined, { numeric: true }), [])
+  const sortItems = useMemo(() => {
+    const itemCmp = {
+      name: (a, b) => collator.compare(a.filename || '', b.filename || ''),
+      title: (a, b) => collator.compare(a.title || a.filename || '', b.title || b.filename || ''),
+      size: (a, b) => (a.file_size || 0) - (b.file_size || 0),
+      duration: (a, b) => (a.duration || 0) - (b.duration || 0),
+    }
+    const cmp = itemCmp[sort] || itemCmp.name
+    return (arr) => [...arr].sort((a, b) => dir * cmp(a, b))
+  }, [sort, dir, collator])
 
   // Folders are ordered by name/order; items within a subfolder use the sort.
-  const folderEntries = Object.entries(byFolder)
-    .map(([folder, subfolders]) => {
-      const sortedSubs = {}
-      for (const [sub, group] of Object.entries(subfolders)) sortedSubs[sub] = sortItems(group)
-      return [folder, sortedSubs]
+  const folderEntries = useMemo(() => {
+    const byFolder = {}
+    filtered.forEach((item) => {
+      const folder = getTopFolder(item)
+      const subPath = getSubPath(item)
+      if (!byFolder[folder]) byFolder[folder] = {}
+      if (!byFolder[folder][subPath]) byFolder[folder][subPath] = []
+      byFolder[folder][subPath].push(item)
     })
-    .sort(([a], [b]) => dir * a.localeCompare(b))
+    return Object.entries(byFolder)
+      .map(([folder, subfolders]) => {
+        const sortedSubs = {}
+        for (const [sub, group] of Object.entries(subfolders)) sortedSubs[sub] = sortItems(group)
+        return [folder, sortedSubs]
+      })
+      .sort(([a], [b]) => dir * collator.compare(a, b))
+  }, [filtered, sortItems, dir, collator])
 
   // Flat sorted item list (used when folder grouping is turned off).
-  const flatItems = sortItems(filtered)
+  const flatItems = useMemo(() => sortItems(filtered), [filtered, sortItems])
 
   // Subtitle counts. `totalCount` is every row the list endpoint returned for
   // this user (not data.total, which is the server's pre-pagination count and
@@ -224,24 +346,34 @@ export default function useMediaGallery(config) {
   // items the user did not receive. `filteredCount` is what the filters leave.
   const totalCount = items.length
   const filteredCount = filtered.length
+  // How much of the library has arrived so far, for callers that want to show
+  // progress while the remaining pages stream in.
+  const totalAvailable = data?.total ?? 0
 
   // Flat ordered list of visible ids, for shift-range selection. Matches the
   // on-screen order: grouped → by folder; flat → the single sorted list.
-  const orderedIds = grouped
-    ? folderEntries.flatMap(([, subfolders]) =>
-        Object.values(subfolders).flatMap((group) => group.map((i) => i.id))
-      )
-    : flatItems.map((i) => i.id)
+  const orderedIds = useMemo(
+    () =>
+      grouped
+        ? folderEntries.flatMap(([, subfolders]) =>
+            Object.values(subfolders).flatMap((group) => group.map((i) => i.id))
+          )
+        : flatItems.map((i) => i.id),
+    [grouped, folderEntries, flatItems]
+  )
   const toggleSelect = (id, mods = {}) => bulk.toggleItem(id, { ...mods, orderedIds })
 
   // Collapse/expand-all affordance state.
-  const allKeys = new Set()
-  folderEntries.forEach(([folder, subfolders]) => {
-    allKeys.add(folder)
-    Object.keys(subfolders)
-      .filter((s) => s)
-      .forEach((s) => allKeys.add(`${folder}::${s}`))
-  })
+  const allKeys = useMemo(() => {
+    const keys = new Set()
+    folderEntries.forEach(([folder, subfolders]) => {
+      keys.add(folder)
+      Object.keys(subfolders)
+        .filter((s) => s)
+        .forEach((s) => keys.add(`${folder}::${s}`))
+    })
+    return keys
+  }, [folderEntries])
   const noFolders = folderEntries.length === 0
   const allCollapsed = !noFolders && [...allKeys].every((k) => collapsed.has(k))
   const allExpanded = collapsed.size === 0
@@ -284,6 +416,9 @@ export default function useMediaGallery(config) {
     // subtitle counts
     totalCount,
     filteredCount,
+    totalAvailable,
+    loadingMore,
+    loadedCount,
     // collapse-all affordances
     allKeys,
     noFolders,

--- a/frontend/src/hooks/useMediaGallery.test.jsx
+++ b/frontend/src/hooks/useMediaGallery.test.jsx
@@ -50,7 +50,7 @@ const item = (over) => ({
 
 function setup(items, savedFilters = [], folders = []) {
   api.get.mockImplementation((url) => {
-    if (url === '/maps') return Promise.resolve({ maps: items, total: items.length })
+    if (url.split('?')[0] === '/maps') return Promise.resolve({ maps: items, total: items.length })
     if (url === '/map-folders') return Promise.resolve({ folders })
     if (url.startsWith('/saved-filters')) return Promise.resolve({ filters: savedFilters })
     return Promise.resolve({})
@@ -272,5 +272,82 @@ describe('useMediaGallery', () => {
     expect(result.current.flatItems[0].filename).toBe('renamed.png')
     act(() => result.current.toggleSelect('a'))
     expect(result.current.selectedObjects().map((i) => i.id)).toEqual(['a'])
+  })
+
+  describe('progressive loading', () => {
+    // A single request for a library of thousands of items left the view on a
+    // spinner until the last row arrived; pages are fetched and appended so the
+    // first one paints early.
+    const pagedSetup = (total, pageSize = 500) => {
+      const all = Array.from({ length: total }, (_, i) =>
+        item({ id: `m${i}`, filename: `m${i}.png` })
+      )
+      api.get.mockImplementation((url) => {
+        const [path, qs] = url.split('?')
+        if (path === '/maps') {
+          const params = new URLSearchParams(qs)
+          const offset = Number(params.get('offset') || 0)
+          const limit = Number(params.get('limit') || pageSize)
+          return Promise.resolve({ maps: all.slice(offset, offset + limit), total })
+        }
+        if (url === '/map-folders') return Promise.resolve({ folders: [] })
+        if (url.startsWith('/saved-filters')) return Promise.resolve({ filters: [] })
+        return Promise.resolve({})
+      })
+      return all
+    }
+
+    it('requests a bounded page rather than the whole library', async () => {
+      pagedSetup(10)
+      const { result } = renderGallery()
+      await waitFor(() => expect(result.current.data).not.toBeNull())
+      const listCalls = api.get.mock.calls.filter(([u]) => u.split('?')[0] === '/maps')
+      expect(listCalls[0][0]).toContain('limit=')
+      expect(listCalls[0][0]).toContain('offset=0')
+    })
+
+    it('accumulates every page so filtering still sees the whole library', async () => {
+      // The hook keeps paging while a full page comes back, so this needs to
+      // straddle the real page size — just over it, to prove the append path
+      // without making the suite sort thousands of rows.
+      const total = 501
+      pagedSetup(total)
+      const { result } = renderGallery()
+      await waitFor(() => expect(result.current.loadingMore).toBe(false))
+      const listCalls = api.get.mock.calls.filter(([u]) => u.split('?')[0] === '/maps')
+      expect(listCalls.length).toBe(2)
+      expect(listCalls[1][0]).toContain('offset=500')
+      // Every row is present exactly once — an append bug would duplicate or drop.
+      expect(result.current.totalCount).toBe(total)
+      expect(new Set(result.current.flatItems.map((i) => i.id)).size).toBe(total)
+    })
+
+    it('stops paging when a short page arrives, even if total disagrees', async () => {
+      // A rescan can shrink the library mid-load; without the short-page check
+      // the loop would keep asking for pages that never come.
+      api.get.mockImplementation((url) => {
+        const path = url.split('?')[0]
+        if (path === '/maps')
+          return Promise.resolve({ maps: [item({ id: 'a', filename: 'a.png' })], total: 9999 })
+        if (url === '/map-folders') return Promise.resolve({ folders: [] })
+        if (url.startsWith('/saved-filters')) return Promise.resolve({ filters: [] })
+        return Promise.resolve({})
+      })
+      const { result } = renderGallery()
+      await waitFor(() => expect(result.current.loadingMore).toBe(false), { timeout: 3000 })
+      expect(result.current.totalCount).toBe(1)
+    })
+
+    it('clears the loading flag when a page request fails', async () => {
+      api.get.mockImplementation((url) => {
+        const path = url.split('?')[0]
+        if (path === '/maps') return Promise.reject(new Error('boom'))
+        if (url === '/map-folders') return Promise.resolve({ folders: [] })
+        if (url.startsWith('/saved-filters')) return Promise.resolve({ filters: [] })
+        return Promise.resolve({})
+      })
+      const { result } = renderGallery()
+      await waitFor(() => expect(result.current.loadingMore).toBe(false))
+    })
   })
 })

--- a/frontend/src/views/AudioView.test.jsx
+++ b/frontend/src/views/AudioView.test.jsx
@@ -104,7 +104,7 @@ describe('AudioView', () => {
 
   function setupAudio(audio) {
     api.get.mockImplementation((url) => {
-      if (url === '/audio') return Promise.resolve(makeResponse(audio))
+      if (url.split('?')[0] === '/audio') return Promise.resolve(makeResponse(audio))
       if (url === '/audio-folders') return Promise.resolve({ folders: [] })
       return Promise.resolve({})
     })

--- a/frontend/src/views/MapsView.test.jsx
+++ b/frontend/src/views/MapsView.test.jsx
@@ -130,7 +130,7 @@ describe('MapsView', () => {
 
   function setupMaps(maps) {
     api.get.mockImplementation((url) => {
-      if (url === '/maps') return Promise.resolve(makeMapsResponse(maps))
+      if (url.split('?')[0] === '/maps') return Promise.resolve(makeMapsResponse(maps))
       if (url === '/map-folders') return Promise.resolve({ folders: [] })
       return Promise.resolve({})
     })
@@ -366,7 +366,7 @@ describe('MapsView', () => {
       // A server-side total that exceeds the delivered rows (pagination, or a
       // user who may not see everything) must never become the denominator.
       api.get.mockImplementation((url) => {
-        if (url === '/maps')
+        if (url.split('?')[0] === '/maps')
           return Promise.resolve({
             maps: [
               makeMap({ filename: 'dungeon.png', relative_path: 'maps/dungeon.png' }),

--- a/frontend/src/views/TokensView.test.jsx
+++ b/frontend/src/views/TokensView.test.jsx
@@ -131,7 +131,7 @@ describe('TokensView', () => {
 
   function setupTokens(tokens) {
     api.get.mockImplementation((url) => {
-      if (url === '/tokens') return Promise.resolve(makeTokensResponse(tokens))
+      if (url.split('?')[0] === '/tokens') return Promise.resolve(makeTokensResponse(tokens))
       if (url === '/token-folders') return Promise.resolve({ folders: [] })
       return Promise.resolve({})
     })

--- a/nightly.md
+++ b/nightly.md
@@ -1042,6 +1042,16 @@ Cache entries are keyed by a hash of the source file's **contents**, so replacin
 
 The on-disk cache is trimmed oldest-first back under `PAGE_CACHE_MAX_MB` (default 2 GiB) at startup and after each library scan.
 
+### Large map &amp; token libraries
+
+The Maps and Tokens galleries are built for large collections (thousands of items, plus their variants):
+
+- **Items load progressively.** The gallery fetches items in pages and shows the first batch as soon as it arrives, instead of waiting for the whole library. Search, tag filters, and folder grouping still apply across everything once loading settles.
+- **Thumbnails are cached by the browser.** Map and token thumbnails now carry cache validators, so revisiting a gallery or scrolling back re-uses the images already downloaded rather than re-fetching every one.
+- **Folders start collapsed**, so opening a large library doesn't render thousands of cards at once - expand just the folders you need.
+
+If a gallery still feels slow with a very large collection, keeping folders collapsed and using search or tag filters to narrow the view is the fastest way to work.
+
 ---
 
 ## Backups


### PR DESCRIPTION
## Summary

<!-- What does this PR do? A few sentences is fine. -->

## Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / cleanup
- [ ] Docs / configuration only

## Testing

<!-- How did you verify this works? Check all that apply. -->

- [x] Backend tests pass (`pytest -q`)
- [x] Frontend tests pass (`npm test`)
- [x] Tested manually in the browser

## Notes for reviewer

<!-- Anything that needs extra context, known limitations, or follow-up work. Delete if not needed. -->
