### PR TITLE
Fix: Clear a special collection left stranded after its folder is deleted

### DIFF
--- a/backend/indexer/reconcile.py
+++ b/backend/indexer/reconcile.py
@@ -253,6 +253,31 @@ def _prune_vanished_systems(ctx: _ScanContext) -> int:
         if filepath and os.path.abspath(filepath).startswith(root):
             in_this_library.add(system_id)
 
+    # A *container* owns no books of its own — its children do — so the book-path
+    # anchor above can never place one in this library, and it was skipped as
+    # "some other library's row" on every rescan. Deleting a container folder
+    # therefore pruned its children and stranded the container itself: an empty
+    # shelf in the special-collections strip that no rescan, and no amount of
+    # deleting the folder from the file manager, could clear (the reported case).
+    #
+    # A row this scan actually walked to is self-evidently this library's, which
+    # covers the container that still exists. The container whose folder has just
+    # vanished is caught by the parent chain below instead: its children were in
+    # this library, so it is too.
+    in_this_library |= ctx.seen_system_ids & {s.id for s in systems}
+    # Ownership flows *up*: a container belongs to this library when any of its
+    # descendants does. Walk child→parent so a chain deeper than one level
+    # resolves in full, and so a container is still claimed on the very scan
+    # that prunes its children (nothing is deleted until the loop below).
+    by_id = {s.id: s for s in systems}
+    pending = [s for s in systems if s.id in in_this_library]
+    while pending:
+        node = pending.pop()
+        parent = by_id.get(node.parent_id) if node.parent_id else None
+        if parent is not None and parent.id not in in_this_library:
+            in_this_library.add(parent.id)
+            pending.append(parent)
+
     # Books are the only collection tied to a system — maps, tokens, and audio
     # are deliberately system-agnostic — so one distinct query covers ownership.
     #
@@ -269,7 +294,6 @@ def _prune_vanished_systems(ctx: _ScanContext) -> int:
     # A container whose children survive must survive too, or the children are
     # orphaned. Parentage is one level in practice but resolved transitively.
     keep_parents: set = set()
-    by_id = {s.id: s for s in systems}
     for system in systems:
         if system.id in owning or system.id in ctx.seen_system_ids:
             node = system

