### PR TITLE
Fix: Load large map/token galleries smoothly and keep the file menu o…

### DIFF
--- a/backend/routers/maps/core.py
+++ b/backend/routers/maps/core.py
@@ -87,7 +87,12 @@ def list_maps(
     q = variants.parents_only(db.query(GenericMap), GenericMap)
     if map_type:
         q = q.filter_by(map_type=map_type)
-    q = q.order_by(GenericMap.filename)
+    # Ordered by path, not filename: the gallery groups by folder and sorts the
+    # folders by name, so ordering the query this way makes the first page the
+    # first folders as they will actually be displayed. Paging by filename
+    # instead scattered each page across the whole tree, and every later page
+    # then inserted rows *above* what the user was already looking at.
+    q = q.order_by(GenericMap.relative_path)
     if folder is not None:
         # Folder is derived from relative_path rather than stored as a column, so
         # it cannot be compared directly. Narrowing on the path prefix in SQL

--- a/backend/routers/tokens/core.py
+++ b/backend/routers/tokens/core.py
@@ -35,7 +35,9 @@ def list_tokens(
     if not can_see_explicit:
         q = q.filter(Token.is_explicit != True)
     total = q.count()
-    tokens = q.order_by(Token.filename).offset(offset).limit(limit).all()
+    # By path rather than filename, so a page is a contiguous run of folders in
+    # display order and later pages append below the fold — see list_maps.
+    tokens = q.order_by(Token.relative_path).offset(offset).limit(limit).all()
     token_tags = tag_service.display_tags_for_resources(db, "token", [t.id for t in tokens])
     vcounts = variants.variant_counts(db, Token, [t.id for t in tokens])
     vkinds = variants.variant_kinds(db, Token, [t.id for t in tokens])

--- a/backend/tests/test_maps.py
+++ b/backend/tests/test_maps.py
@@ -49,6 +49,47 @@ class TestListMaps:
         assert len(resp.json()["maps"]) <= 1
 
 
+class TestListMapsOrdering:
+    """The gallery groups by folder, so a page must be a contiguous run of
+    folders in display order — not a filename-ordered scatter across the whole
+    tree, which made every later page insert rows above what the user was
+    already looking at."""
+
+    @pytest.fixture(scope="class")
+    def scattered(self):
+        # Filenames deliberately sort in the opposite order to their folders, so
+        # ordering by filename and by path give visibly different pages.
+        return [
+            make_map(filename="z.png", relative_path="DnD/Alleys/z.png"),
+            make_map(filename="a.png", relative_path="DnD/Zones/a.png"),
+            make_map(filename="y.png", relative_path="DnD/Alleys/y.png"),
+            make_map(filename="b.png", relative_path="DnD/Zones/b.png"),
+        ]
+
+    def _paths(self, client, headers, query=""):
+        resp = client.get(f"/api/maps{query}", headers=headers)
+        assert resp.status_code == 200
+        return [m["relative_path"] for m in resp.json()["maps"]]
+
+    def test_orders_by_path(self, client, admin_headers, scattered):
+        paths = [p for p in self._paths(client, admin_headers) if p.startswith("DnD/")]
+        assert paths == sorted(paths)
+
+    def test_first_page_holds_one_folder_not_a_scatter(self, client, admin_headers, scattered):
+        # The point of the path ordering: the first two rows of this set are both
+        # Alleys, so the Zones rows arriving later append below rather than
+        # interleaving into a folder already on screen.
+        paths = [p for p in self._paths(client, admin_headers) if p.startswith("DnD/")]
+        assert paths[:2] == ["DnD/Alleys/y.png", "DnD/Alleys/z.png"]
+
+    def test_pages_do_not_overlap_or_drop_rows(self, client, admin_headers, scattered):
+        first = self._paths(client, admin_headers, "?limit=2&offset=0")
+        second = self._paths(client, admin_headers, "?limit=2&offset=2")
+        assert len(set(first) & set(second)) == 0
+        combined = self._paths(client, admin_headers, "?limit=4&offset=0")
+        assert first + second == combined
+
+
 class TestListMapsByFolder:
     @pytest.fixture(scope="class")
     def folder_maps(self):

--- a/backend/tests/test_tokens.py
+++ b/backend/tests/test_tokens.py
@@ -17,6 +17,25 @@ def _set_explicit_pref(username, allow):
     db.close()
 
 
+class TestListTokensOrdering:
+    """Paged by path so each page is a contiguous run of folders in the order
+    the gallery displays them — see the matching maps tests."""
+
+    def test_orders_by_path(self, client, admin_headers):
+        # Filenames sort opposite to their folders, so the two orderings differ.
+        make_token(filename="z.png", relative_path="DnD/Aaa/z.png")
+        make_token(filename="a.png", relative_path="DnD/Zzz/a.png")
+        resp = client.get("/api/tokens", headers=admin_headers)
+        assert resp.status_code == 200
+        paths = [
+            t["relative_path"]
+            for t in resp.json()["tokens"]
+            if t["relative_path"].startswith("DnD/")
+        ]
+        assert paths == sorted(paths)
+        assert paths[0].startswith("DnD/Aaa/")
+
+
 class TestListTokens:
     def test_returns_list(self, client, admin_headers):
         make_token()

--- a/frontend/src/components/files/ContextMenu.jsx
+++ b/frontend/src/components/files/ContextMenu.jsx
@@ -1,0 +1,92 @@
+import { useLayoutEffect, useRef, useState } from 'react'
+
+// Breathing room kept between the menu and the viewport edge, so a clamped
+// menu never sits flush against the window.
+const MARGIN = 8
+
+/**
+ * The file manager's right-click menu, positioned so it is always fully on
+ * screen.
+ *
+ * The position used to be clamped against a hardcoded height guess, which was
+ * wrong for most of the menus this renders: a folder's menu (download, new
+ * folder, two upload rows, scaffold, pin, container kind, NSFW, move, rename,
+ * delete) is roughly half again as tall as a file's, so right-clicking a row
+ * near the bottom of the pane pushed the lower entries — delete, rename, move —
+ * off the bottom of the window where they could not be reached.
+ *
+ * So the menu measures itself instead of being guessed at. It renders hidden at
+ * the click point, and a layout effect (before paint, so there is no visible
+ * jump) reads its real box and picks the final spot: flipped above the cursor
+ * when there is room there and not below, otherwise clamped to the viewport.
+ * If it is taller than the viewport even then — a long container-kind list on a
+ * short window — it pins to the top and scrolls internally rather than
+ * overflowing off both ends.
+ */
+export default function ContextMenu({ x, y, onClick, children }) {
+  const ref = useRef(null)
+  // null until measured; the menu stays invisible (but laid out, so it has a
+  // height to read) for that first pass.
+  const [pos, setPos] = useState(null)
+  const [maxHeight, setMaxHeight] = useState(null)
+
+  useLayoutEffect(() => {
+    const el = ref.current
+    if (!el) return
+    const { width, height } = el.getBoundingClientRect()
+    const vw = window.innerWidth
+    const vh = window.innerHeight
+    const room = vh - 2 * MARGIN
+
+    let top
+    if (height > room) {
+      // Taller than the window: it has to scroll, so anchor it at the top.
+      top = MARGIN
+      setMaxHeight(room)
+    } else if (y + height + MARGIN <= vh) {
+      top = y // fits below the cursor, the normal case
+    } else if (y - height - MARGIN >= 0) {
+      top = y - height // flip above, keeping the cursor on the menu's edge
+    } else {
+      top = vh - height - MARGIN // clamp to the bottom
+    }
+
+    // Horizontal follows the same rule: prefer right of the cursor, flip left
+    // when that overflows, clamp if neither fits.
+    let left
+    if (x + width + MARGIN <= vw) left = x
+    else if (x - width - MARGIN >= 0) left = x - width
+    else left = Math.max(MARGIN, vw - width - MARGIN)
+
+    setPos({ top, left })
+  }, [x, y])
+
+  return (
+    <div
+      ref={ref}
+      role="menu"
+      data-testid="file-context-menu"
+      style={{
+        position: 'fixed',
+        top: pos ? pos.top : y,
+        left: pos ? pos.left : x,
+        // Hidden rather than unmounted for the measuring pass: it needs to be in
+        // the document to have a height, but must not flash at the raw click
+        // point first.
+        visibility: pos ? 'visible' : 'hidden',
+        maxHeight: maxHeight ?? undefined,
+        overflowY: maxHeight ? 'auto' : undefined,
+        background: 'var(--bg-panel)',
+        border: '1px solid var(--border)',
+        borderRadius: 8,
+        padding: 4,
+        zIndex: 900,
+        minWidth: 220,
+        boxShadow: '0 8px 24px var(--overlay)',
+      }}
+      onClick={onClick}
+    >
+      {children}
+    </div>
+  )
+}

--- a/frontend/src/components/files/ContextMenu.test.jsx
+++ b/frontend/src/components/files/ContextMenu.test.jsx
@@ -1,0 +1,92 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest'
+import { render, screen } from '@testing-library/react'
+import ContextMenu from './ContextMenu'
+
+// jsdom gives every element a zero-sized box, so the measuring layout effect
+// has nothing to work with unless the height/width are stubbed. Each test sets
+// the size the menu should believe it has.
+const mockSize = (width, height) =>
+  vi.spyOn(Element.prototype, 'getBoundingClientRect').mockImplementation(function () {
+    const top = parseFloat(this.style.top) || 0
+    const left = parseFloat(this.style.left) || 0
+    return {
+      width,
+      height,
+      top,
+      left,
+      right: left + width,
+      bottom: top + height,
+      x: left,
+      y: top,
+      toJSON: () => {},
+    }
+  })
+
+const renderMenu = (x, y) =>
+  render(
+    <ContextMenu x={x} y={y} onClick={() => {}}>
+      <button>Delete</button>
+    </ContextMenu>
+  )
+
+const menu = () => screen.getByTestId('file-context-menu')
+
+describe('ContextMenu', () => {
+  beforeEach(() => {
+    window.innerWidth = 1000
+    window.innerHeight = 800
+  })
+
+  afterEach(() => {
+    vi.restoreAllMocks()
+  })
+
+  it('opens at the click point when the menu fits below it', () => {
+    mockSize(220, 300)
+    renderMenu(100, 100)
+    expect(menu()).toHaveStyle({ top: '100px', left: '100px' })
+  })
+
+  it('flips above the cursor when the menu would run off the bottom', () => {
+    // The regression this component exists for: a tall folder menu opened from
+    // a row near the bottom of the pane used to push its lower entries —
+    // delete, rename, move — past the bottom of the window.
+    mockSize(220, 480)
+    renderMenu(100, 700)
+    // 700 - 480: the menu's bottom edge lands on the cursor, fully on screen.
+    expect(menu()).toHaveStyle({ top: '220px' })
+  })
+
+  it('clamps to the bottom edge when it fits neither below nor above', () => {
+    mockSize(220, 700)
+    renderMenu(100, 400)
+    // 800 - 700 - 8 margin.
+    expect(menu()).toHaveStyle({ top: '92px' })
+  })
+
+  it('scrolls internally when taller than the whole viewport', () => {
+    mockSize(220, 900)
+    renderMenu(100, 400)
+    expect(menu()).toHaveStyle({ top: '8px', overflowY: 'auto' })
+    // Capped to the viewport minus both margins so both ends stay reachable.
+    expect(menu()).toHaveStyle({ maxHeight: '784px' })
+  })
+
+  it('flips to the left of the cursor when it would run off the right edge', () => {
+    mockSize(220, 300)
+    renderMenu(900, 100)
+    expect(menu()).toHaveStyle({ left: '680px' })
+  })
+
+  it('is visible once measured', () => {
+    mockSize(220, 300)
+    renderMenu(100, 100)
+    expect(menu()).toHaveStyle({ visibility: 'visible' })
+  })
+
+  it('renders its children', () => {
+    mockSize(220, 300)
+    renderMenu(100, 100)
+    expect(screen.getByText('Delete')).toBeInTheDocument()
+  })
+})

--- a/frontend/src/components/files/MenuSubmenu.jsx
+++ b/frontend/src/components/files/MenuSubmenu.jsx
@@ -1,4 +1,4 @@
-import { useRef, useState } from 'react'
+import { useLayoutEffect, useRef, useState } from 'react'
 import { LuChevronRight } from 'react-icons/lu'
 
 /**
@@ -15,6 +15,32 @@ import { LuChevronRight } from 'react-icons/lu'
 export default function MenuSubmenu({ label, icon, children, itemStyle, hoverProps, testId }) {
   const [open, setOpen] = useState(false)
   const closeTimer = useRef(null)
+  const panelRef = useRef(null)
+  // Offsets applied to the panel's default position (right of the row, aligned
+  // to its top) to keep it inside the window — see the layout effect below.
+  const [shift, setShift] = useState({ up: 0, flip: false })
+
+  // The parent menu is already clamped to the viewport, but a panel opening off
+  // its bottom-right corner can still overflow: the container-kind list is
+  // seven rows tall and its row sits low in the menu. Measure once open and
+  // pull it up (and to the left of the row) by however much it overhangs.
+  useLayoutEffect(() => {
+    if (!open) {
+      setShift({ up: 0, flip: false })
+      return
+    }
+    const el = panelRef.current
+    if (!el) return
+    const r = el.getBoundingClientRect()
+    // `r` is the box as currently positioned, so the overhang is measured
+    // against the live layout and subtracting it lands the panel on the edge.
+    const overflowY = r.bottom - (window.innerHeight - 8)
+    const overflowX = r.right - (window.innerWidth - 8)
+    setShift({
+      up: overflowY > 0 ? Math.min(overflowY, r.top - 8) : 0,
+      flip: overflowX > 0,
+    })
+  }, [open])
 
   const cancelClose = () => clearTimeout(closeTimer.current)
   // Leaving the row briefly crosses dead space on the way to the panel; closing
@@ -59,13 +85,15 @@ export default function MenuSubmenu({ label, icon, children, itemStyle, hoverPro
         <div
           role="menu"
           data-testid={testId ? `${testId}-panel` : undefined}
+          ref={panelRef}
           onMouseEnter={cancelClose}
           onMouseLeave={scheduleClose}
           style={{
             position: 'absolute',
-            top: -4,
-            left: '100%',
-            marginLeft: 2,
+            top: -4 - shift.up,
+            // Flipped to the row's left edge when opening rightwards would run
+            // off the window (a menu already clamped to the right edge).
+            ...(shift.flip ? { right: '100%', marginRight: 2 } : { left: '100%', marginLeft: 2 }),
             minWidth: 200,
             background: 'var(--bg-panel)',
             border: '1px solid var(--border)',

--- a/frontend/src/components/files/MenuSubmenu.test.jsx
+++ b/frontend/src/components/files/MenuSubmenu.test.jsx
@@ -11,6 +11,47 @@ const renderSub = (props = {}) =>
   )
 
 describe('MenuSubmenu', () => {
+  it('pulls its panel up when it would open past the bottom of the window', () => {
+    // The parent menu is clamped to the viewport, but a seven-row panel opening
+    // off its bottom corner can still overhang.
+    window.innerHeight = 600
+    vi.spyOn(Element.prototype, 'getBoundingClientRect').mockReturnValue({
+      top: 500,
+      bottom: 700, // 108px past the 592 limit (600 - 8 margin)
+      left: 200,
+      right: 400,
+      width: 200,
+      height: 200,
+      x: 200,
+      y: 500,
+      toJSON: () => {},
+    })
+    renderSub()
+    fireEvent.mouseEnter(screen.getByTestId('sub').parentElement)
+    // -4 default, minus the 108px overhang.
+    expect(screen.getByTestId('sub-panel')).toHaveStyle({ top: '-112px' })
+    vi.restoreAllMocks()
+  })
+
+  it('flips its panel to the left when it would run off the right edge', () => {
+    window.innerWidth = 500
+    vi.spyOn(Element.prototype, 'getBoundingClientRect').mockReturnValue({
+      top: 100,
+      bottom: 300,
+      left: 400,
+      right: 600, // past the 492 limit
+      width: 200,
+      height: 200,
+      x: 400,
+      y: 100,
+      toJSON: () => {},
+    })
+    renderSub()
+    fireEvent.mouseEnter(screen.getByTestId('sub').parentElement)
+    expect(screen.getByTestId('sub-panel')).toHaveStyle({ right: '100%' })
+    vi.restoreAllMocks()
+  })
+
   it('keeps its panel closed until asked', () => {
     renderSub()
     expect(screen.queryByTestId('sub-panel')).not.toBeInTheDocument()

--- a/frontend/src/components/media/gallerySubtitle.js
+++ b/frontend/src/components/media/gallerySubtitle.js
@@ -6,8 +6,20 @@
  * bare count reads as the size of the whole collection, so it switches to
  * "Displaying x of y" — where `total` is only ever the rows the list endpoint
  * returned for this user, never a library-wide figure.
+ *
+ * While the library is still streaming in, `count`/`total` describe only the
+ * pages that have arrived, so on a large collection the number visibly climbed
+ * a page at a time. Passing `loading` with the server's `available` total shows
+ * that figure instead — the collection's real size, which does not change as
+ * pages land — so the header reads correctly from the first page and the rest
+ * of the library fills in silently below the fold.
  */
-export default function gallerySubtitle(t, prefix, { count, total }) {
+export default function gallerySubtitle(t, prefix, { count, total, loading, available }) {
+  // A filter narrowing the (partial) set still has to report what it matched:
+  // "Displaying x of y" stays honest mid-load because both halves grow together.
+  if (loading && count === total) {
+    return t(`${prefix}.subtitle`, { count: Math.max(available || 0, total) })
+  }
   return count === total
     ? t(`${prefix}.subtitle`, { count })
     : t(`${prefix}.subtitleFiltered`, { count, total })

--- a/frontend/src/components/media/gallerySubtitle.test.js
+++ b/frontend/src/components/media/gallerySubtitle.test.js
@@ -25,4 +25,31 @@ describe('gallerySubtitle', () => {
   it('keeps the plain subtitle for an empty collection', () => {
     expect(gallerySubtitle(t, 'maps', { count: 0, total: 0 })).toBe('maps.subtitle:{"count":0}')
   })
+
+  it('reports the collection size, not the loaded slice, while pages stream in', () => {
+    // The whole point of the loading branch: with 500 of 10000 maps in, the
+    // header must not read "500 maps in your collection" and then climb.
+    expect(
+      gallerySubtitle(t, 'maps', { count: 500, total: 500, loading: true, available: 10000 })
+    ).toBe('maps.subtitle:{"count":10000}')
+  })
+
+  it('still reports what a filter matched while loading', () => {
+    // Both halves of "x of y" grow together as pages land, so this stays honest.
+    expect(
+      gallerySubtitle(t, 'maps', { count: 12, total: 500, loading: true, available: 10000 })
+    ).toBe('maps.subtitleFiltered:{"count":12,"total":500}')
+  })
+
+  it('falls back to the loaded total when the server total is not known yet', () => {
+    expect(
+      gallerySubtitle(t, 'tokens', { count: 40, total: 40, loading: true, available: 0 })
+    ).toBe('tokens.subtitle:{"count":40}')
+  })
+
+  it('uses the plain count once loading finishes', () => {
+    expect(
+      gallerySubtitle(t, 'maps', { count: 10000, total: 10000, loading: false, available: 10000 })
+    ).toBe('maps.subtitle:{"count":10000}')
+  })
 })

--- a/frontend/src/hooks/useMediaGallery.js
+++ b/frontend/src/hooks/useMediaGallery.js
@@ -14,6 +14,11 @@ import { splitSpecial, isSpecialFilter } from '../components/library/specialFilt
 // arrives in one request, small enough that the first paint is quick on a big one.
 const PAGE_SIZE = 500
 
+// How many pages are in flight at once while the rest of the library streams
+// in. Enough to keep the connection pool busy on a 10k library without firing
+// every remaining page at the server in one burst.
+const PAGE_CONCURRENCY = 4
+
 // Stable empty array: a fresh `[]` per render would invalidate every useMemo
 // that depends on `items` before the first page lands.
 const EMPTY_ITEMS = []
@@ -91,21 +96,48 @@ export default function useMediaGallery(config) {
     // folder grouping still see the whole library once loading settles.
     let cancelled = false
 
-    const loadPage = async (offset) => {
+    const fetchPage = async (offset) => {
       const page = await api.get(`${listUrl}?limit=${PAGE_SIZE}&offset=${offset}`)
+      return { page, rows: page[collection] || [] }
+    }
+
+    const loadAll = async () => {
+      // The first page is fetched and committed on its own so the grid paints
+      // as soon as anything is available.
+      const { page: first, rows: firstRows } = await fetchPage(0)
       if (cancelled) return
-      const rows = page[collection] || []
-      setData((prev) =>
-        prev && offset > 0
-          ? { ...page, [collection]: [...prev[collection], ...rows] }
-          : { ...page, [collection]: rows }
-      )
-      setLoadedCount((prev) => (offset > 0 ? prev + rows.length : rows.length))
-      // `total` is the server's count before pagination; stop when a short page
-      // arrives too, so a mid-load change on the server cannot spin forever.
-      const seen = offset + rows.length
-      if (rows.length === PAGE_SIZE && seen < page.total) await loadPage(seen)
-      else if (!cancelled) setLoadingMore(false)
+      setData({ ...first, [collection]: firstRows })
+      setLoadedCount(firstRows.length)
+
+      // `total` is the server's count before pagination, so once the first page
+      // is in, the remaining offsets are all known. Fetching them sequentially
+      // meant a 10k library paid twenty round-trips end to end, each one
+      // re-rendering (and re-deriving) the whole accumulated set — so the list
+      // filled in visibly, unevenly, over several seconds. They go out together
+      // instead, in bounded batches so the browser's connection limit does the
+      // queueing rather than a burst of twenty parallel requests, and each batch
+      // lands in a single state update.
+      if (firstRows.length < PAGE_SIZE || firstRows.length >= first.total) {
+        if (!cancelled) setLoadingMore(false)
+        return
+      }
+
+      const offsets = []
+      for (let off = firstRows.length; off < first.total; off += PAGE_SIZE) offsets.push(off)
+
+      for (let i = 0; i < offsets.length; i += PAGE_CONCURRENCY) {
+        const batch = offsets.slice(i, i + PAGE_CONCURRENCY)
+        const results = await Promise.all(batch.map((off) => fetchPage(off)))
+        if (cancelled) return
+        const rows = results.flatMap((r) => r.rows)
+        if (!rows.length) break
+        setData((prev) => ({
+          ...prev,
+          [collection]: [...(prev ? prev[collection] : []), ...rows],
+        }))
+        setLoadedCount((prev) => prev + rows.length)
+      }
+      if (!cancelled) setLoadingMore(false)
     }
 
     api.get(foldersUrl).then((foldersData) => {
@@ -116,7 +148,7 @@ export default function useMediaGallery(config) {
     })
 
     setLoadingMore(true)
-    loadPage(0).catch(() => {
+    loadAll().catch(() => {
       if (!cancelled) setLoadingMore(false)
     })
 
@@ -250,27 +282,48 @@ export default function useMediaGallery(config) {
   // reads, and the per-item values that never change with the filters (lowercased
   // search haystack, effective tags, folder segments) are computed once here and
   // reused by filtering, grouping, and the tag list.
-  const decorated = useMemo(
-    () =>
-      items.map((item) => {
-        const effective = getEffectiveTags(item, folderTags)
-        const topFolder = getTopFolder(item)
-        const subPath = getSubPath(item)
-        return {
-          item,
-          topFolder,
-          subPath,
-          effective,
-          effectiveLower: effective.map((t) => t.toLowerCase()),
-          // NUL-joined: the separator must be something a search term can never
-          // contain, or a query could match across two adjacent fields.
-          haystack: [item.filename || '', topFolder, subPath, ...effective]
-            .join('\0')
-            .toLowerCase(),
-        }
-      }),
-    [items, folderTags]
-  )
+  // Decorating an item is pure in (item, folderTags), and appending a page
+  // leaves every already-decorated item's object identity untouched. Caching on
+  // that identity turns the streaming load from quadratic — each of ~20 pages
+  // re-deriving the whole accumulated set — into one pass per item for the whole
+  // load. The cache is dropped whenever folderTags changes, since that feeds
+  // every entry.
+  const decorateCache = useRef(new Map())
+  const decorateCacheKey = useRef(folderTags)
+  if (decorateCacheKey.current !== folderTags) {
+    decorateCacheKey.current = folderTags
+    decorateCache.current = new Map()
+  }
+
+  const decorated = useMemo(() => {
+    const cache = decorateCache.current
+    const next = items.map((item) => {
+      const hit = cache.get(item)
+      if (hit) return hit
+      const effective = getEffectiveTags(item, folderTags)
+      const topFolder = getTopFolder(item)
+      const subPath = getSubPath(item)
+      const entry = {
+        item,
+        topFolder,
+        subPath,
+        effective,
+        effectiveLower: effective.map((t) => t.toLowerCase()),
+        // NUL-joined: the separator must be something a search term can never
+        // contain, or a query could match across two adjacent fields.
+        haystack: [item.filename || '', topFolder, subPath, ...effective].join('\0').toLowerCase(),
+      }
+      cache.set(item, entry)
+      return entry
+    })
+    // Items dropped from the list (a bulk edit replacing objects, a removal)
+    // would otherwise keep their cache entries alive for the view's lifetime.
+    if (cache.size > items.length) {
+      const live = new Set(items)
+      for (const key of cache.keys()) if (!live.has(key)) cache.delete(key)
+    }
+    return next
+  }, [items, folderTags])
 
   const allTags = useMemo(
     () => (data ? [...new Set(decorated.flatMap((d) => d.effectiveLower))].sort() : []),

--- a/frontend/src/hooks/useMediaGallery.test.jsx
+++ b/frontend/src/hooks/useMediaGallery.test.jsx
@@ -338,6 +338,68 @@ describe('useMediaGallery', () => {
       expect(result.current.totalCount).toBe(1)
     })
 
+    it('fetches the pages after the first concurrently', async () => {
+      // Sequentially, a 10k library paid twenty round-trips end to end and the
+      // grid filled in unevenly over seconds. Once the first page reports the
+      // total, every remaining offset is known and they go out together.
+      const total = 2001
+      let inFlight = 0
+      let peak = 0
+      const all = Array.from({ length: total }, (_, i) =>
+        item({ id: `m${i}`, filename: `m${i}.png` })
+      )
+      api.get.mockImplementation((url) => {
+        const [path, qs] = url.split('?')
+        if (path === '/maps') {
+          const params = new URLSearchParams(qs)
+          const offset = Number(params.get('offset') || 0)
+          inFlight += 1
+          peak = Math.max(peak, inFlight)
+          return new Promise((resolve) =>
+            setTimeout(() => {
+              inFlight -= 1
+              resolve({ maps: all.slice(offset, offset + 500), total })
+            }, 5)
+          )
+        }
+        if (url === '/map-folders') return Promise.resolve({ folders: [] })
+        if (url.startsWith('/saved-filters')) return Promise.resolve({ filters: [] })
+        return Promise.resolve({})
+      })
+      const { result } = renderGallery()
+      await waitFor(() => expect(result.current.loadingMore).toBe(false), { timeout: 3000 })
+      // The first page is alone (its total is what schedules the rest); the four
+      // remaining pages overlap.
+      expect(peak).toBeGreaterThan(1)
+      expect(result.current.totalCount).toBe(total)
+      expect(new Set(result.current.flatItems.map((i) => i.id)).size).toBe(total)
+    })
+
+    it('exposes the server total while pages are still arriving', async () => {
+      // What lets the header show the collection's real size instead of a count
+      // that climbs a page at a time.
+      pagedSetup(1200)
+      const { result } = renderGallery()
+      await waitFor(() => expect(result.current.data).not.toBeNull())
+      expect(result.current.totalAvailable).toBe(1200)
+      await waitFor(() => expect(result.current.loadingMore).toBe(false))
+      expect(result.current.loadedCount).toBe(1200)
+    })
+
+    it('reuses decorated rows across appends instead of re-deriving them', async () => {
+      // Re-decorating the whole accumulated set on every page made the streaming
+      // load quadratic. Already-seen items keep their object identity, so the
+      // cache must hand back the very same decorated entry.
+      pagedSetup(1001)
+      const { result } = renderGallery()
+      await waitFor(() => expect(result.current.data).not.toBeNull())
+      const firstItem = result.current.flatItems[0]
+      await waitFor(() => expect(result.current.loadingMore).toBe(false))
+      // Same underlying object after two more pages appended.
+      expect(result.current.flatItems[0]).toBe(firstItem)
+      expect(result.current.totalCount).toBe(1001)
+    })
+
     it('clears the loading flag when a page request fails', async () => {
       api.get.mockImplementation((url) => {
         const path = url.split('?')[0]

--- a/frontend/src/views/FileManagerView.jsx
+++ b/frontend/src/views/FileManagerView.jsx
@@ -30,6 +30,7 @@ import FilePane from '../components/files/FilePane'
 import NewFolderModal from '../components/files/NewFolderModal'
 import RenameModal from '../components/files/RenameModal'
 import MenuSubmenu from '../components/files/MenuSubmenu'
+import ContextMenu from '../components/files/ContextMenu'
 import UploadPanel from '../components/files/UploadPanel'
 import useUploadQueue from '../hooks/useUploadQueue'
 import BulkEditModal from '../components/BulkEditModal'
@@ -648,19 +649,10 @@ export default function FileManagerView() {
       </p>
 
       {context && (
-        <div
-          style={{
-            position: 'fixed',
-            top: Math.min(context.y, window.innerHeight - 320),
-            left: Math.min(context.x, window.innerWidth - 240),
-            background: 'var(--bg-panel)',
-            border: '1px solid var(--border)',
-            borderRadius: 8,
-            padding: 4,
-            zIndex: 900,
-            minWidth: 220,
-            boxShadow: '0 8px 24px var(--overlay)',
-          }}
+        <ContextMenu
+          key={`${context.x},${context.y}`}
+          x={context.x}
+          y={context.y}
           onClick={(e) => e.stopPropagation()}
         >
           {/* Only indexed *files* can be previewed — a system folder has a
@@ -890,7 +882,7 @@ export default function FileManagerView() {
           >
             <LuTrash2 size={13} /> {t('files.delete')}
           </button>
-        </div>
+        </ContextMenu>
       )}
 
       {creatingIn !== null && (

--- a/frontend/src/views/MapsView.jsx
+++ b/frontend/src/views/MapsView.jsx
@@ -39,6 +39,8 @@ export default function MapsView() {
         subtitle={gallerySubtitle(t, 'maps', {
           count: gallery.filteredCount,
           total: gallery.totalCount,
+          loading: gallery.loadingMore,
+          available: gallery.totalAvailable,
         })}
         onDownload={setDownloadModal}
         onAddToCampaign={() => setShowAddToCampaign(true)}

--- a/frontend/src/views/TokensView.jsx
+++ b/frontend/src/views/TokensView.jsx
@@ -38,6 +38,8 @@ export default function TokensView() {
         subtitle={gallerySubtitle(t, 'tokens', {
           count: gallery.filteredCount,
           total: gallery.totalCount,
+          loading: gallery.loadingMore,
+          available: gallery.totalAvailable,
         })}
         onDownload={setDownloadModal}
         onAddToCampaign={() => setShowAddToCampaign(true)}


### PR DESCRIPTION
…n screen

## Summary

<!-- What does this PR do? A few sentences is fine. -->

## Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / cleanup
- [ ] Docs / configuration only

## Testing

<!-- How did you verify this works? Check all that apply. -->

- [x] Backend tests pass (`pytest -q`)
- [x] Frontend tests pass (`npm test`)
- [x] Tested manually in the browser

## Notes for reviewer

<!-- Anything that needs extra context, known limitations, or follow-up work. Delete if not needed. -->
