### PR TITLE
Fix: Scope category scaffolding to system folders, open file manager at the root

### DIFF
--- a/backend/routers/files/_schemas.py
+++ b/backend/routers/files/_schemas.py
@@ -21,6 +21,10 @@ class BrowseEntry(BaseModel):
     # Folder-only: what the folder declares about itself on disk.
     container_kind: Optional[str] = None
     nsfw: bool = False
+    # Folder-only: whether standard category folders belong inside this one —
+    # true for a system folder under books/, false for books/ itself and for
+    # containers, whose children are the system folders.
+    category_host: bool = False
     # Capped at CHILD_COUNT_CAP; None when the folder could not be read.
     child_count: Optional[int] = None
 

--- a/backend/routers/files/core.py
+++ b/backend/routers/files/core.py
@@ -98,6 +98,12 @@ def browse(
     limit = max(1, min(limit, MAX_ENTRIES))
     section = fs.collection_of(target)
     model = fs.COLLECTIONS.get(section) if section else None
+    # Whether a *child* of this folder could host category folders, resolved once
+    # for the whole listing rather than re-walking each row's ancestors: the
+    # chain above every child is identical, so the per-row question reduces to
+    # "and is this child itself a container?". On a folder holding thousands of
+    # entries that is the difference between one ancestor walk and thousands.
+    children_may_host = section == "books" and fs.holds_system_folders(target)
 
     entries: list[BrowseEntry] = []
     try:
@@ -145,6 +151,9 @@ def browse(
                     is_dir=True,
                     container_kind=markers["container_kind"] or None,
                     nsfw=markers["nsfw"],
+                    # A container's children are systems, so they host
+                    # categories; the container itself does not.
+                    category_host=children_may_host and not markers["container_kind"],
                     child_count=_child_count(child_path),
                     record_id=getattr(system, "id", None),
                     title=getattr(system, "name", None),

--- a/backend/services/library_fs/__init__.py
+++ b/backend/services/library_fs/__init__.py
@@ -95,6 +95,8 @@ from .folders import (  # noqa: F401
     _write_marker,
     create_folder,
     find_singleton_container,
+    holds_system_folders,
+    is_category_host,
     read_folder_markers,
     scaffold_categories,
     set_folder_markers,

--- a/backend/services/library_fs/folders.py
+++ b/backend/services/library_fs/folders.py
@@ -15,10 +15,12 @@ from sqlalchemy.orm import Session
 
 from ...config import logger
 from ...indexer.categories import (
+    detect_container_kind,
     guess_category,
     is_one_page_folder,
     is_system_agnostic_folder,
     slugify,
+    strip_container_suffix,
 )
 from ...indexer.constants import (
     CONTAINER_AGNOSTIC,
@@ -244,6 +246,60 @@ def read_folder_markers(target: Path) -> dict:
     }
 
 
+def holds_system_folders(target: Path) -> bool:
+    """Whether ``target``'s immediate children are system folders.
+
+    True for ``books/`` and for any container reached from it through nothing but
+    containers. This is the half of the rule that makes nesting work: a family
+    holding a parent-system holding editions (issue #301) keeps handing "these
+    children are systems" down the chain, and the first folder that is not a
+    container ends it — its children are category folders.
+    """
+    rel = to_relative(target)
+    parts = rel.split("/")
+    if parts[0] != "books":
+        return False
+    if len(parts) == 1:
+        return True
+    root = library_root()
+    # Every folder from books/ down to and including the target must be a
+    # container, or the target is a system folder and its children are
+    # categories.
+    return all(
+        _container_kind_of(root.joinpath(*parts[: depth + 1])) != ""
+        for depth in range(1, len(parts))
+    )
+
+
+def is_category_host(target: Path) -> bool:
+    """Whether standard category folders belong directly inside ``target``.
+
+    Categories are a books-tree concept that hangs off a *system* folder, and a
+    container holds systems rather than categories — its children are the system
+    folders, so scaffolding "Core"/"Adventures" onto the container itself would
+    invent sibling systems named after categories and re-file nothing correctly.
+
+    So ``target`` hosts categories exactly when its *parent* hands down system
+    folders and ``target`` is not itself a container. That mirrors
+    ``_scan_container``, which recurses through containers and only reads
+    categories in the first folder that is not one.
+    """
+    rel = to_relative(target)
+    parts = rel.split("/")
+    # `books/<system>` at minimum: `books/` itself holds systems, not categories.
+    if len(parts) < 2 or parts[0] != "books":
+        return False
+    if not holds_system_folders(target.parent):
+        return False
+    return _container_kind_of(target) == ""
+
+
+def _container_kind_of(folder: Path) -> str:
+    """The container kind a books folder declares, by marker, suffix, or name."""
+    _, suffix_kind = strip_container_suffix(folder.name)
+    return suffix_kind or detect_container_kind(folder, folder.name)
+
+
 def scaffold_categories(path: str) -> dict:
     """Create the standard category folders inside a system folder.
 
@@ -252,9 +308,11 @@ def scaffold_categories(path: str) -> dict:
     hand is tedious and easy to get subtly wrong — "Adventures" works, "Modules"
     silently becomes a custom category — so this writes the canonical set.
 
-    Only offered under ``books/``, since categories are a books-tree concept.
-    Existing folders are left alone and reported separately, so running this on a
-    partly-organised system fills the gaps instead of failing.
+    Only offered on a folder that actually hosts categories — see
+    ``is_category_host``: under ``books/``, and not a container, whose children
+    are the system folders instead. Existing folders are left alone and reported
+    separately, so running this on a partly-organised system fills the gaps
+    instead of failing.
     """
     target = safe_join(path, must_exist=True)
     if not target.is_dir():
@@ -263,10 +321,12 @@ def scaffold_categories(path: str) -> dict:
         raise LibraryFSError(
             "Category folders only apply to the books library", code="invalid"
         )
-    # `books/` itself holds systems, not categories.
-    if to_relative(target).count("/") < 1:
+    # `books/` itself holds systems, not categories, and neither does a
+    # container — its children are the system folders that hold them.
+    if not is_category_host(target):
         raise LibraryFSError(
-            "Pick a system folder inside books/ rather than the books folder itself",
+            "Pick a system folder inside books/ — the books folder itself and "
+            "container folders hold systems, not categories",
             code="invalid",
         )
     assert_writable(target)

--- a/backend/tests/test_files.py
+++ b/backend/tests/test_files.py
@@ -1096,6 +1096,136 @@ class TestScaffoldCategories:
         assert resp.status_code == 200
         assert "Supplements" in resp.json()["created"]
 
+    def test_refused_on_a_container(self, library_tree):
+        """A container holds systems, so categories belong one level down.
+
+        Scaffolding onto the container itself would create "Core"/"Adventures"
+        folders that the scanner then reads as *systems*, not categories.
+        """
+        import shutil
+
+        from backend.indexer.constants import PARENT_SYSTEM_MARKER
+
+        base = f"books/Family-{library_tree}"
+        os.makedirs(os.path.join(LIB, base), exist_ok=True)
+        open(os.path.join(LIB, base, PARENT_SYSTEM_MARKER), "w").close()
+        try:
+            with pytest.raises(fs.LibraryFSError) as exc:
+                fs.scaffold_categories(base)
+            assert exc.value.code == "invalid"
+        finally:
+            shutil.rmtree(os.path.join(LIB, base), ignore_errors=True)
+
+    def test_refused_on_a_suffix_declared_container(self, library_tree):
+        """The `(publisher)` name suffix declares a container just as a marker does."""
+        import shutil
+
+        base = f"books/Paizo-{library_tree} (publisher)"
+        os.makedirs(os.path.join(LIB, base), exist_ok=True)
+        try:
+            with pytest.raises(fs.LibraryFSError) as exc:
+                fs.scaffold_categories(base)
+            assert exc.value.code == "invalid"
+        finally:
+            shutil.rmtree(os.path.join(LIB, base), ignore_errors=True)
+
+    def test_allowed_inside_a_container(self, library_tree):
+        """A container's child *is* the system folder, so it takes categories."""
+        import shutil
+
+        from backend.indexer.constants import PARENT_SYSTEM_MARKER
+
+        top = f"books/DnD-{library_tree}"
+        os.makedirs(os.path.join(LIB, top, "5e"), exist_ok=True)
+        open(os.path.join(LIB, top, PARENT_SYSTEM_MARKER), "w").close()
+        try:
+            result = fs.scaffold_categories(f"{top}/5e")
+            assert "Core" in result["created"]
+            assert os.path.isdir(os.path.join(LIB, top, "5e", "Core"))
+        finally:
+            shutil.rmtree(os.path.join(LIB, top), ignore_errors=True)
+
+    def test_allowed_inside_nested_containers(self, library_tree):
+        """A family holding a parent-system holding editions (issue #301)."""
+        import shutil
+
+        from backend.indexer.constants import (
+            PARENT_SYSTEM_MARKER,
+            SYSTEM_FAMILY_MARKER,
+        )
+
+        top = f"books/d20-{library_tree}"
+        mid = os.path.join(LIB, top, "Pathfinder")
+        os.makedirs(os.path.join(mid, "2e"), exist_ok=True)
+        open(os.path.join(LIB, top, SYSTEM_FAMILY_MARKER), "w").close()
+        open(os.path.join(mid, PARENT_SYSTEM_MARKER), "w").close()
+        try:
+            # The two containers are refused...
+            for container in (top, f"{top}/Pathfinder"):
+                with pytest.raises(fs.LibraryFSError):
+                    fs.scaffold_categories(container)
+            # ...and the edition folder below them is not.
+            result = fs.scaffold_categories(f"{top}/Pathfinder/2e")
+            assert "Core" in result["created"]
+        finally:
+            shutil.rmtree(os.path.join(LIB, top), ignore_errors=True)
+
+    def test_refused_below_a_plain_system_folder(self, library_tree):
+        """A category folder's own children are not another shelf of categories."""
+        with pytest.raises(fs.LibraryFSError) as exc:
+            fs.scaffold_categories(f"books/System-{library_tree}/core")
+        assert exc.value.code == "invalid"
+
+
+class TestCategoryHostFlag:
+    """`category_host` on a browse row — what drives the UI's scaffold action."""
+
+    def test_system_folders_under_books_are_hosts(self, client, admin_headers, library_tree):
+        resp = client.get("/api/files/browse", headers=admin_headers, params={"path": "books"})
+        rows = {e["name"]: e for e in resp.json()["entries"]}
+        assert rows[f"System-{library_tree}"]["category_host"] is True
+
+    def test_a_container_is_not_a_host_but_its_children_are(
+        self, client, admin_headers, library_tree
+    ):
+        import shutil
+
+        from backend.indexer.constants import PARENT_SYSTEM_MARKER
+
+        top = f"books/DnD-{library_tree}"
+        os.makedirs(os.path.join(LIB, top, "5e"), exist_ok=True)
+        open(os.path.join(LIB, top, PARENT_SYSTEM_MARKER), "w").close()
+        try:
+            listing = client.get(
+                "/api/files/browse", headers=admin_headers, params={"path": "books"}
+            ).json()
+            container = next(
+                e for e in listing["entries"] if e["name"] == f"DnD-{library_tree}"
+            )
+            assert container["category_host"] is False
+
+            inside = client.get(
+                "/api/files/browse", headers=admin_headers, params={"path": top}
+            ).json()
+            child = next(e for e in inside["entries"] if e["name"] == "5e")
+            assert child["category_host"] is True
+        finally:
+            shutil.rmtree(os.path.join(LIB, top), ignore_errors=True)
+
+    def test_category_folders_are_not_hosts(self, client, admin_headers, library_tree):
+        resp = client.get(
+            "/api/files/browse",
+            headers=admin_headers,
+            params={"path": f"books/System-{library_tree}"},
+        )
+        rows = {e["name"]: e for e in resp.json()["entries"]}
+        assert rows["core"]["category_host"] is False
+
+    def test_other_collections_are_never_hosts(self, client, admin_headers, library_tree):
+        resp = client.get("/api/files/browse", headers=admin_headers, params={"path": "maps"})
+        rows = {e["name"]: e for e in resp.json()["entries"]}
+        assert rows[f"Battlemaps-{library_tree}"]["category_host"] is False
+
 
 class TestSystemFolderMetadata:
     """A books/<system> folder maps to the GameSystem row it represents."""

--- a/docs/api.md
+++ b/docs/api.md
@@ -1443,13 +1443,18 @@ from `total` when a content file with the same stem sits beside them; an
 orphaned one is listed normally. They are moved and re-stemmed automatically by
 `/api/files/move` and `/api/files/rename`. Returns
 `{path, parent, writable, entries[], total, truncated}`. Each entry carries
-`name`, `path`, `is_dir`, and `size`; folders add `container_kind`, `nsfw`, and
-`child_count`, while files add `record_id`, `title`, `collection`,
+`name`, `path`, `is_dir`, and `size`; folders add `container_kind`, `nsfw`,
+`child_count`, and `category_host`, while files add `record_id`, `title`, `collection`,
 `has_thumbnail`, and `is_missing` when Grimoire has indexed them. A folder
 directly under `books/` that maps to a game system also carries `record_id`,
 `title`, and `collection: "system"`, so a client can offer the system editor on
-it. Note `collection` names the *library folder* (`books`, `maps`, …) for files
-but the resource type (`system`) for system folders. Marker/dotfiles
+it. `category_host` is true when standard category folders belong *inside* that
+folder - a system folder under `books/`, reached from `books/` through nothing
+but containers. It is false for `books/` itself, for every container (whose
+children are the system folders), for a category folder, and outside `books/`, so
+a client can offer the category scaffold only where it applies. Note `collection`
+names the *library folder* (`books`, `maps`, …) for files but the resource type
+(`system`) for system folders. Marker/dotfiles
 are surfaced as folder properties, never as listable entries.
 
 The listing is **one folder's immediate children only** - it does not recurse -
@@ -1574,7 +1579,10 @@ structure; it is validated against the library root like any other path.
 folders (`Core`, `Supplements`, `Adventures`, `Character Sheets`, `Maps`,
 `Handouts`, `Homebrew`, `Starter Sets`) inside a system folder. Each name is
 chosen to infer back to its canonical category slug, so the folders classify
-correctly on the next scan. Only valid for a folder directly under `books/`.
+correctly on the next scan. Only valid for a folder that hosts categories - the
+`category_host` folders above: under `books/`, and not a container, since a
+container holds systems rather than categories. A container's children *are* the
+system folders, so they take the scaffold however deeply the containers nest.
 Returns `{path, created, existing}`. A category is skipped when an existing
 folder already *resolves to* it, matched on the inferred category rather than the
 folder name - a system holding `Rules` will not gain a second `Core`, and one

--- a/frontend/src/views/FileManagerView.jsx
+++ b/frontend/src/views/FileManagerView.jsx
@@ -91,7 +91,10 @@ export default function FileManagerView() {
   const { user } = useAuth()
   const isAdmin = user?.role === 'admin'
 
-  const primary = useLibraryPane('books')
+  // Both panes start at the library root. Anchoring the first pane on `books`
+  // hid the other collections behind a "go up" the user had no reason to guess
+  // was there — maps, tokens and audio are managed here too.
+  const primary = useLibraryPane('')
   const secondary = useLibraryPane('')
   // null when only one pane is open; otherwise the edge the second pane is
   // pinned to ('right' | 'left' | 'top' | 'bottom').
@@ -106,7 +109,9 @@ export default function FileManagerView() {
   const [movingEntries, setMovingEntries] = useState(null) // entries pending a destination
   const [editing, setEditing] = useState(null) // { type, item } for the metadata editor
   // Where a file picker will drop its files, set just before the input opens.
-  const uploadTarget = useRef('')
+  // null is "not set yet", distinct from '' — the library root, which is a real
+  // folder the user can be anchored on.
+  const uploadTarget = useRef(null)
   const fileInput = useRef(null)
   const folderInput = useRef(null)
   const [showUploads, setShowUploads] = useState(false)
@@ -327,10 +332,12 @@ export default function FileManagerView() {
   /** Queue a FileList for upload into `destination`. */
   const startUpload = useCallback(
     (fileList, destination) => {
-      // Fall back to the pane's own folder. The picker sets a target before it
-      // opens, but a drop or a stray change event can arrive without one, and
-      // "no destination" should mean "here" rather than an error.
-      destination = destination || primary.path || 'books'
+      // A stray change event that arrives before the picker set a target has no
+      // folder to land in. Dropping it is the only honest answer: the previous
+      // fallback to `primary.path || 'books'` guessed, and once the pane could
+      // be anchored on the library root that guess silently routed files into
+      // books/ — somewhere other than where the user put them.
+      if (destination == null) return
       const entries = [...fileList].map((file) => {
         // A folder pick reports each file's path within the dropped folder;
         // strip the file name to get the sub-directory to recreate.
@@ -342,7 +349,7 @@ export default function FileManagerView() {
       setShowUploads(true)
       uploads.enqueue(entries, destination)
     },
-    [uploads, primary.path]
+    [uploads]
   )
 
   /** Open the OS picker, remembering which folder the files belong in. */
@@ -401,13 +408,6 @@ export default function FileManagerView() {
         {t('files.adminOnly')}
       </div>
     )
-  }
-
-  // A system folder is a direct child of books/ — the only place category
-  // folders make sense.
-  const isSystemFolder = (path) => {
-    const parts = (path || '').split('/')
-    return parts[0] === 'books' && parts.length === 2
   }
 
   // The kinds this folder can be changed *to*. Two exclusions:
@@ -743,9 +743,11 @@ export default function FileManagerView() {
                 <LuFolderUp size={13} /> {t('files.uploadFolder')}
               </button>
 
-              {/* Only under books/, and not on books/ itself: categories are a
-                  books-tree concept and belong to a system folder. */}
-              {isSystemFolder(context.entry.path) && (
+              {/* Categories hang off a *system* folder. The server decides
+                  which folders those are — a container holds systems, so its
+                  children get the option and it does not, however deeply the
+                  containers nest. */}
+              {context.entry.category_host && (
                 <button
                   style={menuItem}
                   {...menuHover}

--- a/frontend/src/views/FileManagerView.test.jsx
+++ b/frontend/src/views/FileManagerView.test.jsx
@@ -101,8 +101,15 @@ beforeEach(() => {
   // Each pane must echo back its own path: the destination of a cross-pane move
   // is the *other* pane's current folder, so a shared response would make the
   // move look like it targeted the source.
+  // The view anchors on the library root, but almost every case here is about
+  // acting on a *books* row, so the root listing stands in for `books/` and its
+  // rows carry books/ paths. Only the row paths are faked that way — the path
+  // browse is *called* with is untouched, so assertions about where the pane is
+  // anchored stay honest.
   filesApi.browse.mockImplementation((path) =>
-    Promise.resolve(browseResult([folder('core', path), file('bestiary.pdf', path)], path))
+    Promise.resolve(
+      browseResult([folder('core', path || 'books'), file('bestiary.pdf', path || 'books')], path)
+    )
   )
 })
 
@@ -284,7 +291,9 @@ describe('FileManagerView', () => {
     await userEvent.click(screen.getByRole('button', { name: 'files.create' }))
 
     await waitFor(() =>
-      expect(filesApi.createFolder).toHaveBeenCalledWith('books', 'Homebrew', expect.anything())
+      // The pane is anchored on the library root, so that is where the folder
+      // lands — the button always means "here", whatever "here" happens to be.
+      expect(filesApi.createFolder).toHaveBeenCalledWith('', 'Homebrew', expect.anything())
     )
   })
 
@@ -511,13 +520,13 @@ describe('FileManagerView', () => {
     const tree = await screen.findByTestId('move-tree')
     expect(within(tree).queryByText('bestiary.pdf')).not.toBeInTheDocument()
 
-    // The picker browses from the library root, so the mock's folder is rooted
-    // there rather than under books/.
+    // The picker browses from the library root, and the mock's root listing
+    // stands in for books/ — so the folder offered there is books/core.
     await userEvent.click(within(tree).getByText('core'))
     await userEvent.click(screen.getByText('files.moveHere'))
 
     await waitFor(() =>
-      expect(filesApi.move).toHaveBeenCalledWith(['books/bestiary.pdf'], '/core', 'rename')
+      expect(filesApi.move).toHaveBeenCalledWith(['books/bestiary.pdf'], 'books/core', 'rename')
     )
   })
 
@@ -556,7 +565,7 @@ describe('FileManagerView', () => {
       },
     })
 
-    await waitFor(() => expect(filesApi.move).toHaveBeenCalledWith(['maps/tavern.png'], 'books'))
+    await waitFor(() => expect(filesApi.move).toHaveBeenCalledWith(['maps/tavern.png'], ''))
   })
 
   it('warns when only some of the selection moved', async () => {
@@ -584,9 +593,7 @@ describe('FileManagerView', () => {
     const buttons = screen.getAllByTitle('files.moveAcrossHint')
     await userEvent.click(buttons[buttons.length - 1])
 
-    await waitFor(() =>
-      expect(filesApi.move).toHaveBeenCalledWith(['books/core/bestiary.pdf'], 'books')
-    )
+    await waitFor(() => expect(filesApi.move).toHaveBeenCalledWith(['books/core/bestiary.pdf'], ''))
   })
 
   it('refreshes on demand', async () => {
@@ -669,7 +676,17 @@ describe('FileManagerView', () => {
     expect(screen.queryByTestId('kind-one-page')).not.toBeInTheDocument()
   })
 
+  // Which folders can hold category folders is the server's call — a system
+  // folder can, a container cannot, however deep the containers nest — so the
+  // view keys off the row's flag rather than re-deriving it from the path.
+  const showCategoryHost = (host) =>
+    filesApi.browse.mockImplementation((path) => {
+      const shown = path || 'books'
+      return Promise.resolve(browseResult([folder('core', shown, { category_host: host })], path))
+    })
+
   it('scaffolds category folders for a system folder', async () => {
+    showCategoryHost(true)
     filesApi.scaffold.mockResolvedValue({ path: 'books/core', created: ['Core'], existing: [] })
     render(<FileManagerView />)
     await openMenuOn('core')
@@ -681,12 +698,25 @@ describe('FileManagerView', () => {
   })
 
   it('says when the category folders already existed', async () => {
+    showCategoryHost(true)
     filesApi.scaffold.mockResolvedValue({ path: 'books/core', created: [], existing: ['Core'] })
     render(<FileManagerView />)
     await openMenuOn('core')
     await userEvent.click(await screen.findByTestId('scaffold-categories'))
 
     expect(await screen.findByRole('status')).toHaveTextContent('files.scaffoldNothingToDo')
+  })
+
+  it('hides the category scaffold on a folder that cannot hold categories', async () => {
+    // A container holds *systems*, so scaffolding "Core"/"Adventures" onto it
+    // would invent systems named after categories. The option is not offered.
+    showCategoryHost(false)
+    render(<FileManagerView />)
+    await openMenuOn('core')
+
+    // The menu is open — the scaffold entry is the only thing missing from it.
+    expect(await screen.findByTestId('container-submenu')).toBeInTheDocument()
+    expect(screen.queryByTestId('scaffold-categories')).not.toBeInTheDocument()
   })
 
   it('opens the shared metadata editor for an indexed file', async () => {
@@ -809,7 +839,7 @@ describe('FileManagerView', () => {
     await waitFor(() => expect(uploadQueue.enqueue).toHaveBeenCalled())
     const [entries, destination] = uploadQueue.enqueue.mock.calls[0]
     expect(entries[0].file.name).toBe('new.pdf')
-    expect(destination).toBe('books')
+    expect(destination).toBe('')
     expect(filesApi.move).not.toHaveBeenCalled()
   })
 
@@ -867,17 +897,27 @@ describe('FileManagerView', () => {
     expect(screen.queryByTestId('upload-folder')).not.toBeInTheDocument()
   })
 
-  it('falls back to the pane folder when no destination was set', async () => {
+  it('ignores a picker event that arrived without a destination', async () => {
     render(<FileManagerView />)
     await screen.findByTestId('file-pane-primary')
 
-    // A change event that arrives without the picker having set a target must
-    // still land somewhere sensible rather than failing with "Path is empty".
+    // A change event that arrives before the picker set a target has no folder
+    // to land in. Guessing one used to mean books/, which quietly put files
+    // somewhere the user never chose — so it is dropped instead.
     fireEvent.change(screen.getByTestId('file-input'), {
       target: { files: [new File(['x'], 'stray.pdf')] },
     })
 
-    await waitFor(() => expect(uploadQueue.enqueue).toHaveBeenCalled())
-    expect(uploadQueue.enqueue.mock.calls[0][1]).toBe('books')
+    await waitFor(() => expect(filesApi.browse).toHaveBeenCalled())
+    expect(uploadQueue.enqueue).not.toHaveBeenCalled()
+  })
+
+  it('starts anchored on the library root, not books/', async () => {
+    // The file manager manages maps, tokens and audio too; anchoring on books/
+    // hid them behind a "go up" the user had no reason to guess was there.
+    render(<FileManagerView />)
+    await screen.findByTestId('file-pane-primary')
+
+    await waitFor(() => expect(filesApi.browse).toHaveBeenCalledWith(''))
   })
 })

--- a/nightly.md
+++ b/nightly.md
@@ -649,6 +649,9 @@ Admins can reorganize the library from inside Grimoire - **Settings → Maintena
 → Open file manager**. It is a folder tree (think Finder or Explorer, but aware
 of Grimoire's own concepts) built for bulk reorganization:
 
+- **It opens at the library root**, showing `books`, `maps`, `tokens`, and
+  `audio` side by side. Everything in the library is managed here, so the tree
+  starts where all of it is visible rather than inside `books/`.
 - **Expand folders in place** to see a file and its destination at once, instead
   of navigating away from one to reach the other.
 - **Move** files and folders by dragging them onto any folder. Collapsed folders
@@ -708,7 +711,10 @@ of Grimoire's own concepts) built for bulk reorganization:
   in an empty folder, where there is no row to right-click.
 - **Set up a system in one step** with **Create standard category folders** -
   Core, Supplements, Adventures, Character Sheets, Maps, Handouts, Homebrew, and
-  Starter Sets, named so the scanner classifies them correctly.
+  Starter Sets, named so the scanner classifies them correctly. Offered on system
+  folders only. A container holds *systems*, not categories, so the option does
+  not appear on one - it appears on the folders inside it, however deeply the
+  containers nest.
 - **Mark a folder NSFW or SFW**, or change its container type, without recreating
   it. The *One-page RPGs* and *System-agnostic* collections are one-of-a-kind:
   once a folder claims one, it is not offered on any other folder.


### PR DESCRIPTION
…at the root

## Summary

<!-- What does this PR do? A few sentences is fine. -->

## Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / cleanup
- [ ] Docs / configuration only

## Testing

<!-- How did you verify this works? Check all that apply. -->

- [x] Backend tests pass (`pytest -q`)
- [x] Frontend tests pass (`npm test`)
- [x] Tested manually in the browser

## Notes for reviewer

<!-- Anything that needs extra context, known limitations, or follow-up work. Delete if not needed. -->
