### PR TITLE
Fix: Keep a book's cover when its title was edited before a move

### DIFF
--- a/backend/services/library_fs/__init__.py
+++ b/backend/services/library_fs/__init__.py
@@ -84,6 +84,7 @@ from .moves import (  # noqa: F401
     _restore_sidecars,
     _section_for_model,
     _thumb_file,
+    _thumb_files_for,
     _thumb_key,
     move_paths,
     relocate_book_for_category,

--- a/backend/services/library_fs/deletes.py
+++ b/backend/services/library_fs/deletes.py
@@ -20,7 +20,7 @@ from ...models.campaigns import Campaign
 from ...models.library import Book, GameSystem
 from . import folders
 from .constants import _THUMB_SECTIONS, LibraryFSError
-from .moves import _records_under, _section_for_model, _thumb_file, _thumb_key
+from .moves import _records_under, _section_for_model, _thumb_files_for
 from .paths import (
     assert_writable,
     collection_of,
@@ -43,12 +43,19 @@ def _purge_derived(db: Session, model: Any, record: Any) -> None:
     """
     section = _THUMB_SECTIONS.get(_section_for_model(model))
     if section and getattr(record, "has_thumbnail", False):
-        thumb = _thumb_file(section, _thumb_key(record), record.filepath)
-        try:
-            thumb.unlink()
-        except OSError as e:
-            if getattr(e, "errno", None) != 2:  # ENOENT - already gone
-                logger.warning("Could not delete thumbnail %s: %s", thumb, e)
+        # Every thumbnail matching the path hash, not just the one the current
+        # title composes (issue #421). A book whose title was edited after
+        # indexing still has its cover under the old slug, and the composed name
+        # would miss it — silently, since the ENOENT that follows is the same
+        # errno as an already-deleted file. The row is about to go, so anything
+        # left behind is unreachable for good: exactly the stranding this
+        # function exists to prevent.
+        for thumb in _thumb_files_for(record, section, record.filepath, every=True):
+            try:
+                thumb.unlink()
+            except OSError as e:
+                if getattr(e, "errno", None) != 2:  # ENOENT - already gone
+                    logger.warning("Could not delete thumbnail %s: %s", thumb, e)
 
     if model is Book:
         from ..content_cache import invalidate_book_content

--- a/backend/services/library_fs/moves.py
+++ b/backend/services/library_fs/moves.py
@@ -138,6 +138,74 @@ def _thumb_file(section: str, title: str, filepath: str) -> Path:
     )
 
 
+def _slug_of(thumb: Path) -> str:
+    """The name half of an existing thumbnail filename, ready to re-compose.
+
+    ``{slug}_{hash}.webp`` splits at the *last* underscore, since a slug may
+    contain none but the hash never does. ``slugify`` is idempotent, so feeding
+    the result back through :func:`_thumb_file` reproduces the same name against
+    a different path — which is what lets a re-home carry an index-time slug
+    across a move untouched.
+    """
+    return thumb.stem.rsplit("_", 1)[0]
+
+
+def _thumb_glob(section: str, filepath: str) -> list[Path]:
+    """Every cached thumbnail written for ``filepath``, whatever title named it.
+
+    Only the path hash actually identifies a record's file; the slug half is a
+    snapshot of the title *at index time*. Editing a book's title does not
+    rename the cached file (nothing needs it to — the cover route already falls
+    back to this same glob), so from then on the title-derived name points at a
+    file that never existed. Callers that must find the real file — a move that
+    would otherwise drop the cover, a delete that would otherwise strand it —
+    resolve through here.
+
+    Returns matches sorted, so a stale thumbnail left beside a current one gives
+    the same answer on every call instead of depending on directory order.
+    """
+    import hashlib
+
+    fhash = hashlib.md5(filepath.encode()).hexdigest()[:8]
+    return sorted((Path(THUMB_DIR) / section).glob(f"*_{fhash}.webp"))
+
+
+def _thumb_files_for(
+    record: Any, section: str, filepath: str, *, every: bool = False
+) -> list[Path]:
+    """The thumbnails belonging to ``record`` at ``filepath``, best first.
+
+    The exact title-derived name when it is on disk, otherwise whatever the path
+    hash turns up. Only ``Book`` carries a ``title`` column, so it is the only
+    collection whose key can drift: the others are named from the filename stem,
+    which travels with the file and can never go stale. Globbing for them would
+    scan a directory of thousands of files to confirm what the composed name
+    already says, so they skip it.
+
+    ``every`` returns all hash matches instead of stopping at the first hit, for
+    the one caller that must not leave a straggler: a delete, where a stale
+    thumbnail beside the current one becomes unreachable the moment the row is
+    gone. A move wants the single best file — re-homing two names onto one
+    destination would just delete one of them by overwrite.
+
+    Always returns at least one path, so a caller can report the name it looked
+    for when nothing is on disk.
+    """
+    exact = _thumb_file(section, _thumb_key(record), filepath)
+    drifts = hasattr(type(record), "title")
+    if not drifts:
+        return [exact]
+    if every:
+        found = _thumb_glob(section, filepath)
+        # The composed name may be absent from the glob only when it is absent
+        # from disk, in which case there is nothing to unlink but the caller
+        # still wants a name for its warning.
+        return found or [exact]
+    if exact.is_file():
+        return [exact]
+    return _thumb_glob(section, filepath) or [exact]
+
+
 def _rehome_thumbnail(record: Any, section: str, old_path: str, new_path: str) -> bool:
     """Move a record's cached thumbnail to its new path-derived name.
 
@@ -146,12 +214,24 @@ def _rehome_thumbnail(record: Any, section: str, old_path: str, new_path: str) -
     re-render of every moved item — a bulk reorganisation would otherwise
     re-render the whole library. Returns True when the record still has a
     thumbnail afterwards.
+
+    The source is resolved by path hash rather than composed from the current
+    title (issue #421). A book whose title was edited after indexing still has
+    its cover on disk under the *old* slug, so composing the name would name a
+    file that never existed and drop a cover that was there all along — the
+    exact re-render this function exists to avoid, hitting hardest on a library
+    reorganised after a metadata pass.
+
+    The destination keeps the name the source actually had, so the file stays
+    reachable by the cover route's identical fallback.
     """
     if not getattr(record, "has_thumbnail", False):
         return False
-    key = _thumb_key(record)
-    src = _thumb_file(section, key, old_path)
-    dst = _thumb_file(section, key, new_path)
+    src = _thumb_files_for(record, section, old_path)[0]
+    # Renamed to match its source, not to the current title: re-homing moves a
+    # file, it does not re-key one. A book still carrying an index-time slug
+    # keeps it here and is found by the same glob next time.
+    dst = _thumb_file(section, _slug_of(src), new_path)
     if src == dst:
         return True
     try:

--- a/backend/tests/test_files.py
+++ b/backend/tests/test_files.py
@@ -465,6 +465,128 @@ class TestThumbnails:
         assert os.path.exists(new_thumb), "thumbnail must be re-homed under the new key"
         assert not os.path.exists(old_thumb)
 
+    def test_a_title_edited_after_indexing_keeps_its_cover(self, library_tree):
+        """Issue #421: the cached file is named from the title *at index time*.
+
+        Editing a book's title does not rename it — the cover route falls back to
+        the path hash — so re-homing must resolve the source the same way. Keying
+        off the current title names a file that never existed and drops a cover
+        that was on disk the whole time.
+        """
+        import hashlib
+
+        from backend.config import THUMB_DIR
+
+        system = make_game_system(name=f"System-{library_tree}")
+        src = _write(f"books/System-{library_tree}/core/phb.pdf")
+        # Indexed as "phb" (from the filename), then retitled in the editor.
+        book = make_book(
+            system.id, title=f"Retitled Handbook {library_tree}", filepath=src,
+            filename="phb.pdf",
+            relative_path=f"books/System-{library_tree}/core/phb.pdf",
+            has_thumbnail=True,
+        )
+        old_thumb = os.path.join(
+            THUMB_DIR, "books", f"phb_{hashlib.md5(src.encode()).hexdigest()[:8]}.webp",
+        )
+        os.makedirs(os.path.dirname(old_thumb), exist_ok=True)
+        with open(old_thumb, "wb") as f:
+            f.write(b"webp")
+
+        db = SessionLocal()
+        fs.move_paths(
+            db, [f"books/System-{library_tree}/core/phb.pdf"],
+            f"books/System-{library_tree}/adventures",
+        )
+        db.close()
+
+        db = SessionLocal()
+        refreshed = db.query(Book).filter(Book.id == book.id).first()
+        new_path, still_has = refreshed.filepath, refreshed.has_thumbnail
+        db.close()
+        # Re-homed under the slug it actually had, which is what the cover
+        # route's glob finds — not under a slug of the edited title.
+        new_thumb = os.path.join(
+            THUMB_DIR, "books", f"phb_{hashlib.md5(new_path.encode()).hexdigest()[:8]}.webp",
+        )
+        assert still_has is True, "a retitled book must not lose its cover on a move"
+        assert os.path.exists(new_thumb)
+        assert not os.path.exists(old_thumb)
+        os.unlink(new_thumb)
+
+    def test_a_retitled_book_keeps_its_cover_across_a_rename(self, library_tree):
+        """The reported reproduction (issue #421): rename, not move. Both land in
+        ``_fix_caches``, but rename is the path four-of-sixteen files hit."""
+        import hashlib
+
+        from backend.config import THUMB_DIR
+
+        system = make_game_system(name=f"System-{library_tree}")
+        src = _write(f"books/System-{library_tree}/core/xanathar.pdf")
+        book = make_book(
+            system.id, title=f"Retitled Guide {library_tree}", filepath=src,
+            filename="xanathar.pdf",
+            relative_path=f"books/System-{library_tree}/core/xanathar.pdf",
+            has_thumbnail=True,
+        )
+        old_thumb = os.path.join(
+            THUMB_DIR, "books", f"xanathar_{hashlib.md5(src.encode()).hexdigest()[:8]}.webp",
+        )
+        os.makedirs(os.path.dirname(old_thumb), exist_ok=True)
+        with open(old_thumb, "wb") as f:
+            f.write(b"webp")
+
+        db = SessionLocal()
+        fs.rename_path(
+            db, f"books/System-{library_tree}/core/xanathar.pdf", "xge.pdf",
+        )
+        db.close()
+
+        db = SessionLocal()
+        refreshed = db.query(Book).filter(Book.id == book.id).first()
+        new_path, still_has = refreshed.filepath, refreshed.has_thumbnail
+        db.close()
+        new_thumb = os.path.join(
+            THUMB_DIR, "books",
+            f"xanathar_{hashlib.md5(new_path.encode()).hexdigest()[:8]}.webp",
+        )
+        assert still_has is True, "has_thumbnail must survive a rename after a retitle"
+        assert os.path.exists(new_thumb)
+        assert not os.path.exists(old_thumb)
+        os.unlink(new_thumb)
+
+    def test_a_retitled_book_strands_no_thumbnail_on_delete(self, library_tree):
+        """Issue #421, the delete half: the composed name misses the real file
+        and the resulting ENOENT is indistinguishable from an already-deleted
+        one, so the cover would be left under DATA_PATH with its row gone and
+        nothing able to find it again."""
+        import hashlib
+
+        from backend.config import THUMB_DIR
+
+        system = make_game_system(name=f"System-{library_tree}")
+        src = _write(f"books/System-{library_tree}/core/dmg.pdf")
+        make_book(
+            system.id, title=f"Retitled Masters Guide {library_tree}", filepath=src,
+            filename="dmg.pdf",
+            relative_path=f"books/System-{library_tree}/core/dmg.pdf",
+            has_thumbnail=True,
+        )
+        thumb = os.path.join(
+            THUMB_DIR, "books", f"dmg_{hashlib.md5(src.encode()).hexdigest()[:8]}.webp",
+        )
+        os.makedirs(os.path.dirname(thumb), exist_ok=True)
+        with open(thumb, "wb") as f:
+            f.write(b"webp")
+
+        db = SessionLocal()
+        try:
+            fs.delete_path(db, f"books/System-{library_tree}/core/dmg.pdf")
+        finally:
+            db.close()
+
+        assert not os.path.exists(thumb), "the stale-slug thumbnail must not be stranded"
+
     def test_missing_thumbnail_clears_flag(self, library_tree):
         """A thumbnail that cannot be moved degrades to a re-render, not a broken image."""
         system = make_game_system(name=f"System-{library_tree}")


### PR DESCRIPTION
## Summary

<!-- What does this PR do? A few sentences is fine. -->

## Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / cleanup
- [ ] Docs / configuration only

## Testing

<!-- How did you verify this works? Check all that apply. -->

- [x] Backend tests pass (`pytest -q`)
- [ ] Frontend tests pass (`npm test`)
- [ ] Tested manually in the browser

## Notes for reviewer

<!-- Anything that needs extra context, known limitations, or follow-up work. Delete if not needed. -->
