### PR TITLE
Fix: Reach the file manager's menus on touch and from empty space

### DIFF
--- a/backend/routers/files/_schemas.py
+++ b/backend/routers/files/_schemas.py
@@ -33,6 +33,12 @@ class BrowseResponse(BaseModel):
     path: str
     parent: Optional[str] = None
     writable: bool
+    # Whether standard category folders belong directly inside the folder being
+    # browsed — the same question `BrowseEntry.category_host` answers about a
+    # child row, asked about the folder itself. The UI needs both: the scaffold
+    # action is offered on a system folder's row *and* on the empty space of a
+    # pane already anchored inside it, which has no row to click.
+    category_host: bool = False
     entries: list[BrowseEntry]
     # How many entries the folder really holds, and whether `entries` is a
     # prefix of them — so the UI can say "showing 2000 of 48,213" rather than

--- a/backend/routers/files/core.py
+++ b/backend/routers/files/core.py
@@ -197,6 +197,11 @@ def browse(
         path="" if target == root else fs.to_relative(target),
         parent=parent,
         writable=os.access(target, os.W_OK | os.X_OK),
+        # Asked about the browsed folder itself, so the UI can offer the
+        # scaffold action from a pane already anchored inside a system folder —
+        # where there is no row for it to hang off. Only meaningful in the books
+        # tree; `is_category_host` returns False everywhere else.
+        category_host=fs.is_category_host(target),
         entries=entries,
         total=total,
         truncated=total > len(entries),

--- a/backend/tests/test_files.py
+++ b/backend/tests/test_files.py
@@ -1389,6 +1389,43 @@ class TestCategoryHostFlag:
         rows = {e["name"]: e for e in resp.json()["entries"]}
         assert rows[f"Battlemaps-{library_tree}"]["category_host"] is False
 
+    def test_the_browsed_folder_reports_its_own_hosting(
+        self, client, admin_headers, library_tree
+    ):
+        """The same flag about the folder itself, not its children.
+
+        The UI offers the scaffold action from a pane's empty space — which is
+        all there is once you have navigated *into* a system folder, and all
+        there is at all when that folder is empty. Answering only for child rows
+        left it unreachable exactly there.
+        """
+        resp = client.get(
+            "/api/files/browse",
+            headers=admin_headers,
+            params={"path": f"books/System-{library_tree}"},
+        )
+        assert resp.json()["category_host"] is True
+
+    def test_books_itself_does_not_host_categories(self, client, admin_headers):
+        resp = client.get("/api/files/browse", headers=admin_headers, params={"path": "books"})
+        # books/ holds systems; scaffolding here would invent systems named
+        # after categories.
+        assert resp.json()["category_host"] is False
+
+    def test_the_library_root_does_not_host_categories(self, client, admin_headers):
+        resp = client.get("/api/files/browse", headers=admin_headers, params={"path": ""})
+        assert resp.json()["category_host"] is False
+
+    def test_a_category_folder_does_not_host_categories(
+        self, client, admin_headers, library_tree
+    ):
+        resp = client.get(
+            "/api/files/browse",
+            headers=admin_headers,
+            params={"path": f"books/System-{library_tree}/core"},
+        )
+        assert resp.json()["category_host"] is False
+
 
 class TestSystemFolderMetadata:
     """A books/<system> folder maps to the GameSystem row it represents."""

--- a/docs/api.md
+++ b/docs/api.md
@@ -1615,7 +1615,7 @@ rows) are re-homed or invalidated so no item silently loses its cover.
 from `total` when a content file with the same stem sits beside them; an
 orphaned one is listed normally. They are moved and re-stemmed automatically by
 `/api/files/move` and `/api/files/rename`. Returns
-`{path, parent, writable, entries[], total, truncated}`. Each entry carries
+`{path, parent, writable, category_host, entries[], total, truncated}`. Each entry carries
 `name`, `path`, `is_dir`, and `size`; folders add `container_kind`, `nsfw`,
 `child_count`, and `category_host`, while files add `record_id`, `title`, `collection`,
 `has_thumbnail`, and `is_missing` when Grimoire has indexed them. A folder
@@ -1625,7 +1625,11 @@ it. `category_host` is true when standard category folders belong *inside* that
 folder - a system folder under `books/`, reached from `books/` through nothing
 but containers. It is false for `books/` itself, for every container (whose
 children are the system folders), for a category folder, and outside `books/`, so
-a client can offer the category scaffold only where it applies. Note `collection`
+a client can offer the category scaffold only where it applies. The top-level
+`category_host` answers the same question about the folder *being browsed* rather
+than about its children, so a client anchored inside a system folder - where
+there is no row to hang the action off, and none at all when the folder is empty
+- can still offer the scaffold. Note `collection`
 names the *library folder* (`books`, `maps`, …) for files but the resource type
 (`system`) for system folders. Marker/dotfiles
 are surfaced as folder properties, never as listable entries.