--- a/backend/indexer/systems.py
+++ b/backend/indexer/systems.py
@@ -245,10 +245,15 @@ def _register_system(
     else:
         if folder.is_nsfw and not system.is_explicit:
             system.is_explicit = True
-        if is_agnostic and not system.is_system_agnostic:
-            system.is_system_agnostic = True
-        if is_one_page and not system.is_one_page:
-            system.is_one_page = True
+        # Both flags track the folder in *both* directions. They used to be
+        # set-only, so re-typing a shelf — ``Fantasy (one-page)`` renamed to
+        # ``Fantasy (publisher)`` — updated ``container_kind`` while leaving the
+        # old flag set, and the row stayed pinned in the special-collections
+        # strip claiming to be a collection it no longer was.
+        if bool(system.is_system_agnostic) != is_agnostic:
+            system.is_system_agnostic = is_agnostic
+        if bool(system.is_one_page) != is_one_page:
+            system.is_one_page = is_one_page
         if (system.container_kind or "") != folder.container_kind:
             system.container_kind = folder.container_kind
         if parent is not None and system.parent_id != parent.id:

--- a/backend/services/library_fs/deletes.py
+++ b/backend/services/library_fs/deletes.py
@@ -16,7 +16,9 @@ from sqlalchemy.orm import Session
 
 from ...config import logger
 from ...indexer.constants import CONTAINER_MARKERS, NSFW_MARKER
-from ...models.library import Book
+from ...models.campaigns import Campaign
+from ...models.library import Book, GameSystem
+from . import folders
 from .constants import _THUMB_SECTIONS, LibraryFSError
 from .moves import _records_under, _section_for_model, _thumb_file, _thumb_key
 from .paths import (
@@ -295,6 +297,45 @@ def delete_empty_folder(path: str) -> dict:
     return {"path": to_relative(target)}
 
 
+def _unindex_system_row(db: Session, target: Path) -> int:
+    """Drop the ``GameSystem`` a books folder represents, once nothing is left in it.
+
+    ``_records_under`` only knows about path-keyed *file* rows, so unindexing a
+    system folder forgot its books and left the system itself behind — including
+    container/special-collection rows, which own no books at all and so lost
+    nothing. "Delete this folder from the database" visibly did nothing to the
+    shelf the user was trying to remove, which is the reported bug.
+
+    Conservative in the same spirit as the scanner's prune: the row goes only
+    when it has no books and no child systems left, and never when the user has
+    adapted it (a rename, description, or cover means the row is worth keeping
+    even with an empty shelf). Anything still holding content is left alone, so
+    this can only ever remove a shelf that is already empty.
+    """
+    system = folders.system_for_folder(db, target)
+    if system is None:
+        return 0
+    if db.query(Book).filter_by(game_system_id=system.id).count():
+        return 0
+    if db.query(GameSystem).filter_by(parent_id=system.id).count():
+        return 0
+    if system.name_is_custom or system.description or system.cover_image:
+        logger.info(
+            "Unindex: keeping system '%s' - it carries user metadata", system.name
+        )
+        return 0
+    # ``campaigns.system_id`` is a real foreign key with no ``ondelete``, so a
+    # campaign still pointing here would either block the delete or strand a
+    # dangling reference. A system a campaign is played in is in use regardless
+    # of how empty its shelf looks.
+    if db.query(Campaign).filter_by(system_id=system.id).count():
+        logger.info("Unindex: keeping system '%s' - a campaign references it", system.name)
+        return 0
+    db.delete(system)
+    logger.info("Unindex: removed system '%s'", system.name)
+    return 1
+
+
 def unindex_path(db: Session, path: str) -> dict:
     """Forget a file or folder's indexed rows, leaving the files untouched.
 
@@ -327,6 +368,7 @@ def unindex_path(db: Session, path: str) -> dict:
 
     affected = _records_under(db, target)
     records = _delete_records(db, affected)
+    records += _unindex_system_row(db, target)
     db.commit()
     logger.info("Library unindex: %s (%d record(s))", to_relative(target), records)
     return {"path": to_relative(target), "records": records, "files": 0}

--- a/backend/tests/test_delete_cascade.py
+++ b/backend/tests/test_delete_cascade.py
@@ -19,6 +19,7 @@ from backend.models import (
     CampaignResource,
     CampaignResourceShare,
     Favorite,
+    GameSystem,
     GenericMap,
     ResourceTag,
     Token,
@@ -267,6 +268,96 @@ class TestUnindexPath:
         try:
             result = unindex_path(db, "books/System/ghost.pdf")
             assert result["records"] == 1
+        finally:
+            db.close()
+
+    def test_forgets_the_system_row_for_an_emptied_system_folder(
+        self, monkeypatch, tmp_path
+    ):
+        """Unindexing a system folder must take the ``GameSystem`` with it.
+
+        ``_records_under`` only sees path-keyed *file* rows, so this used to
+        forget the books and leave the system standing — and for a container,
+        which owns no books at all, it did nothing whatsoever. "Delete this
+        folder from the database" visibly failed to remove the shelf.
+        """
+        library = tmp_path / "lib"
+        folder = library / "books" / "Doomed" / "core"
+        folder.mkdir(parents=True)
+        path = folder / "a.pdf"
+        path.write_bytes(b"%PDF-1.4 stub")
+        monkeypatch.setattr("backend.services.library_fs.paths.LIBRARY_PATH", str(library))
+
+        system = make_game_system(name="Doomed", slug="doomed")
+        make_book(system_id=system.id, filepath=str(path))
+
+        db = SessionLocal()
+        try:
+            result = unindex_path(db, "books/Doomed")
+            # One book plus the system row itself.
+            assert result["records"] == 2
+            assert db.query(GameSystem).filter_by(id=system.id).first() is None
+            assert path.exists()
+        finally:
+            db.close()
+
+    def test_keeps_a_system_row_that_still_holds_books(self, monkeypatch, tmp_path):
+        """Only the folder's own books are forgotten, so a shelf with more stays."""
+        library = tmp_path / "lib"
+        folder = library / "books" / "Partial" / "core"
+        folder.mkdir(parents=True)
+        path = folder / "a.pdf"
+        path.write_bytes(b"%PDF-1.4 stub")
+        monkeypatch.setattr("backend.services.library_fs.paths.LIBRARY_PATH", str(library))
+
+        system = make_game_system(name="Partial", slug="partial")
+        make_book(system_id=system.id, filepath=str(path))
+        # A second book elsewhere under the same system.
+        make_book(system_id=system.id, filepath=str(library / "books/Partial/extra/b.pdf"))
+
+        db = SessionLocal()
+        try:
+            unindex_path(db, "books/Partial/core")
+            assert db.query(GameSystem).filter_by(id=system.id).first() is not None
+        finally:
+            db.close()
+
+    def test_keeps_a_system_row_a_campaign_references(self, monkeypatch, tmp_path, admin_id):
+        """``campaigns.system_id`` is a real FK, so a referenced shelf is in use."""
+        library = tmp_path / "lib"
+        folder = library / "books" / "Played" / "core"
+        folder.mkdir(parents=True)
+        path = folder / "a.pdf"
+        path.write_bytes(b"%PDF-1.4 stub")
+        monkeypatch.setattr("backend.services.library_fs.paths.LIBRARY_PATH", str(library))
+
+        system = make_game_system(name="Played", slug="played")
+        make_book(system_id=system.id, filepath=str(path))
+        make_campaign(owner_id=admin_id, system_id=system.id)
+
+        db = SessionLocal()
+        try:
+            unindex_path(db, "books/Played")
+            assert db.query(GameSystem).filter_by(id=system.id).first() is not None
+        finally:
+            db.close()
+
+    def test_keeps_a_system_row_the_user_has_adapted(self, monkeypatch, tmp_path):
+        """A renamed or described shelf is worth keeping even when emptied."""
+        library = tmp_path / "lib"
+        folder = library / "books" / "Loved" / "core"
+        folder.mkdir(parents=True)
+        path = folder / "a.pdf"
+        path.write_bytes(b"%PDF-1.4 stub")
+        monkeypatch.setattr("backend.services.library_fs.paths.LIBRARY_PATH", str(library))
+
+        system = make_game_system(name="Loved", slug="loved", description="My shelf")
+        make_book(system_id=system.id, filepath=str(path))
+
+        db = SessionLocal()
+        try:
+            unindex_path(db, "books/Loved")
+            assert db.query(GameSystem).filter_by(id=system.id).first() is not None
         finally:
             db.close()
 

--- a/backend/tests/test_indexer_containers.py
+++ b/backend/tests/test_indexer_containers.py
@@ -12,6 +12,7 @@ right rather than categories. Two flavours:
 Containers are declared by marker file, by a ``(parent-system)``/``(one-page)``
 folder-name suffix, or (for one-page) by a reserved folder slug.
 """
+import shutil
 import tempfile
 from pathlib import Path
 
@@ -991,3 +992,82 @@ class TestAgnosticContainer:
         _scan(lib, tmp)
 
         assert _system("tiny-games--honey-heist") is not None
+
+
+class TestVanishedContainerPruning:
+    """A container folder that is deleted must not leave its row behind.
+
+    ``_prune_vanished_systems`` anchors "is this row mine to delete?" on the
+    absolute paths of the books a system owns. A container owns none — its
+    children hold the books — so it could never satisfy that test and was
+    skipped as another library's row on every rescan. Deleting the folder
+    pruned the children and stranded the container: an empty shelf pinned in
+    the special-collections strip that no rescan could clear.
+    """
+
+    def test_deleted_container_is_pruned(self):
+        tmp, lib = _mk_lib()
+        _touch_pdf(_books_dir(lib, "Fantasy Shelf (publisher)", "Dragonbane", "core"))
+        _scan(lib, tmp)
+        assert _system("fantasy-shelf") is not None
+
+        shutil.rmtree(lib / "books" / "Fantasy Shelf (publisher)")
+        _scan(lib, tmp)
+
+        assert _system("fantasy-shelf") is None, "container survived its folder"
+        assert _system("fantasy-shelf--dragonbane") is None
+
+    def test_container_with_content_survives(self):
+        """The prune stays conservative: a shelf still holding books is kept."""
+        tmp, lib = _mk_lib()
+        _touch_pdf(_books_dir(lib, "Kept Shelf (publisher)", "Dragonbane", "core"))
+        _scan(lib, tmp)
+        _scan(lib, tmp)
+
+        assert _system("kept-shelf") is not None
+        assert _system("kept-shelf--dragonbane") is not None
+
+
+class TestContainerKindChange:
+    """Re-typing a shelf must clear the special-collection flag it used to carry.
+
+    ``is_one_page``/``is_system_agnostic`` were set-only, so changing a folder's
+    container kind updated ``container_kind`` while the stale flag kept the row
+    in the special strip — the shelf claimed to be a collection it no longer was.
+    """
+
+    def test_one_page_flag_clears_when_kind_changes(self):
+        tmp, lib = _mk_lib()
+        _touch_pdf(_books_dir(lib, "Retyped (one-page)", "Retyped Tiny"))
+        _scan(lib, tmp)
+        assert _system("retyped").is_one_page is True
+
+        (lib / "books" / "Retyped (one-page)").rename(lib / "books" / "Retyped (publisher)")
+        _scan(lib, tmp)
+
+        system = _system("retyped")
+        assert system.container_kind == "publisher"
+        assert not system.is_one_page, "stale flag kept it in the special strip"
+
+    def test_agnostic_flag_clears_when_marker_removed(self):
+        tmp, lib = _mk_lib()
+        root = _books_dir(lib, "Was Agnostic")
+        marker = root / ".system-agnostic-container"
+        marker.write_text("")
+        _touch_pdf(_books_dir(lib, "Was Agnostic", "handouts"))
+        _scan(lib, tmp)
+        assert _system("was-agnostic").is_system_agnostic is True
+
+        marker.unlink()
+        _scan(lib, tmp)
+
+        assert not _system("was-agnostic").is_system_agnostic
+
+    def test_one_page_flag_is_kept_while_the_kind_stands(self):
+        """Clearing is driven by the folder, so an unchanged shelf keeps its flag."""
+        tmp, lib = _mk_lib()
+        _touch_pdf(_books_dir(lib, "Still One Page (one-page)", "Still Tiny"))
+        _scan(lib, tmp)
+        _scan(lib, tmp)
+
+        assert _system("still-one-page").is_one_page is True


### PR DESCRIPTION
## Summary

<!-- What does this PR do? A few sentences is fine. -->

## Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / cleanup
- [ ] Docs / configuration only

## Testing

<!-- How did you verify this works? Check all that apply. -->

- [x] Backend tests pass (`pytest -q`)
- [ ] Frontend tests pass (`npm test`)
- [x] Tested manually in the browser

## Notes for reviewer

<!-- Anything that needs extra context, known limitations, or follow-up work. Delete if not needed. -->
