### PR TITLE
Fix: Keep system and category when renaming inside a nested container

### DIFF
--- a/backend/services/library_fs/placement.py
+++ b/backend/services/library_fs/placement.py
@@ -42,42 +42,67 @@ def _system_folder_name(raw_name: str) -> str:
 
 
 def _system_depth_for(db: Session, parts: list[str]) -> int:
-    """How many path segments precede the category folder: 2, or 3 under a container.
+    """How many path segments precede the category folder.
 
     ``parts`` is the library-relative path split on "/", starting with ``books``.
 
-    The folder at ``parts[1]`` is a *container* rather than a system when it is
-    marked as one on disk — the same test the scanner applies (issue #395). The
-    DB cannot answer this on its own: a container has its own ``GameSystem`` row
-    whose ``parent_id`` is None, so asking whether the row at ``parts[1]`` has a
-    parent says "no" for the container itself and yields depth 2, which is how a
-    re-categorised book escaped its system folder and landed in the container
-    root.
+    2 for the plain ``books/<system>/<category>/`` layout, and one more for every
+    *container* stacked above the system: a family holding a parent-system
+    holding editions puts the category folder at index 4 (issues #261/#262/#301).
+    This mirrors ``_scan_container``, which recurses through containers with
+    ``depth + 1`` and only reads categories in the first folder that is not one —
+    so the walk has to continue past ``parts[1]`` rather than stopping there.
+    Testing only that first folder capped the answer at 3, which is how a rename
+    or move under two containers read the *system* folder as the category and
+    reattached the book to the inner container (issue #413).
 
-    The marker file is authoritative; the DB is a fallback for a container
-    declared by a name suffix (``(parent-system)``), where the folder carries no
-    marker but the nested system row does record a parent.
+    A container declares itself by marker file or by name suffix; the DB is a
+    fallback for the suffix form on rows written before the folder was read.
     """
-    if len(parts) < 3:
-        return 2
-    container_dir = library_root() / parts[0] / parts[1]
-    if detect_container_kind(container_dir, parts[1]):
-        return 3
-    # A suffix-declared container leaves no marker on disk. Its child systems do
-    # carry ``parent_id``, so look the *nested* folder up directly — but only
-    # believe it when that parent is the folder at ``parts[1]``. In a standard
-    # layout ``parts[2]`` is the *category* folder, and a system elsewhere in the
-    # library that happens to share its name ("Core") must not be mistaken for a
-    # nested system here.
+    depth = 1
+    # Walk down from books/ while each folder is a container. The first one that
+    # is not is the system folder, and its children are the categories — so the
+    # category folder sits at the index just past it.
+    while depth + 1 < len(parts) and _is_container(db, parts, depth):
+        depth += 1
+    return max(depth + 1, 2)
+
+
+def _is_container(db: Session, parts: list[str], depth: int) -> bool:
+    """Whether the folder at ``parts[depth]`` holds systems rather than categories."""
+    folder = library_root().joinpath(*parts[: depth + 1])
+    # A name suffix (``(parent-system)``) is as authoritative as a marker file,
+    # and unlike the marker it needs no disk read.
+    _, suffix_kind = strip_container_suffix(parts[depth])
+    if suffix_kind or detect_container_kind(folder, parts[depth]):
+        return True
+    # A suffix-declared container that has since been renamed leaves nothing on
+    # disk. Its child systems do carry ``parent_id``, so look the *nested* folder
+    # up — but only believe it when that parent is this folder. In a standard
+    # layout the next segment is the *category* folder, and a system elsewhere in
+    # the library that happens to share its name ("Core") must not be mistaken
+    # for a nested system here.
+    if depth + 1 >= len(parts):
+        return False
     nested = (
-        db.query(GameSystem).filter(GameSystem.name == _system_folder_name(parts[2])).first()
+        db.query(GameSystem)
+        .filter(GameSystem.name == _system_folder_name(parts[depth + 1]))
+        .first()
     )
     parent_id = getattr(nested, "parent_id", None) if nested is not None else None
-    if parent_id:
-        parent = db.query(GameSystem).filter(GameSystem.id == parent_id).first()
-        if parent is not None and parent.name == _system_folder_name(parts[1]):
-            return 3
-    return 2
+    if not parent_id:
+        return False
+    parent = db.query(GameSystem).filter(GameSystem.id == parent_id).first()
+    return parent is not None and parent.name == _system_folder_name(parts[depth])
+
+
+def _match_system(db: Session, folder_name: str) -> Optional[GameSystem]:
+    """The system row a books folder maps to, matched by name then slug."""
+    name = _system_folder_name(folder_name)
+    return (
+        db.query(GameSystem).filter(GameSystem.name == name).first()
+        or db.query(GameSystem).filter(GameSystem.slug == slugify(name)).first()
+    )
 
 
 def resolve_book_placement(db: Session, dest_file: Path) -> tuple[Optional[str], str]:
@@ -100,28 +125,21 @@ def resolve_book_placement(db: Session, dest_file: Path) -> tuple[Optional[str],
         return None, UNCATEGORIZED
 
     system_folder = parts[1]
-    system_name = _system_folder_name(system_folder)
-    system = (
-        db.query(GameSystem).filter(GameSystem.name == system_name).first()
-        or db.query(GameSystem).filter(GameSystem.slug == slugify(system_name)).first()
-    )
 
-    # A system nested one level inside a container folder shifts every
-    # subsequent segment right by one; the scanner expresses that as
-    # `system_depth`. Shared with ``_system_root_for`` so both agree on where the
-    # category folder starts — asking whether the row at ``parts[1]`` has a
-    # parent got this wrong for a marker-declared container, whose own row has
-    # no parent (issue #395).
+    # Every container above the system shifts the subsequent segments right by
+    # one; the scanner expresses that as `system_depth`. Shared with
+    # ``_system_root_for`` so both agree on where the category folder starts —
+    # asking whether the row at ``parts[1]`` has a parent got this wrong for a
+    # marker-declared container, whose own row has no parent (issue #395).
     depth = _system_depth_for(db, parts)
-    if depth == 3:
-        # The real system folder is the second segment inside the container.
-        nested_name = _system_folder_name(parts[2])
-        nested = (
-            db.query(GameSystem).filter(GameSystem.name == nested_name).first()
-            or db.query(GameSystem).filter(GameSystem.slug == slugify(nested_name)).first()
-        )
-        if nested is not None:
-            system = nested
+    # The system folder is the last segment before the category folder, so it
+    # walks right with the depth: `parts[1]` unnested, `parts[2]` inside one
+    # container, `parts[3]` inside two (issue #413).
+    system = _match_system(db, parts[depth - 1])
+    if system is None and depth > 2:
+        # An unregistered nested folder should still land on the container row
+        # rather than orphaning the book, as it did before containers nested.
+        system = _match_system(db, system_folder)
 
     if is_special_collection_folder(system_folder):
         return (system.id if system else None), agnostic_category(rel)

--- a/backend/tests/test_files.py
+++ b/backend/tests/test_files.py
@@ -2001,6 +2001,175 @@ class TestCategoryRelocationInContainer:
             shutil.rmtree(os.path.join(LIB, "books", folder), ignore_errors=True)
 
 
+class TestNestedContainerPlacement:
+    """A system two containers deep (issue #413).
+
+    ``_system_depth_for`` used to test only the folder at ``parts[1]`` and stop,
+    so a family holding a parent-system holding editions — the layout
+    ``_scan_container`` recurses through with ``depth + 1`` — resolved to depth 3
+    when the category folder actually sits at index 4. Renaming or moving
+    anything beneath it then read the *system* folder as the category and pinned
+    every book to the inner container.
+    """
+
+    @pytest.fixture
+    def nested_tree(self):
+        """books/<family>/<parent-system>/<system>/Handouts/<title>/x.pdf."""
+        import shutil
+
+        stamp = str(uuid.uuid4())[:8]
+        family, parent, system = f"Family-{stamp}", f"Parent-{stamp}", f"5 DE-{stamp}"
+        title = "Spielkartenset - Vor- und Nachteile"
+        base = f"books/{family}/{parent}/{system}/Handouts/{title}"
+        os.makedirs(os.path.join(LIB, base), exist_ok=True)
+        # Two nested containers, each declared by its own marker.
+        open(os.path.join(LIB, f"books/{family}/.system-family-container"), "wb").close()
+        open(
+            os.path.join(LIB, f"books/{family}/{parent}/.parent-system-container"), "wb"
+        ).close()
+        yield stamp, family, parent, system, title
+        shutil.rmtree(os.path.join(LIB, f"books/{family}"), ignore_errors=True)
+
+    def _rows(self, tree):
+        stamp, family, parent, system, title = tree
+        family_row = make_game_system(name=family, slug=f"family-{stamp}")
+        parent_row = make_game_system(
+            name=parent, slug=f"parent-{stamp}", parent_id=family_row.id
+        )
+        system_row = make_game_system(
+            name=system, slug=f"system-{stamp}", parent_id=parent_row.id
+        )
+        rel = f"books/{family}/{parent}/{system}/Handouts/{title}/karten.pdf"
+        src = _write(rel)
+        book = make_book(
+            system_row.id,
+            filename="karten.pdf",
+            filepath=src,
+            relative_path=rel,
+            category="handout",
+        )
+        return parent_row, system_row, book, src
+
+    def test_depth_counts_every_container_above_the_system(self, nested_tree):
+        """Two containers put the category folder at index 4, not 3."""
+        _stamp, family, parent, system, title = nested_tree
+        db = SessionLocal()
+        depth = fs.placement._system_depth_for(
+            db, f"books/{family}/{parent}/{system}/Handouts/{title}/karten.pdf".split("/")
+        )
+        db.close()
+        assert depth == 4
+
+    def test_placement_matches_what_the_scanner_would_infer(self, nested_tree):
+        """The scanner walks this tree with ``system_depth=2 + depth`` = 4."""
+        from backend.indexer.categories import guess_category
+
+        _stamp, family, parent, system, title = nested_tree
+        _parent_row, system_row, _book, src = self._rows(nested_tree)
+
+        db = SessionLocal()
+        system_id, category = fs.resolve_book_placement(db, Path(src))
+        db.close()
+
+        rel = f"books/{family}/{parent}/{system}/Handouts/{title}/karten.pdf"
+        assert category == guess_category(rel, system_depth=4)
+        assert category == "handout"
+        assert system_id == system_row.id, "the innermost system owns the book"
+
+    def test_folder_rename_keeps_system_and_category(self, nested_tree):
+        """The reported bug: a folder rename silently reclassified the rows.
+
+        ``relative_path`` was updated correctly and the response read as success,
+        while ``game_system`` became the inner container and ``category`` the
+        slug of the system folder's own name.
+        """
+        _stamp, family, parent, system, title = nested_tree
+        _parent_row, system_row, book, _src = self._rows(nested_tree)
+        book_id = book.id
+
+        db = SessionLocal()
+        result = fs.rename_path(
+            db,
+            f"books/{family}/{parent}/{system}/Handouts/{title}",
+            "Spielkartenset Vor- & Nachteile",
+        )
+        db.close()
+
+        assert result["records"] == 1
+        db = SessionLocal()
+        row = db.query(Book).filter(Book.id == book_id).first()
+        assert row.relative_path == (
+            f"books/{family}/{parent}/{system}/Handouts/"
+            "Spielkartenset Vor- & Nachteile/karten.pdf"
+        )
+        assert row.category == "handout", "the rename must not rewrite the category"
+        assert row.game_system_id == system_row.id, "must not fall back to the container"
+        db.close()
+
+    def test_container_known_only_to_the_db_is_still_a_container(self):
+        """Neither marker nor suffix on disk — the parent link is all there is.
+
+        A container declared by suffix and later renamed leaves nothing on disk
+        to read, so the depth has to come from the nested system's ``parent_id``.
+        This is the fallback branch the marker and suffix cases never reach.
+        """
+        import shutil
+
+        stamp = str(uuid.uuid4())[:8]
+        container, system = f"Plain-{stamp}", f"Edition-{stamp}"
+        rel = f"books/{container}/{system}/core/tome.pdf"
+        src = _write(rel)
+        try:
+            parent = make_game_system(name=container, slug=f"plain-{stamp}")
+            child = make_game_system(
+                name=system, slug=f"edition-{stamp}", parent_id=parent.id
+            )
+            db = SessionLocal()
+            system_id, category = fs.resolve_book_placement(db, Path(src))
+            db.close()
+            assert category == "core", "the category folder sits one level deeper"
+            assert system_id == child.id, "the nested system owns the book"
+        finally:
+            shutil.rmtree(os.path.join(LIB, "books", container), ignore_errors=True)
+
+    def test_unregistered_nested_system_falls_back_to_the_container(self, nested_tree):
+        """A folder with no row of its own must not orphan the book.
+
+        The system is matched by name, and a folder the scanner has not reached
+        yet has none. Rather than leaving ``game_system_id`` unset, the nearest
+        registered ancestor keeps the book on a shelf.
+        """
+        _stamp, family, parent, _system, _title = nested_tree
+        family_row = make_game_system(name=family, slug=f"fam-only-{_stamp}")
+        rel = f"books/{family}/{parent}/Unregistered-{_stamp}/core/tome.pdf"
+        src = _write(rel)
+        db = SessionLocal()
+        system_id, _category = fs.resolve_book_placement(db, Path(src))
+        db.close()
+        assert system_id == family_row.id
+
+    def test_move_keeps_system_and_category(self, nested_tree):
+        """``/api/files/move`` re-infers from the destination too (issue #413)."""
+        _stamp, family, parent, system, title = nested_tree
+        _parent_row, system_row, book, _src = self._rows(nested_tree)
+        book_id = book.id
+        # Move the file up out of its per-title folder, into the category folder.
+        dest = f"books/{family}/{parent}/{system}/Handouts"
+
+        db = SessionLocal()
+        result = fs.move_paths(
+            db, [f"{dest}/{title}/karten.pdf"], dest
+        )
+        db.close()
+
+        assert result.count == 1
+        db = SessionLocal()
+        row = db.query(Book).filter(Book.id == book_id).first()
+        assert row.category == "handout"
+        assert row.game_system_id == system_row.id
+        db.close()
+
+
 # ---------------------------------------------------------------------------
 # Read-only library
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

<!-- What does this PR do? A few sentences is fine. -->

## Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / cleanup
- [ ] Docs / configuration only

## Testing

<!-- How did you verify this works? Check all that apply. -->

- [x] Backend tests pass (`pytest -q`)
- [ ] Frontend tests pass (`npm test`)
- [x] Tested manually in the browser

## Notes for reviewer

<!-- Anything that needs extra context, known limitations, or follow-up work. Delete if not needed. -->