--- a/frontend/src/components/files/FilePane.jsx
+++ b/frontend/src/components/files/FilePane.jsx
@@ -12,6 +12,7 @@ import Spinner from '../Spinner'
 import FileRow from './FileRow'
 import useVirtualRows from '../../hooks/useVirtualRows'
 import { indexOfPath, nextSelectable, rightTarget, leftTarget } from './treeNav'
+import useLongPress from '../../hooks/useLongPress'
 
 // Drag payloads are JSON so a drop can carry several paths at once (a
 // multi-select drag) plus the pane it came from, which the drop handler needs to
@@ -219,6 +220,59 @@ export default function FilePane({
     },
     [pane, onOpenContext, side]
   )
+
+  /**
+   * The menu for the pane's *own* folder, opened by clicking the empty space
+   * below the rows rather than any one of them.
+   *
+   * Uploading into the folder you are looking at, or scaffolding categories
+   * into it, previously required right-clicking that folder in a listing — so
+   * they were unreachable once you had navigated *into* it, and completely
+   * unreachable in an empty folder, which has no rows to click at all.
+   *
+   * `entry: null` is what marks it as the background menu; the view reads
+   * `folder` for the path to act on.
+   */
+  const handlePaneContext = useCallback(
+    (e) => {
+      e.preventDefault()
+      pane.clearSelection()
+      onOpenContext({
+        x: e.clientX,
+        y: e.clientY,
+        entry: null,
+        folder: pane.path,
+        writable: pane.writable,
+        categoryHost: pane.categoryHost,
+        side,
+      })
+    },
+    [pane, onOpenContext, side]
+  )
+
+  const paneLongPress = useLongPress(handlePaneContext)
+
+  // Both menus are wired on this one element — a row's handlers bubble up to
+  // it — so each entry point has to ask whether the gesture landed on the
+  // background or on a row, and let the row's own handler have it if so.
+  //
+  // Asked as "not inside a row" rather than "is the container itself": the
+  // background of this list is not one element. It is the container, the
+  // virtual spacers standing in for off-screen rows, the placeholder lines
+  // under an expanded folder, and — in an empty folder, which is exactly where
+  // this menu matters most — a message filling the whole pane. All of those are
+  // background; only a row is not.
+  const onBackground = (e) => !e.target?.closest?.('[data-file-row]')
+
+  const paneBackgroundProps = {
+    onContextMenu: (e) => onBackground(e) && handlePaneContext(e),
+    onTouchStart: (e) =>
+      onBackground(e) ? paneLongPress.onTouchStart(e) : paneLongPress.onTouchEnd(),
+    onTouchMove: paneLongPress.onTouchMove,
+    onTouchEnd: paneLongPress.onTouchEnd,
+    onTouchCancel: paneLongPress.onTouchCancel,
+    onClickCapture: paneLongPress.onClickCapture,
+  }
 
   // --- Keyboard navigation.
   //
