### PR TITLE
Fix: Scaffold every category folder for a system nested in a container

### DIFF
--- a/backend/services/library_fs/folders.py
+++ b/backend/services/library_fs/folders.py
@@ -337,12 +337,22 @@ def scaffold_categories(path: str) -> dict:
     # adding a "Core" folder beside them would split one category across two
     # shelves and leave the user tidying up after the button that was supposed
     # to tidy for them.
+    #
+    # `guess_category` reads the category folder at a fixed index, so it has to
+    # be told how deep this system sits. `books/<system>` is the depth-2 default,
+    # but a system inside one or more containers pushes the category folder down
+    # by a level per container (issue #412) — read at the default depth, every
+    # candidate would resolve to the same container name and only the first would
+    # ever be created.
+    rel_target = to_relative(target)
+    system_depth = len(rel_target.split("/"))
+
     covered: dict[str, str] = {}
     try:
         for child in target.iterdir():
             if not child.is_dir() or child.name.startswith("."):
                 continue
-            category = guess_category(f"{to_relative(child)}/x.pdf")
+            category = guess_category(f"{to_relative(child)}/x.pdf", system_depth=system_depth)
             covered.setdefault(category, child.name)
     except OSError as e:
         logger.warning("Could not read %s while scaffolding: %s", target, e)
@@ -350,7 +360,7 @@ def scaffold_categories(path: str) -> dict:
     created: list[str] = []
     existing: list[str] = []
     for name in SCAFFOLD_CATEGORY_FOLDERS:
-        category = guess_category(f"{to_relative(target)}/{name}/x.pdf")
+        category = guess_category(f"{rel_target}/{name}/x.pdf", system_depth=system_depth)
         held_by = covered.get(category)
         if held_by is not None:
             existing.append(held_by)
@@ -373,5 +383,5 @@ def scaffold_categories(path: str) -> dict:
                 ) from e
             logger.warning("Could not create category folder %s: %s", child, e)
 
-    return {"path": to_relative(target), "created": created, "existing": existing}
+    return {"path": rel_target, "created": created, "existing": existing}
 

--- a/backend/tests/test_files.py
+++ b/backend/tests/test_files.py
@@ -1140,8 +1140,13 @@ class TestScaffoldCategories:
         open(os.path.join(LIB, top, PARENT_SYSTEM_MARKER), "w").close()
         try:
             result = fs.scaffold_categories(f"{top}/5e")
-            assert "Core" in result["created"]
-            assert os.path.isdir(os.path.join(LIB, top, "5e", "Core"))
+            # The whole set, not just the first name: reading the category at the
+            # top-level depth would resolve every candidate to the container and
+            # create only one folder (issue #412).
+            assert result["created"] == list(fs.SCAFFOLD_CATEGORY_FOLDERS)
+            assert result["existing"] == []
+            for name in fs.SCAFFOLD_CATEGORY_FOLDERS:
+                assert os.path.isdir(os.path.join(LIB, top, "5e", name))
         finally:
             shutil.rmtree(os.path.join(LIB, top), ignore_errors=True)
 
@@ -1166,7 +1171,43 @@ class TestScaffoldCategories:
                     fs.scaffold_categories(container)
             # ...and the edition folder below them is not.
             result = fs.scaffold_categories(f"{top}/Pathfinder/2e")
-            assert "Core" in result["created"]
+            assert result["created"] == list(fs.SCAFFOLD_CATEGORY_FOLDERS)
+            assert result["existing"] == []
+            for name in fs.SCAFFOLD_CATEGORY_FOLDERS:
+                assert os.path.isdir(os.path.join(LIB, top, "Pathfinder", "2e", name))
+        finally:
+            shutil.rmtree(os.path.join(LIB, top), ignore_errors=True)
+
+    def test_nested_system_reports_existing_categories_by_their_own_names(self, library_tree):
+        """A partly-organised nested system fills gaps and names what it skipped.
+
+        The `covered` pre-pass reads child folders at the same depth, so before
+        issue #412 it too collapsed every child onto one category — reporting the
+        categories a nested system already had under whichever child was read
+        first, and refusing to create the rest.
+        """
+        import shutil
+
+        from backend.indexer.constants import PARENT_SYSTEM_MARKER
+
+        top = f"books/Partial-{library_tree}"
+        system = os.path.join(LIB, top, "3e")
+        # "Rulebooks" and "Modules" infer back to `core` and `adventures`, so the
+        # canonical names for those two must be reported as already covered.
+        os.makedirs(os.path.join(system, "Rulebooks"), exist_ok=True)
+        os.makedirs(os.path.join(system, "Modules"), exist_ok=True)
+        open(os.path.join(LIB, top, PARENT_SYSTEM_MARKER), "w").close()
+        try:
+            result = fs.scaffold_categories(f"{top}/3e")
+            assert sorted(result["existing"]) == ["Modules", "Rulebooks"]
+            assert "Core" not in result["created"]
+            assert "Adventures" not in result["created"]
+            assert result["created"] == [
+                n
+                for n in fs.SCAFFOLD_CATEGORY_FOLDERS
+                if n not in ("Core", "Adventures")
+            ]
+            assert not os.path.isdir(os.path.join(system, "Core"))
         finally:
             shutil.rmtree(os.path.join(LIB, top), ignore_errors=True)
 


### PR DESCRIPTION
## Summary

<!-- What does this PR do? A few sentences is fine. -->

## Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / cleanup
- [ ] Docs / configuration only

## Testing

<!-- How did you verify this works? Check all that apply. -->

- [x] Backend tests pass (`pytest -q`)
- [x] Frontend tests pass (`npm test`)
- [x] Tested manually in the browser

## Notes for reviewer

<!-- Anything that needs extra context, known limitations, or follow-up work. Delete if not needed. -->