@@ -532,6 +586,7 @@ export default function FilePane({
         onFocus={() => setFocused(true)}
         onBlur={() => setFocused(false)}
         onScroll={onScroll}
+        {...paneBackgroundProps}
         onDragOver={handleListDragOver}
         onDragLeave={() => clearInterval(scrollTimer.current)}
         style={{

--- a/frontend/src/components/files/FilePane.test.jsx
+++ b/frontend/src/components/files/FilePane.test.jsx
@@ -282,6 +282,113 @@ describe('FilePane', () => {
     )
   })
 
+  it('opens a row menu on a long press, for touch devices with no right button', () => {
+    vi.useFakeTimers()
+    try {
+      const { onOpenContext } = renderPane(makePane())
+      fireEvent.touchStart(screen.getByTestId('entry-core'), {
+        touches: [{ clientX: 44, clientY: 88 }],
+      })
+      act(() => vi.advanceTimersByTime(600))
+      expect(onOpenContext).toHaveBeenCalledWith(
+        expect.objectContaining({
+          entry: expect.objectContaining({ name: 'core' }),
+          x: 44,
+          y: 88,
+        })
+      )
+    } finally {
+      vi.useRealTimers()
+    }
+  })
+
+  describe('the pane background menu', () => {
+    it('opens on a right-click in the empty space, targeting the pane folder', () => {
+      const pane = makePane({ categoryHost: true })
+      const { onOpenContext } = renderPane(pane)
+      fireEvent.contextMenu(screen.getByTestId('file-list-primary'), { clientX: 5, clientY: 6 })
+      expect(onOpenContext).toHaveBeenCalledWith({
+        x: 5,
+        y: 6,
+        entry: null,
+        folder: 'books/System',
+        writable: true,
+        categoryHost: true,
+        side: 'primary',
+      })
+      // A menu about the folder, not about whatever was selected in it.
+      expect(pane.clearSelection).toHaveBeenCalled()
+    })
+
+    it('leaves a right-click on a row to that row', () => {
+      const { onOpenContext } = renderPane(makePane())
+      fireEvent.contextMenu(screen.getByTestId('entry-core'))
+      // One call, and it is the row's — the same event bubbling to the list
+      // must not open a second, background menu on top of it.
+      expect(onOpenContext).toHaveBeenCalledTimes(1)
+      expect(onOpenContext.mock.calls[0][0].entry).toBeTruthy()
+    })
+
+    it('opens on a long press in the empty space', () => {
+      vi.useFakeTimers()
+      try {
+        const { onOpenContext } = renderPane(makePane())
+        fireEvent.touchStart(screen.getByTestId('file-list-primary'), {
+          touches: [{ clientX: 12, clientY: 14 }],
+        })
+        act(() => vi.advanceTimersByTime(600))
+        expect(onOpenContext).toHaveBeenCalledWith(
+          expect.objectContaining({ entry: null, folder: 'books/System', x: 12, y: 14 })
+        )
+      } finally {
+        vi.useRealTimers()
+      }
+    })
+
+    it('does not also fire for a long press that started on a row', () => {
+      vi.useFakeTimers()
+      try {
+        const { onOpenContext } = renderPane(makePane())
+        fireEvent.touchStart(screen.getByTestId('entry-core'), {
+          touches: [{ clientX: 3, clientY: 4 }],
+        })
+        act(() => vi.advanceTimersByTime(600))
+        // The row's press bubbles to the list, which must disarm rather than
+        // arm a competing background menu.
+        expect(onOpenContext).toHaveBeenCalledTimes(1)
+        expect(onOpenContext.mock.calls[0][0].entry).toBeTruthy()
+      } finally {
+        vi.useRealTimers()
+      }
+    })
+
+    it('opens from the empty-folder message, which fills a pane with no rows', () => {
+      // The case the menu exists for: an empty folder has no row to right-click
+      // and its message covers the whole pane, so a check for "the container
+      // itself" would never match and the menu would be unreachable.
+      const { onOpenContext } = renderPane(makePane({ rows: [] }))
+      fireEvent.contextMenu(screen.getByText('files.emptyFolder'), { clientX: 7, clientY: 8 })
+      expect(onOpenContext).toHaveBeenCalledWith(
+        expect.objectContaining({ entry: null, folder: 'books/System' })
+      )
+    })
+
+    it('opens from a click on a row\u2019s own label, not just its edge', () => {
+      // `closest` walks up from whatever was hit — the filename span here —
+      // so the row still wins over the background.
+      const { onOpenContext } = renderPane(makePane())
+      fireEvent.contextMenu(screen.getByText('bestiary.pdf'))
+      expect(onOpenContext).toHaveBeenCalledTimes(1)
+      expect(onOpenContext.mock.calls[0][0].entry).toBeTruthy()
+    })
+
+    it('reports a read-only pane, so the menu can say why it is empty', () => {
+      const { onOpenContext } = renderPane(makePane({ writable: false }))
+      fireEvent.contextMenu(screen.getByTestId('file-list-primary'))
+      expect(onOpenContext.mock.calls[0][0]).toMatchObject({ entry: null, writable: false })
+    })
+  })
+
   it('shows badges for container kind, NSFW, and indexed state', () => {
     renderPane(
       makePane({

--- a/frontend/src/components/files/FileRow.jsx
+++ b/frontend/src/components/files/FileRow.jsx
@@ -3,6 +3,7 @@ import { useTranslation } from 'react-i18next'
 import { LuChevronRight, LuChevronDown } from 'react-icons/lu'
 import Chip from './Chip'
 import EntryIcon from './EntryIcon'
+import useLongPress from '../../hooks/useLongPress'
 
 function formatSize(bytes) {
   if (bytes == null) return ''
@@ -43,10 +44,15 @@ function FileRow({
   onDropRow,
 }) {
   const { t } = useTranslation()
+  // Touch has no right mouse button, so a held finger stands in for one — every
+  // action on a row lives behind this menu and was otherwise unreachable on a
+  // phone or tablet.
+  const longPress = useLongPress((e) => onContext(e, entry))
 
   return (
     <div
       id={id}
+      {...longPress}
       role="option"
       aria-selected={!!isSelected}
       draggable
@@ -71,6 +77,11 @@ function FileRow({
         fontSize: 13,
         cursor: 'grab',
         userSelect: 'none',
+        // Suppress the browser's own long-press behaviours — the iOS callout
+        // menu and the Android text selection — which would otherwise appear on
+        // top of ours partway through the hold.
+        WebkitTouchCallout: 'none',
+        WebkitUserSelect: 'none',
         background: isDropTarget || isSelected ? 'var(--bg-card-hover)' : 'transparent',
         // Three states share one outline slot. A drop target wins while a drag
         // is live; otherwise the cursor is drawn solid, so a row that is the
@@ -85,6 +96,10 @@ function FileRow({
         borderBottom: '1px solid var(--border-light)',
       }}
       title={entry.path}
+      // Marks this subtree as "a row" for the pane's background-menu check,
+      // which has to tell a click on a row from a click on the space around
+      // one.
+      data-file-row=""
       data-testid={`entry-${entry.name}`}
     >
       {/* Twisty. Folders get a real toggle; files get a spacer so names stay

--- a/frontend/src/hooks/useLibraryPane.js
+++ b/frontend/src/hooks/useLibraryPane.js
@@ -52,6 +52,7 @@ export function useLibraryPane(initialPath = '') {
         [target]: {
           entries: res.entries || [],
           writable: res.writable,
+          categoryHost: !!res.category_host,
           parent: res.parent ?? null,
           total: res.total ?? (res.entries || []).length,
           truncated: !!res.truncated,
@@ -66,6 +67,7 @@ export function useLibraryPane(initialPath = '') {
         [target]: {
           entries: [],
           writable: false,
+          categoryHost: false,
           parent: prev[target]?.parent ?? null,
           loading: false,
           error: e.message || 'Could not read that folder',
@@ -306,6 +308,10 @@ export function useLibraryPane(initialPath = '') {
     rows,
     entries: root?.entries || [],
     writable: root?.writable ?? false,
+    // Whether the standard category folders belong directly inside the folder
+    // this pane is anchored on — what decides if its background menu offers to
+    // scaffold them.
+    categoryHost: root?.categoryHost ?? false,
     parent: root?.parent ?? null,
     loading: root?.loading ?? true,
     error: root?.error ?? null,

--- a/frontend/src/hooks/useLibraryPane.test.jsx
+++ b/frontend/src/hooks/useLibraryPane.test.jsx
@@ -37,6 +37,20 @@ beforeEach(() => {
 })
 
 describe('useLibraryPane', () => {
+  it('reports whether the anchored folder hosts category folders', async () => {
+    filesApi.browse.mockResolvedValue(listing('books/System', [], { category_host: true }))
+    const { result } = renderHook(() => useLibraryPane('books/System'))
+    await waitFor(() => expect(result.current.categoryHost).toBe(true))
+  })
+
+  it('defaults categoryHost to false where the server says nothing', async () => {
+    const { result } = renderHook(() => useLibraryPane('books'))
+    await waitFor(() => expect(result.current.loading).toBe(false))
+    // Absent rather than false in the response — an old server, or a folder
+    // outside the books tree — must not offer the scaffold action.
+    expect(result.current.categoryHost).toBe(false)
+  })
+
   it('loads the initial path into rows', async () => {
     const { result } = renderHook(() => useLibraryPane('books'))
     await waitFor(() => expect(result.current.loading).toBe(false))

--- a/frontend/src/hooks/useLongPress.js
+++ b/frontend/src/hooks/useLongPress.js
@@ -1,0 +1,121 @@
+import { useCallback, useEffect, useRef } from 'react'
+
+// How long a finger must stay down before it counts as a long press. Matches
+// the platform convention on both iOS and Android closely enough that it feels
+// native rather than sluggish.
+const HOLD_MS = 500
+
+// How far the finger may drift and still be a press rather than a scroll. The
+// tree scrolls vertically under these rows, so a hold that starts a flick must
+// not also open a menu.
+const MOVE_TOLERANCE_PX = 10
+
+/**
+ * Long-press as a stand-in for right-click, for touch devices that have no
+ * second mouse button.
+ *
+ * The file manager's every per-item action — rename, move, delete, upload,
+ * pin — lives behind the context menu, which on a phone or tablet was simply
+ * unreachable: `contextmenu` fires from a real right-click, and a touch browser
+ * either does not fire it at all or fires it only after its own text-selection
+ * UI has already appeared.
+ *
+ * So the press is timed by hand. `touchstart` arms a timer; movement past
+ * `MOVE_TOLERANCE_PX` or an early `touchend` disarms it; if it survives, the
+ * callback runs with the touch's coordinates, which is exactly the shape a
+ * mouse `contextmenu` handler already takes.
+ *
+ * The tap that ends the press is then swallowed. A touch that opens a menu
+ * still ends in `touchend` → a synthesised `click`, which would otherwise
+ * select the row behind the menu — or, worse, reach the window-level listener
+ * that closes the menu and shut it in the same gesture that opened it.
+ *
+ * Returns props to spread onto the element. `onClickCapture` is part of them:
+ * it belongs to the same gesture and has to run before the element's own
+ * `onClick`.
+ */
+export default function useLongPress(onLongPress) {
+  const timer = useRef(null)
+  const start = useRef(null)
+  // Set when the timer fires, read (and cleared) by the click it must swallow.
+  const fired = useRef(false)
+  // Held in a ref so the returned handlers keep one identity for the life of
+  // the component. The tree is virtualised and its rows are memoised; handlers
+  // that changed on every render — which an inline `(e) => onContext(e, entry)`
+  // callback would cause — would defeat that and re-render every visible row on
+  // each scroll frame.
+  const callback = useRef(onLongPress)
+  callback.current = onLongPress
+
+  const cancel = useCallback(() => {
+    clearTimeout(timer.current)
+    timer.current = null
+    start.current = null
+  }, [])
+
+  // A component unmounting mid-press — the pane closing, the tree scrolling a
+  // row out of the virtual window — must not leave a timer that fires into a
+  // dead component.
+  useEffect(() => cancel, [cancel])
+
+  const onTouchStart = useCallback(
+    (e) => {
+      // A second finger means a pinch or a two-finger scroll, not a press.
+      if (e.touches.length !== 1) return cancel()
+      const t = e.touches[0]
+      start.current = { x: t.clientX, y: t.clientY }
+      fired.current = false
+      clearTimeout(timer.current)
+      timer.current = setTimeout(() => {
+        timer.current = null
+        fired.current = true
+        callback.current({
+          clientX: t.clientX,
+          clientY: t.clientY,
+          // The caller's handler is shared with the mouse path, which calls
+          // both of these; neither means anything for a touch that has already
+          // been held past the point of being a tap.
+          preventDefault: () => {},
+          stopPropagation: () => {},
+        })
+      }, HOLD_MS)
+    },
+    [cancel]
+  )
+
+  const onTouchMove = useCallback(
+    (e) => {
+      if (!timer.current || !start.current) return
+      const t = e.touches[0]
+      if (!t) return
+      const { x, y } = start.current
+      if (
+        Math.abs(t.clientX - x) > MOVE_TOLERANCE_PX ||
+        Math.abs(t.clientY - y) > MOVE_TOLERANCE_PX
+      ) {
+        cancel()
+      }
+    },
+    [cancel]
+  )
+
+  const onClickCapture = useCallback((e) => {
+    if (!fired.current) return
+    fired.current = false
+    e.preventDefault()
+    e.stopPropagation()
+    // React's synthetic `stopPropagation` only stops React's own tree walk; the
+    // native event carries on to `window`, where the menu's own
+    // close-on-outside-click listener is waiting. Stopping it there too is what
+    // keeps the menu open past the gesture that opened it.
+    e.nativeEvent?.stopImmediatePropagation?.()
+  }, [])
+
+  return {
+    onTouchStart,
+    onTouchMove,
+    onTouchEnd: cancel,
+    onTouchCancel: cancel,
+    onClickCapture,
+  }
+}

--- a/frontend/src/hooks/useLongPress.test.jsx
+++ b/frontend/src/hooks/useLongPress.test.jsx
@@ -1,0 +1,147 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
+import { render, screen, fireEvent, act } from '@testing-library/react'
+import useLongPress from './useLongPress'
+
+// A touch list shaped like the one a real event carries — the hook reads
+// `length` and the first touch's coordinates.
+const touches = (...points) => points.map(([x, y]) => ({ clientX: x, clientY: y }))
+
+function Probe({ onLongPress }) {
+  const props = useLongPress(onLongPress)
+  return (
+    <div data-testid="target" {...props}>
+      hold me
+    </div>
+  )
+}
+
+function renderProbe() {
+  const onLongPress = vi.fn()
+  const { unmount } = render(<Probe onLongPress={onLongPress} />)
+  return { onLongPress, target: screen.getByTestId('target'), unmount }
+}
+
+/** Advance past the hold threshold. */
+const hold = () => act(() => vi.advanceTimersByTime(600))
+
+describe('useLongPress', () => {
+  beforeEach(() => vi.useFakeTimers())
+  afterEach(() => vi.useRealTimers())
+
+  it('fires with the touch coordinates once the hold completes', () => {
+    const { onLongPress, target } = renderProbe()
+    fireEvent.touchStart(target, { touches: touches([120, 340]) })
+    hold()
+    expect(onLongPress).toHaveBeenCalledTimes(1)
+    expect(onLongPress.mock.calls[0][0]).toMatchObject({ clientX: 120, clientY: 340 })
+  })
+
+  it('does not fire before the threshold', () => {
+    const { onLongPress, target } = renderProbe()
+    fireEvent.touchStart(target, { touches: touches([10, 10]) })
+    act(() => vi.advanceTimersByTime(300))
+    expect(onLongPress).not.toHaveBeenCalled()
+  })
+
+  it('cancels when the finger drifts past the tolerance — that is a scroll', () => {
+    const { onLongPress, target } = renderProbe()
+    fireEvent.touchStart(target, { touches: touches([50, 50]) })
+    fireEvent.touchMove(target, { touches: touches([50, 90]) })
+    hold()
+    expect(onLongPress).not.toHaveBeenCalled()
+  })
+
+  it('survives a small drift, so a steady finger still counts', () => {
+    const { onLongPress, target } = renderProbe()
+    fireEvent.touchStart(target, { touches: touches([50, 50]) })
+    fireEvent.touchMove(target, { touches: touches([54, 53]) })
+    hold()
+    expect(onLongPress).toHaveBeenCalledTimes(1)
+  })
+
+  it('cancels when the finger lifts early', () => {
+    const { onLongPress, target } = renderProbe()
+    fireEvent.touchStart(target, { touches: touches([50, 50]) })
+    fireEvent.touchEnd(target)
+    hold()
+    expect(onLongPress).not.toHaveBeenCalled()
+  })
+
+  it('ignores a second finger — that is a pinch, not a press', () => {
+    const { onLongPress, target } = renderProbe()
+    fireEvent.touchStart(target, { touches: touches([50, 50], [90, 90]) })
+    hold()
+    expect(onLongPress).not.toHaveBeenCalled()
+  })
+
+  it('swallows the click that ends a completed press', () => {
+    const onClick = vi.fn()
+    const onLongPress = vi.fn()
+    render(
+      <Wrapper onClick={onClick}>
+        <Probe onLongPress={onLongPress} />
+      </Wrapper>
+    )
+    const target = screen.getByTestId('target')
+    fireEvent.touchStart(target, { touches: touches([50, 50]) })
+    hold()
+    fireEvent.click(target)
+    expect(onLongPress).toHaveBeenCalledTimes(1)
+    // The tap that ends the hold must not also select the row behind the menu.
+    expect(onClick).not.toHaveBeenCalled()
+  })
+
+  it('lets a plain tap through', () => {
+    const onClick = vi.fn()
+    render(
+      <Wrapper onClick={onClick}>
+        <Probe onLongPress={vi.fn()} />
+      </Wrapper>
+    )
+    const target = screen.getByTestId('target')
+    fireEvent.touchStart(target, { touches: touches([50, 50]) })
+    fireEvent.touchEnd(target)
+    fireEvent.click(target)
+    expect(onClick).toHaveBeenCalledTimes(1)
+  })
+
+  it('only swallows one click, so the next tap works', () => {
+    const onClick = vi.fn()
+    render(
+      <Wrapper onClick={onClick}>
+        <Probe onLongPress={vi.fn()} />
+      </Wrapper>
+    )
+    const target = screen.getByTestId('target')
+    fireEvent.touchStart(target, { touches: touches([50, 50]) })
+    hold()
+    fireEvent.click(target)
+    fireEvent.click(target)
+    expect(onClick).toHaveBeenCalledTimes(1)
+  })
+
+  it('drops a pending timer on unmount rather than firing into a dead component', () => {
+    const { onLongPress, target, unmount } = renderProbe()
+    fireEvent.touchStart(target, { touches: touches([50, 50]) })
+    unmount()
+    hold()
+    expect(onLongPress).not.toHaveBeenCalled()
+  })
+
+  it('reads the latest callback, so stale props are never called', () => {
+    const first = vi.fn()
+    const second = vi.fn()
+    const { rerender } = render(<Probe onLongPress={first} />)
+    rerender(<Probe onLongPress={second} />)
+    fireEvent.touchStart(screen.getByTestId('target'), { touches: touches([1, 2]) })
+    hold()
+    expect(first).not.toHaveBeenCalled()
+    expect(second).toHaveBeenCalledTimes(1)
+  })
+})
+
+// A click listener above the hook's element, standing in for the row's own
+// onClick and the menu's close-on-outside-click.
+function Wrapper({ onClick, children }) {
+  return <div onClick={onClick}>{children}</div>
+}

--- a/frontend/src/views/FileManagerView.jsx
+++ b/frontend/src/views/FileManagerView.jsx
@@ -648,7 +648,84 @@ export default function FileManagerView() {
         {t('files.dragHint')}
       </p>
 
-      {context && (
+      {/* Two menus, one component. `entry` is the row that was clicked; a null
+          `entry` means the click landed on a pane's empty space, and the menu
+          acts on the folder that pane is showing instead. */}
+      {context && !context.entry && (
+        <ContextMenu
+          key={`${context.x},${context.y}`}
+          x={context.x}
+          y={context.y}
+          onClick={(e) => e.stopPropagation()}
+        >
+          <div style={menuHeading} data-testid="pane-menu-folder">
+            {context.folder || t('files.libraryRoot')}
+          </div>
+
+          {context.writable ? (
+            <>
+              <button
+                style={menuItem}
+                {...menuHover}
+                data-testid="pane-new-folder"
+                onClick={() => {
+                  setCreatingIn(context.folder)
+                  setContext(null)
+                }}
+              >
+                <LuFolderPlus size={13} /> {t('files.newFolderHere')}
+              </button>
+              <button
+                style={menuItem}
+                {...menuHover}
+                data-testid="pane-upload-files"
+                onClick={() => {
+                  pickFiles(context.folder, 'files')
+                  setContext(null)
+                }}
+              >
+                <LuUpload size={13} /> {t('files.uploadFiles')}
+              </button>
+              <button
+                style={menuItem}
+                {...menuHover}
+                data-testid="pane-upload-folder"
+                onClick={() => {
+                  pickFiles(context.folder, 'folder')
+                  setContext(null)
+                }}
+              >
+                <LuFolderUp size={13} /> {t('files.uploadFolder')}
+              </button>
+
+              {/* Only inside a system folder — the same rule the row menu
+                  follows, asked of the folder the pane is anchored on. */}
+              {context.categoryHost && (
+                <button
+                  style={menuItem}
+                  {...menuHover}
+                  data-testid="pane-scaffold-categories"
+                  onClick={() => {
+                    scaffold(context.folder)
+                    setContext(null)
+                  }}
+                >
+                  <LuLayoutGrid size={13} /> {t('files.scaffoldCategories')}
+                </button>
+              )}
+            </>
+          ) : (
+            // Every action this menu offers writes to disk, so on a read-only
+            // mount it would be entirely empty. Saying why beats a menu that
+            // opens onto nothing.
+            <div style={menuHeading} data-testid="pane-menu-readonly">
+              {t('files.readOnlyHint')}
+            </div>
+          )}
+        </ContextMenu>
+      )}
+
+      {context && context.entry && (
         <ContextMenu
           key={`${context.x},${context.y}`}
           x={context.x}
@@ -980,6 +1057,19 @@ const menuItem = {
   fontSize: 13,
   cursor: 'pointer',
   textAlign: 'left',
+}
+
+// A non-clickable line at the top of the pane menu naming the folder it acts
+// on. The row menu never needs one — you just clicked the thing it applies to —
+// but the background menu's target is the folder the pane is *showing*, which is
+// otherwise only visible in the breadcrumb above it.
+const menuHeading = {
+  padding: '6px 10px',
+  fontSize: 11,
+  color: 'var(--text-muted)',
+  overflow: 'hidden',
+  textOverflow: 'ellipsis',
+  whiteSpace: 'nowrap',
 }
 
 // Hover feedback for context-menu rows. Applied as handlers rather than CSS

--- a/frontend/src/views/FileManagerView.test.jsx
+++ b/frontend/src/views/FileManagerView.test.jsx
@@ -266,6 +266,102 @@ describe('FileManagerView', () => {
     })
   }
 
+  // The background menu: a right-click on a pane's empty space rather than on
+  // any row, which acts on the folder the pane is showing.
+  async function openPaneMenu(pane = 'primary') {
+    const list = await screen.findByTestId(`file-list-${pane}`)
+    fireEvent.contextMenu(list, { clientX: 20, clientY: 20 })
+  }
+
+  describe('the pane background menu', () => {
+    it('uploads files into the folder the pane is showing', async () => {
+      render(<FileManagerView />)
+      await openPaneMenu()
+      await userEvent.click(await screen.findByTestId('pane-upload-files'))
+      const file = new File(['x'], 'a.pdf', { type: 'application/pdf' })
+      fireEvent.change(screen.getByTestId('file-input'), { target: { files: [file] } })
+
+      // The root listing is what the pane is anchored on, so that is where the
+      // upload lands — no row was clicked to say otherwise.
+      await waitFor(() => expect(uploadQueue.enqueue).toHaveBeenCalledWith(expect.any(Array), ''))
+    })
+
+    it('uploads a folder into the folder the pane is showing', async () => {
+      render(<FileManagerView />)
+      await openPaneMenu()
+      await userEvent.click(await screen.findByTestId('pane-upload-folder'))
+      const file = new File(['x'], 'a.pdf', { type: 'application/pdf' })
+      fireEvent.change(screen.getByTestId('folder-input'), { target: { files: [file] } })
+      await waitFor(() => expect(uploadQueue.enqueue).toHaveBeenCalledWith(expect.any(Array), ''))
+    })
+
+    it('creates a folder inside the folder the pane is showing', async () => {
+      filesApi.createFolder.mockResolvedValue({ path: 'New' })
+      render(<FileManagerView />)
+      await openPaneMenu()
+      await userEvent.click(await screen.findByTestId('pane-new-folder'))
+      await userEvent.type(screen.getByLabelText('files.folderName'), 'Adventures')
+      await userEvent.click(screen.getByText('files.create'))
+      await waitFor(() =>
+        expect(filesApi.createFolder).toHaveBeenCalledWith('', 'Adventures', expect.anything())
+      )
+    })
+
+    it('scaffolds categories when the pane sits inside a system folder', async () => {
+      // The bug this closes: navigating *into* a system folder left no row to
+      // right-click, so the scaffold action became unreachable exactly where it
+      // is most wanted.
+      filesApi.browse.mockImplementation((path) =>
+        Promise.resolve(browseResult([], path, { category_host: true }))
+      )
+      filesApi.scaffold.mockResolvedValue({ path: '', created: ['Core'], existing: [] })
+      render(<FileManagerView />)
+      await openPaneMenu()
+      await userEvent.click(await screen.findByTestId('pane-scaffold-categories'))
+      await waitFor(() => expect(filesApi.scaffold).toHaveBeenCalledWith(''))
+    })
+
+    it('hides the scaffold where categories do not belong', async () => {
+      // The default listing is the library root, which holds systems rather
+      // than categories.
+      render(<FileManagerView />)
+      await openPaneMenu()
+      await screen.findByTestId('pane-upload-files')
+      expect(screen.queryByTestId('pane-scaffold-categories')).not.toBeInTheDocument()
+    })
+
+    it('names the folder it will act on', async () => {
+      render(<FileManagerView />)
+      // The heading reports where the *pane* is anchored, so navigate into a
+      // folder first — at the root it would only ever say "library root".
+      const pane = await screen.findByTestId('file-pane-primary')
+      fireEvent.doubleClick(within(pane).getByTestId('entry-core'))
+      await waitFor(() => expect(filesApi.browse).toHaveBeenCalledWith('books/core'))
+
+      await openPaneMenu()
+      expect(await screen.findByTestId('pane-menu-folder')).toHaveTextContent('books/core')
+    })
+
+    it('offers nothing but an explanation on a read-only mount', async () => {
+      filesApi.browse.mockImplementation((path) =>
+        Promise.resolve(browseResult([], path, { writable: false }))
+      )
+      render(<FileManagerView />)
+      await openPaneMenu()
+      // Every entry here writes to disk, so all of them would fail.
+      expect(await screen.findByTestId('pane-menu-readonly')).toBeInTheDocument()
+      expect(screen.queryByTestId('pane-upload-files')).not.toBeInTheDocument()
+      expect(screen.queryByTestId('pane-new-folder')).not.toBeInTheDocument()
+    })
+
+    it('opens the row menu, not this one, for a right-click on a row', async () => {
+      render(<FileManagerView />)
+      await openMenuOn('core')
+      expect(await screen.findByTestId('rename-entry')).toBeInTheDocument()
+      expect(screen.queryByTestId('pane-menu-folder')).not.toBeInTheDocument()
+    })
+  })
+
   // Multi-choice actions (pin edges, container kinds) live behind a submenu so
   // the top level stays scannable; open it before clicking a leaf.
   async function openSubmenu(testId) {

--- a/nightly.md
+++ b/nightly.md
@@ -798,6 +798,16 @@ of Grimoire's own concepts) built for bulk reorganization:
   folders only. A container holds *systems*, not categories, so the option does
   not appear on one - it appears on the folders inside it, however deeply the
   containers nest.
+- **Right-click the empty space** in a pane for a menu about the folder you are
+  *looking at*, rather than about any row in it: upload files or a folder, create
+  a folder, and - inside a system folder - create the standard category folders.
+  Those actions used to need a row to right-click, which put them out of reach
+  once you had navigated into the folder you meant, and out of reach entirely in
+  an empty one.
+- **On a phone or tablet, press and hold** instead of right-clicking. Touch has
+  no second mouse button, so a held finger opens the same menus - on a row, or on
+  a pane's empty space. Sliding your finger cancels the hold, so scrolling the
+  tree still scrolls it.
 - **Mark a folder NSFW or SFW**, or change its container type, without recreating
   it. The *One-page RPGs* and *System-agnostic* collections are one-of-a-kind:
   once a folder claims one, it is not offered on any other folder.


### PR DESCRIPTION
## Summary

<!-- What does this PR do? A few sentences is fine. -->

## Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / cleanup
- [ ] Docs / configuration only

## Testing

<!-- How did you verify this works? Check all that apply. -->

- [ ] Backend tests pass (`pytest -q`)
- [x] Frontend tests pass (`npm test`)
- [x] Tested manually in the browser

## Notes for reviewer

<!-- Anything that needs extra context, known limitations, or follow-up work. Delete if not needed. -->
